### PR TITLE
端口跳跃清掉旧 DNAT（含 mack-a 残留），修 hy2 不通

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -244,9 +244,12 @@ def setup_port_hopping(target_port, rng):
        与 mack-a 同法。带 comment 便于去重/清理；尽量持久化。"""
     lo, hi = rng.split("-")
     tagc = "xy_hy2_portHopping"
-    # 先清掉本脚本旧的同类规则，避免重跑叠加
+    # 先清掉这段 UDP 上所有旧 DNAT 规则——不只本脚本的，还包括 mack-a 等残留的
+    # “强制固定”规则（它们指向已死的旧端口，且可能排在前面先匹配，导致 hy2 不通）。
     for line in sh("iptables -t nat -S PREROUTING", check=False).splitlines():
-        if tagc in line and line.startswith("-A"):
+        if not line.startswith("-A"):
+            continue
+        if "portHopping" in line or f"--dport {lo}:{hi}" in line:
             sh("iptables -t nat " + line.replace("-A", "-D", 1), check=False)
     sh(f"iptables -t nat -A PREROUTING -p udp --dport {lo}:{hi} "
        f"-m comment --comment {tagc} -j DNAT --to-destination :{target_port}", check=False)
@@ -566,7 +569,11 @@ def takeover_cleanup():
     for p in dirs:
         sh(f"rm -rf {p}", check=False)
     sh("rm -f /usr/bin/vasma /usr/bin/v2ray-agent", check=False)     # mack-a 管理命令软链
-    print("已清理，端口与服务名已腾出。\n")
+    # 清掉别人残留的端口跳跃 iptables 规则（mack-a 的“强制固定”DNAT，指向已死端口会顶掉 hy2）
+    for line in sh("iptables -t nat -S PREROUTING", check=False).splitlines():
+        if line.startswith("-A") and "portHopping" in line:
+            sh("iptables -t nat " + line.replace("-A", "-D", 1), check=False)
+    print("已清理，端口/服务名/端口跳跃规则已腾出。\n")
 
 def run(sb_names, xr_names):
     ensure_deps()               # 先补齐 curl/socat/unzip/openssl 等，避免中途才炸


### PR DESCRIPTION
## 现象

接管 mack-a 后，其余 9 个协议全部连通，**仅 hy2 挂**。

## 根因

`takeover_cleanup` 清了 systemd 服务与 `/etc/v2ray-agent`，但**没清 iptables**。mack-a 那条「强制固定」的端口跳跃 DNAT 规则仍在，指向它自己**已死的旧 hy2 端口**，且在 `PREROUTING` 里排在本脚本规则**之前**——先匹配先赢，UDP `30000-31000` 被转到死端口，hy2 不通。（用户自行定位，判断准确。）

## 改动

- `setup_port_hopping`：加规则前删掉该 UDP 段上**所有**旧 DNAT（凡带 `portHopping` comment，或同 `--dport 30000:31000`），不再只删自己的。
- `takeover_cleanup`：接管清理时一并删除残留的 `portHopping` 规则。

## 立即修复（无需重装）

```bash
iptables -t nat -S PREROUTING | grep -- '--dport 30000:31000' | sed 's/^-A/-D/' | while read -r r; do eval iptables -t nat $r; done
iptables -t nat -A PREROUTING -p udp --dport 30000:31000 -m comment --comment xy_hy2_portHopping -j DNAT --to-destination :20005
netfilter-persistent save 2>/dev/null || true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYvMbH716hPckedcKHV5Up

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYvMbH716hPckedcKHV5Up)_