### PR TITLE
sing-box 协议表精简为对齐 mack-a 的 10 个

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -361,14 +361,39 @@ def sb_shadowtls(port, tag):
            f"plugin-opts: {{host: {G['sni']}, password: {pw}, version: 3}}}}")
     return [st_ib, ss_ib], yml
 
-SB = {"reality-vision": sb_reality_vision, "reality-grpc": sb_reality_grpc,
-      "hy2": sb_hysteria2, "tuic": sb_tuic, "anytls": sb_anytls, "ss2022": sb_ss2022,
-      "vless-ws": make_sb_vless("ws"), "vless-h2": make_sb_vless("h2"),
-      "vless-httpupgrade": make_sb_vless("httpupgrade"),
-      "vmess-ws": make_sb_vmess("ws"), "vmess-h2": make_sb_vmess("h2"),
+def sb_vless_vision(port, tag):
+    # VLESS + TCP + 真 TLS + XTLS-Vision（对应 mack-a 的 VLESS_TCP/TLS_Vision）
+    # 与 reality-vision 区别：这条用服务器自己的证书（给域名走 acme，否则自签+insecure）
+    uid = new_uuid(); crt, key, insec = ensure_acme()
+    ib = {"type": "vless", "tag": tag, "listen": "::", "listen_port": port,
+          "users": [{"uuid": uid, "flow": "xtls-rprx-vision"}],
+          "tls": {"enabled": True, "server_name": tls_host(),
+                  "certificate_path": crt, "key_path": key}}
+    lk = (f"vless://{uid}@{G['host']}:{port}?encryption=none&flow=xtls-rprx-vision"
+          f"&security=tls&sni={tls_host()}&fp=chrome&type=tcp"
+          f"&allowInsecure={1 if insec else 0}#{tag}")
+    return ib, lk
+
+# 当前只装这 10 个协议（对齐 mack-a 的输出，顺序也一致）。
+# 想加回其它协议：把下面「备用」块里对应行搬进 SB 即可——builder 都还在，没删。
+SB = {"vless-vision": sb_vless_vision,
+      "vless-ws": make_sb_vless("ws"),
+      "vmess-ws": make_sb_vmess("ws"),
+      "trojan": sb_trojan,
+      "hy2": sb_hysteria2,
+      "reality-vision": sb_reality_vision,
+      "reality-grpc": sb_reality_grpc,
+      "tuic": sb_tuic,
       "vmess-httpupgrade": make_sb_vmess("httpupgrade"),
-      "trojan": sb_trojan, "socks5": sb_socks5, "naive": sb_naive,
-      "shadowtls": sb_shadowtls}
+      "anytls": sb_anytls}
+# 备用（以后想加回，取消注释挪进上面的 SB）：
+#   "ss2022": sb_ss2022,
+#   "vless-h2": make_sb_vless("h2"),
+#   "vless-httpupgrade": make_sb_vless("httpupgrade"),
+#   "vmess-h2": make_sb_vmess("h2"),
+#   "socks5": sb_socks5,
+#   "naive": sb_naive,
+#   "shadowtls": sb_shadowtls,
 
 # ============================================================================
 # xray 协议表 —— builder 返回 (inbound_dict, share_link)


### PR DESCRIPTION
## 需求

把 sing-box 协议裁到 mack-a 实测可用的那 10 个，其余先移出（以后可加回）。

## 目标 10 个（顺序对齐 mack-a 输出）

`vless-vision` · `vless-ws` · `vmess-ws` · `trojan` · `hy2` · `reality-vision` · `reality-grpc` · `tuic` · `vmess-httpupgrade` · `anytls`

## 改动

- 新增 `sb_vless_vision`：VLESS + TCP + 真 TLS + XTLS-Vision（对应 mack-a 的 `VLESS_TCP/TLS_Vision`，用服务器自己的证书；区别于借目标站证书的 `reality-vision`）。
- 从 `SB` 表移出：`ss2022` / `vless-h2` / `vless-httpupgrade` / `vmess-h2` / `socks5` / `naive` / `shadowtls`。**builder 全部保留**，想加回把注释行搬进 `SB` 即可，无需重写。
- httpupgrade 改用 vmess 版（mack-a 那条是 `VMess_HTTPUpgrade`，非 vless）。
- 菜单与 `--help` 协议清单由 `SB` 自动生成，已同步为 10 项。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYvMbH716hPckedcKHV5Up

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYvMbH716hPckedcKHV5Up)_