### PR TITLE
sing-box 订阅改为双锚点（节点/名称锚点），服务器端生成；跳过 xhttp

### DIFF
--- a/subbox-template.json
+++ b/subbox-template.json
@@ -1,21 +1,91 @@
 {
-  "log": {"disabled": false, "level": "warning", "output": "./singbox.log", "timestamp": true},
+  "log": {
+    "disabled": false,
+    "level": "warning",
+    "output": "./singbox.log",
+    "timestamp": true
+  },
   "dns": {
     "servers": [
-      { "tag": "bootstrap", "type": "udp", "server": "223.5.5.5" },
-      { "tag": "local", "type": "https", "server": "dns.alidns.com", "path": "/dns-query", "domain_resolver": "bootstrap", "detour": "🎯直连" },
-      { "tag": "remote", "type": "https", "server": "cloudflare-dns.com", "path": "/dns-query", "domain_resolver": "bootstrap", "detour": "🌍代理" },
-      { "tag": "google", "type": "https", "server": "8.8.8.8", "path": "/dns-query", "tls": {"server_name": "dns.google"}, "domain_resolver": "bootstrap", "detour": "🌍代理" },
-      { "tag": "system", "type": "local" },
-      { "tag": "fakeip", "type": "fakeip", "inet4_range": "198.18.0.0/15", "inet6_range": "fc00::/18" }
+      {
+        "tag": "bootstrap",
+        "type": "udp",
+        "server": "223.5.5.5"
+      },
+      {
+        "tag": "local",
+        "type": "https",
+        "server": "dns.alidns.com",
+        "path": "/dns-query",
+        "domain_resolver": "bootstrap",
+        "detour": "🎯直连"
+      },
+      {
+        "tag": "remote",
+        "type": "https",
+        "server": "cloudflare-dns.com",
+        "path": "/dns-query",
+        "domain_resolver": "bootstrap",
+        "detour": "🌍代理"
+      },
+      {
+        "tag": "google",
+        "type": "https",
+        "server": "8.8.8.8",
+        "path": "/dns-query",
+        "tls": {
+          "server_name": "dns.google"
+        },
+        "domain_resolver": "bootstrap",
+        "detour": "🌍代理"
+      },
+      {
+        "tag": "system",
+        "type": "local"
+      },
+      {
+        "tag": "fakeip",
+        "type": "fakeip",
+        "inet4_range": "198.18.0.0/15",
+        "inet6_range": "fc00::/18"
+      }
     ],
     "rules": [
-      { "rule_set": ["reject"], "action": "reject" },
-      { "query_type": ["HTTPS", "SVCB"], "action": "reject" },
-      { "rule_set": ["private"], "server": "local" },
-      { "query_type": ["A", "AAAA"], "server": "fakeip", "rewrite_ttl": 60 },
-      { "clash_mode": "全局", "server": "remote" },
-      { "clash_mode": "直连", "server": "local" }
+      {
+        "rule_set": [
+          "reject"
+        ],
+        "action": "reject"
+      },
+      {
+        "query_type": [
+          "HTTPS",
+          "SVCB"
+        ],
+        "action": "reject"
+      },
+      {
+        "rule_set": [
+          "private"
+        ],
+        "server": "local"
+      },
+      {
+        "query_type": [
+          "A",
+          "AAAA"
+        ],
+        "server": "fakeip",
+        "rewrite_ttl": 60
+      },
+      {
+        "clash_mode": "全局",
+        "server": "remote"
+      },
+      {
+        "clash_mode": "直连",
+        "server": "local"
+      }
     ],
     "final": "google",
     "strategy": "prefer_ipv4",
@@ -24,146 +94,833 @@
     "optimistic": true
   },
   "experimental": {
-    "cache_file": { "enabled": true, "path": "cache.db", "store_fakeip": true, "store_dns": true },
+    "cache_file": {
+      "enabled": true,
+      "path": "cache.db",
+      "store_fakeip": true,
+      "store_dns": true
+    },
     "clash_api": {
       "external_controller": "127.0.0.1:9091",
       "secret": "88888888",
       "external_ui": "zashboard",
       "external_ui_download_url": "https://codeload.github.com/Zephyruso/zashboard/zip/refs/heads/gh-pages",
       "default_mode": "规则",
-      "access_control_allow_origin": ["*"],
+      "access_control_allow_origin": [
+        "*"
+      ],
       "access_control_allow_private_network": true
     }
   },
   "inbounds": [
-    { "tag": "mixed-in", "type": "mixed", "listen": "0.0.0.0", "listen_port": 7898 },
-    { "tag": "socks-in", "type": "socks", "listen": "0.0.0.0", "listen_port": 7897 },
-    { "tag": "http-in", "type": "http", "listen": "0.0.0.0", "listen_port": 7895 },
+    {
+      "tag": "mixed-in",
+      "type": "mixed",
+      "listen": "0.0.0.0",
+      "listen_port": 7898
+    },
+    {
+      "tag": "socks-in",
+      "type": "socks",
+      "listen": "0.0.0.0",
+      "listen_port": 7897
+    },
+    {
+      "tag": "http-in",
+      "type": "http",
+      "listen": "0.0.0.0",
+      "listen_port": 7895
+    },
     {
       "tag": "tun-in",
       "type": "tun",
       "interface_name": "singbox",
-      "address": ["172.18.0.1/30", "fdfe:dcba:9876::1/126"],
+      "address": [
+        "172.18.0.1/30",
+        "fdfe:dcba:9876::1/126"
+      ],
       "mtu": 9000,
       "stack": "mixed",
       "auto_route": true,
       "strict_route": true,
       "endpoint_independent_nat": true,
-      "route_address": ["0.0.0.0/1", "128.0.0.0/1", "::/1", "8000::/1"],
-      "route_exclude_address": ["192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12", "fc00::/7"],
-      "route_exclude_address_set": ["private-ip"],
-      "platform": { "http_proxy": { "enabled": true, "server": "127.0.0.1", "server_port": 7898 } },
-      "exclude_package": ["com.android.captiveportallogin"],
+      "route_address": [
+        "0.0.0.0/1",
+        "128.0.0.0/1",
+        "::/1",
+        "8000::/1"
+      ],
+      "route_exclude_address": [
+        "192.168.0.0/16",
+        "10.0.0.0/8",
+        "172.16.0.0/12",
+        "fc00::/7"
+      ],
+      "route_exclude_address_set": [
+        "private-ip"
+      ],
+      "platform": {
+        "http_proxy": {
+          "enabled": true,
+          "server": "127.0.0.1",
+          "server_port": 7898
+        }
+      },
+      "exclude_package": [
+        "com.android.captiveportallogin"
+      ],
       "udp_timeout": "5m"
     }
   ],
   "outbounds": [
-    { "tag": "DIRECT", "type": "direct" },
-    { "tag": "🌍代理", "type": "selector", "default": "♻️随机", "outbounds": ["♻️随机", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "🎷抖音", "type": "selector", "outbounds": ["♻️随机", "🌍代理", "🎯直连", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "🎬TikTok", "type": "selector", "outbounds": ["♻️随机", "🌍代理", "🎯直连", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "🎮国际游戏", "type": "selector", "outbounds": ["♻️随机", "🌍代理", "🎯直连", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "💻Telegram", "type": "selector", "outbounds": ["♻️随机", "🌍代理", "🎯直连", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "🧠OpenAI", "type": "selector", "outbounds": ["♻️随机", "🌍代理", "🎯直连", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "🤖Claude", "type": "selector", "outbounds": ["♻️随机", "🌍代理", "🎯直连", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "💳PayPal", "type": "selector", "outbounds": ["♻️随机", "🌍代理", "🎯直连", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "💰加密货币", "type": "selector", "outbounds": ["🎯直连", "🌍代理", "♻️随机", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "🌐Google服务", "type": "selector", "outbounds": ["♻️随机", "🌍代理", "🎯直连", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "📱Meta", "type": "selector", "outbounds": ["🌍代理", "♻️随机", "🎯直连", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "🐦X", "type": "selector", "outbounds": ["🌍代理", "♻️随机", "🎯直连", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "📽️Netflix", "type": "selector", "outbounds": ["🌍代理", "♻️随机", "🎯直连", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "😈GitHub", "type": "selector", "outbounds": ["♻️随机", "🌍代理", "🎯直连", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "😊微软服务", "type": "selector", "outbounds": ["♻️随机", "🌍代理", "🎯直连", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "🍎苹果服务", "type": "selector", "outbounds": ["♻️随机", "🌍代理", "🎯直连", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "📹B站", "type": "selector", "outbounds": ["🎯直连", "♻️随机", "🌍代理", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "📕小红书", "type": "selector", "outbounds": ["🎯直连", "♻️随机", "🌍代理", "🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"] },
-    { "tag": "⛩️阿里腾讯", "type": "selector", "outbounds": ["🎯直连", "🌍代理"] },
-    { "tag": "🎯直连", "type": "selector", "outbounds": ["DIRECT", "🌍代理"] },
-    { "tag": "🤡漏网之鱼", "type": "selector", "outbounds": ["🌍代理", "🎯直连"] },
-    { "tag": "♻️随机", "type": "urltest", "outbounds": ["🇺🇲 VLESS_TCP/TLS_Vision", "🇺🇲 VLESS_WS", "🇺🇲 VMess_WS", "🇺🇲 Trojan_TCP", "🇺🇲 Hysteria2_TLS", "🇺🇲 VLESS_Reality_Vision", "🇺🇲 VLESS_Reality_gPRC", "🇺🇲 singbox_tuic", "🇺🇲 AnyTLS", "🇺🇲 VMess_HTTPUpgrade_TLS"], "url": "https://www.gstatic.com/generate_204", "interval": "120s", "tolerance": 30 },
-
-    { "tag": "🇺🇲 VLESS_TCP/TLS_Vision", "type": "vless", "server": "ddffgg.cc", "server_port": 40429, "uuid": "e73ad66f-c63d-472b-8519-3c3c904c06e4", "flow": "xtls-rprx-vision", "packet_encoding": "xudp", "tls": {"enabled": true, "server_name": "ddffgg.cc", "insecure": false, "utls": {"enabled": true, "fingerprint": "chrome"}} },
-    { "tag": "🇺🇲 VLESS_WS", "type": "vless", "server": "ddffgg.cc", "server_port": 16311, "uuid": "e73ad66f-c63d-472b-8519-3c3c904c06e4", "packet_encoding": "xudp", "tls": {"enabled": true, "server_name": "ddffgg.cc", "insecure": false, "utls": {"enabled": true, "fingerprint": "chrome"}}, "transport": {"type": "ws", "path": "/iaxgws", "headers": {"Host": "ddffgg.cc"}} },
-    { "tag": "🇺🇲 VMess_WS", "type": "vmess", "server": "ddffgg.cc", "server_port": 20245, "uuid": "e73ad66f-c63d-472b-8519-3c3c904c06e4", "security": "none", "alter_id": 0, "tls": {"enabled": true, "server_name": "ddffgg.cc", "insecure": false, "utls": {"enabled": true, "fingerprint": "chrome"}}, "transport": {"type": "ws", "path": "/nnta", "headers": {"Host": "ddffgg.cc"}} },
-    { "tag": "🇺🇲 Trojan_TCP", "type": "trojan", "server": "ddffgg.cc", "server_port": 32952, "password": "e73ad66f-c63d-472b-8519-3c3c904c06e4", "tls": {"enabled": true, "server_name": "ddffgg.cc", "insecure": false, "alpn": ["http/1.1"], "utls": {"enabled": true, "fingerprint": "chrome"}} },
-    { "tag": "🇺🇲 Hysteria2_TLS", "type": "hysteria2", "server": "ddffgg.cc", "server_ports": ["30000:31000"], "hop_interval": "30s", "password": "e73ad66f-c63d-472b-8519-3c3c904c06e4", "tls": {"enabled": true, "server_name": "ddffgg.cc", "insecure": false, "alpn": ["h3"]} },
-    { "tag": "🇺🇲 VLESS_Reality_Vision", "type": "vless", "server": "36.212.189.99", "server_port": 11183, "uuid": "e73ad66f-c63d-472b-8519-3c3c904c06e4", "flow": "xtls-rprx-vision", "packet_encoding": "xudp", "tls": {"enabled": true, "server_name": "www.bing.com", "insecure": false, "utls": {"enabled": true, "fingerprint": "chrome"}, "reality": {"enabled": true, "public_key": "2V2z-DYVp2dZ2j5cXwLThhvWNL_DuyIQ9fLtzpr2ZyY", "short_id": "6ba85179e30d4fc2"}} },
-    { "tag": "🇺🇲 VLESS_Reality_gPRC", "type": "vless", "server": "36.212.189.99", "server_port": 27515, "uuid": "e73ad66f-c63d-472b-8519-3c3c904c06e4", "packet_encoding": "xudp", "tls": {"enabled": true, "server_name": "www.bing.com", "insecure": false, "utls": {"enabled": true, "fingerprint": "chrome"}, "reality": {"enabled": true, "public_key": "2V2z-DYVp2dZ2j5cXwLThhvWNL_DuyIQ9fLtzpr2ZyY", "short_id": "6ba85179e30d4fc2"}} },
-    { "tag": "🇺🇲 singbox_tuic", "type": "tuic", "server": "ddffgg.cc", "server_port": 41183, "uuid": "e73ad66f-c63d-472b-8519-3c3c904c06e4", "password": "e73ad66f-c63d-472b-8519-3c3c904c06e4", "congestion_control": "bbr", "tls": {"enabled": true, "server_name": "ddffgg.cc", "insecure": false, "alpn": ["h3"]} },
-    { "tag": "🇺🇲 AnyTLS", "type": "anytls", "server": "ddffgg.cc", "server_port": 35177, "password": "e73ad66f-c63d-472b-8519-3c3c904c06e4", "tls": {"enabled": true, "server_name": "ddffgg.cc", "insecure": false, "alpn": ["h2", "http/1.1"], "utls": {"enabled": true, "fingerprint": "chrome"}} },
-    { "tag": "🇺🇲 VMess_HTTPUpgrade_TLS", "type": "vmess", "server": "ddffgg.cc", "server_port": 16666, "uuid": "e73ad66f-c63d-472b-8519-3c3c904c06e4", "security": "none", "alter_id": 0, "tls": {"enabled": true, "server_name": "ddffgg.cc", "insecure": false, "utls": {"enabled": true, "fingerprint": "chrome"}}, "transport": {"type": "httpupgrade", "path": "/ypom", "headers": {"Host": "ddffgg.cc"}} }
+    {
+      "tag": "DIRECT",
+      "type": "direct"
+    },
+    {
+      "tag": "🌍代理",
+      "type": "selector",
+      "default": "♻️随机",
+      "outbounds": [
+        "♻️随机",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "🎷抖音",
+      "type": "selector",
+      "outbounds": [
+        "♻️随机",
+        "🌍代理",
+        "🎯直连",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "🎬TikTok",
+      "type": "selector",
+      "outbounds": [
+        "♻️随机",
+        "🌍代理",
+        "🎯直连",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "🎮国际游戏",
+      "type": "selector",
+      "outbounds": [
+        "♻️随机",
+        "🌍代理",
+        "🎯直连",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "💻Telegram",
+      "type": "selector",
+      "outbounds": [
+        "♻️随机",
+        "🌍代理",
+        "🎯直连",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "🧠OpenAI",
+      "type": "selector",
+      "outbounds": [
+        "♻️随机",
+        "🌍代理",
+        "🎯直连",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "🤖Claude",
+      "type": "selector",
+      "outbounds": [
+        "♻️随机",
+        "🌍代理",
+        "🎯直连",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "💳PayPal",
+      "type": "selector",
+      "outbounds": [
+        "♻️随机",
+        "🌍代理",
+        "🎯直连",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "💰加密货币",
+      "type": "selector",
+      "outbounds": [
+        "🎯直连",
+        "🌍代理",
+        "♻️随机",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "🌐Google服务",
+      "type": "selector",
+      "outbounds": [
+        "♻️随机",
+        "🌍代理",
+        "🎯直连",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "📱Meta",
+      "type": "selector",
+      "outbounds": [
+        "🌍代理",
+        "♻️随机",
+        "🎯直连",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "🐦X",
+      "type": "selector",
+      "outbounds": [
+        "🌍代理",
+        "♻️随机",
+        "🎯直连",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "📽️Netflix",
+      "type": "selector",
+      "outbounds": [
+        "🌍代理",
+        "♻️随机",
+        "🎯直连",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "😈GitHub",
+      "type": "selector",
+      "outbounds": [
+        "♻️随机",
+        "🌍代理",
+        "🎯直连",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "😊微软服务",
+      "type": "selector",
+      "outbounds": [
+        "♻️随机",
+        "🌍代理",
+        "🎯直连",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "🍎苹果服务",
+      "type": "selector",
+      "outbounds": [
+        "♻️随机",
+        "🌍代理",
+        "🎯直连",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "📹B站",
+      "type": "selector",
+      "outbounds": [
+        "🎯直连",
+        "♻️随机",
+        "🌍代理",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "📕小红书",
+      "type": "selector",
+      "outbounds": [
+        "🎯直连",
+        "♻️随机",
+        "🌍代理",
+        "__PATTERN__:🇺🇲.*"
+      ]
+    },
+    {
+      "tag": "⛩️阿里腾讯",
+      "type": "selector",
+      "outbounds": [
+        "🎯直连",
+        "🌍代理"
+      ]
+    },
+    {
+      "tag": "🎯直连",
+      "type": "selector",
+      "outbounds": [
+        "DIRECT",
+        "🌍代理"
+      ]
+    },
+    {
+      "tag": "🤡漏网之鱼",
+      "type": "selector",
+      "outbounds": [
+        "🌍代理",
+        "🎯直连"
+      ]
+    },
+    {
+      "tag": "♻️随机",
+      "type": "urltest",
+      "outbounds": [
+        "__PATTERN__:🇺🇲.*"
+      ],
+      "url": "https://www.gstatic.com/generate_204",
+      "interval": "120s",
+      "tolerance": 30
+    },
+    "__PROXY__"
   ],
   "route": {
     "auto_detect_interface": true,
     "final": "🤡漏网之鱼",
-    "default_domain_resolver": {"server": "local", "strategy": "prefer_ipv4"},
+    "default_domain_resolver": {
+      "server": "local",
+      "strategy": "prefer_ipv4"
+    },
     "rules": [
-      { "action": "sniff" },
-      { "action": "route-options", "udp_connect": true },
-      { "type": "logical", "mode": "or", "rules": [{"port": [53]}, {"protocol": "dns"}], "action": "hijack-dns" },
-      { "clash_mode": "直连", "outbound": "🎯直连" },
-      { "clash_mode": "全局", "outbound": "🌍代理" },
-      { "rule_set": ["reject"], "action": "reject" },
-      { "ip_cidr": ["0.0.0.0/8"], "action": "reject" },
-      { "rule_set": ["TikTok-zj"], "outbound": "🎬TikTok" },
-      { "rule_set": ["douyin-zj"], "outbound": "🎷抖音" },
-      { "rule_set": ["games-!cn"], "outbound": "🎮国际游戏" },
-      { "rule_set": ["OpenAI-zj"], "outbound": "🧠OpenAI" },
-      { "rule_set": ["Claude-zj"], "outbound": "🤖Claude" },
-      { "rule_set": ["PayPal"], "outbound": "💳PayPal" },
-      { "rule_set": ["Cryptocurrency"], "outbound": "💰加密货币" },
-      { "rule_set": ["Telegram-zj"], "outbound": "💻Telegram" },
-      { "rule_set": ["Netflix"], "outbound": "📽️Netflix" },
-      { "rule_set": ["Google-zj", "google-ip"], "outbound": "🌐Google服务" },
-      { "rule_set": ["Facebook-zj"], "outbound": "📱Meta" },
-      { "rule_set": ["GitHub-zj"], "outbound": "😈GitHub" },
-      { "rule_set": ["Microsoft"], "outbound": "😊微软服务" },
-      { "rule_set": ["Apple", "icloud"], "outbound": "🍎苹果服务" },
-      { "rule_set": ["twitter"], "outbound": "🐦X" },
-      { "rule_set": ["cloudflare-ip", "cloudfront-ip", "fastly-ip", "gfw", "greatfire", "geolocation-!cn"], "outbound": "🌍代理" },
-      { "action": "resolve" },
-      { "rule_set": ["bilibili"], "outbound": "📹B站" },
-      { "rule_set": ["xiaohongshu"], "outbound": "📕小红书" },
-      { "rule_set": ["Tencent", "Alibaba"], "outbound": "⛩️阿里腾讯" },
-      { "rule_set": ["games-cn", "private", "cn-domain", "private-ip", "cn-ip"], "outbound": "🎯直连" },
-      { "ip_is_private": true, "outbound": "🎯直连" },
-      { "clash_mode": "直连", "outbound": "🎯直连" },
-      { "clash_mode": "全局", "outbound": "🌍代理" }
+      {
+        "action": "sniff"
+      },
+      {
+        "action": "route-options",
+        "udp_connect": true
+      },
+      {
+        "type": "logical",
+        "mode": "or",
+        "rules": [
+          {
+            "port": [
+              53
+            ]
+          },
+          {
+            "protocol": "dns"
+          }
+        ],
+        "action": "hijack-dns"
+      },
+      {
+        "clash_mode": "直连",
+        "outbound": "🎯直连"
+      },
+      {
+        "clash_mode": "全局",
+        "outbound": "🌍代理"
+      },
+      {
+        "rule_set": [
+          "reject"
+        ],
+        "action": "reject"
+      },
+      {
+        "ip_cidr": [
+          "0.0.0.0/8"
+        ],
+        "action": "reject"
+      },
+      {
+        "rule_set": [
+          "TikTok-zj"
+        ],
+        "outbound": "🎬TikTok"
+      },
+      {
+        "rule_set": [
+          "douyin-zj"
+        ],
+        "outbound": "🎷抖音"
+      },
+      {
+        "rule_set": [
+          "games-!cn"
+        ],
+        "outbound": "🎮国际游戏"
+      },
+      {
+        "rule_set": [
+          "OpenAI-zj"
+        ],
+        "outbound": "🧠OpenAI"
+      },
+      {
+        "rule_set": [
+          "Claude-zj"
+        ],
+        "outbound": "🤖Claude"
+      },
+      {
+        "rule_set": [
+          "PayPal"
+        ],
+        "outbound": "💳PayPal"
+      },
+      {
+        "rule_set": [
+          "Cryptocurrency"
+        ],
+        "outbound": "💰加密货币"
+      },
+      {
+        "rule_set": [
+          "Telegram-zj"
+        ],
+        "outbound": "💻Telegram"
+      },
+      {
+        "rule_set": [
+          "Netflix"
+        ],
+        "outbound": "📽️Netflix"
+      },
+      {
+        "rule_set": [
+          "Google-zj",
+          "google-ip"
+        ],
+        "outbound": "🌐Google服务"
+      },
+      {
+        "rule_set": [
+          "Facebook-zj"
+        ],
+        "outbound": "📱Meta"
+      },
+      {
+        "rule_set": [
+          "GitHub-zj"
+        ],
+        "outbound": "😈GitHub"
+      },
+      {
+        "rule_set": [
+          "Microsoft"
+        ],
+        "outbound": "😊微软服务"
+      },
+      {
+        "rule_set": [
+          "Apple",
+          "icloud"
+        ],
+        "outbound": "🍎苹果服务"
+      },
+      {
+        "rule_set": [
+          "twitter"
+        ],
+        "outbound": "🐦X"
+      },
+      {
+        "rule_set": [
+          "cloudflare-ip",
+          "cloudfront-ip",
+          "fastly-ip",
+          "gfw",
+          "greatfire",
+          "geolocation-!cn"
+        ],
+        "outbound": "🌍代理"
+      },
+      {
+        "action": "resolve"
+      },
+      {
+        "rule_set": [
+          "bilibili"
+        ],
+        "outbound": "📹B站"
+      },
+      {
+        "rule_set": [
+          "xiaohongshu"
+        ],
+        "outbound": "📕小红书"
+      },
+      {
+        "rule_set": [
+          "Tencent",
+          "Alibaba"
+        ],
+        "outbound": "⛩️阿里腾讯"
+      },
+      {
+        "rule_set": [
+          "games-cn",
+          "private",
+          "cn-domain",
+          "private-ip",
+          "cn-ip"
+        ],
+        "outbound": "🎯直连"
+      },
+      {
+        "ip_is_private": true,
+        "outbound": "🎯直连"
+      },
+      {
+        "clash_mode": "直连",
+        "outbound": "🎯直连"
+      },
+      {
+        "clash_mode": "全局",
+        "outbound": "🌍代理"
+      }
     ],
     "rule_set": [
-      { "tag": "reject", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/category-ads-all.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "douyin-zj", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/bytedance.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "TikTok-zj", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/tiktok.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "Telegram-zj", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/telegram.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "OpenAI-zj", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/openai.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "Facebook-zj", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/meta.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "Google-zj", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/google.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "GitHub-zj", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/github.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "Claude-zj", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/anthropic.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "PayPal", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/paypal.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "Cryptocurrency", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/category-cryptocurrency.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "Netflix", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/netflix.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "games-!cn", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/category-games-!cn.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "twitter", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/twitter.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "google-ip", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geoip/google.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "cloudflare-ip", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geoip/cloudflare.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "cloudfront-ip", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geoip/cloudfront.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "fastly-ip", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geoip/fastly.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "icloud", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/icloud.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "Apple", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/apple.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "Microsoft", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/microsoft.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "gfw", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/gfw.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "greatfire", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/greatfire.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "geolocation-!cn", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/geolocation-!cn.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "games-cn", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/category-games-cn.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "bilibili", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/bilibili.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "xiaohongshu", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/xiaohongshu.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "Alibaba", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/alibaba.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "Tencent", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/tencent.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "private", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/private.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "cn-domain", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/cn.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "private-ip", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geoip/private.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} },
-      { "tag": "cn-ip", "type": "remote", "format": "binary", "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geoip/cn.srs", "update_interval": "1d", "http_client": {"detour": "🎯直连"} }
+      {
+        "tag": "reject",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/category-ads-all.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "douyin-zj",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/bytedance.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "TikTok-zj",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/tiktok.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "Telegram-zj",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/telegram.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "OpenAI-zj",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/openai.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "Facebook-zj",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/meta.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "Google-zj",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/google.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "GitHub-zj",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/github.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "Claude-zj",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/anthropic.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "PayPal",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/paypal.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "Cryptocurrency",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/category-cryptocurrency.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "Netflix",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/netflix.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "games-!cn",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/category-games-!cn.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "twitter",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/twitter.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "google-ip",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geoip/google.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "cloudflare-ip",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geoip/cloudflare.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "cloudfront-ip",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geoip/cloudfront.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "fastly-ip",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geoip/fastly.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "icloud",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/icloud.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "Apple",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/apple.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "Microsoft",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/microsoft.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "gfw",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/gfw.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "greatfire",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/greatfire.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "geolocation-!cn",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/geolocation-!cn.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "games-cn",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/category-games-cn.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "bilibili",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/bilibili.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "xiaohongshu",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/xiaohongshu.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "Alibaba",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/alibaba.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "Tencent",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/tencent.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "private",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/private.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "cn-domain",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geosite/cn.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "private-ip",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geoip/private.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      },
+      {
+        "tag": "cn-ip",
+        "type": "remote",
+        "format": "binary",
+        "url": "https://gh-proxy.com/https://raw.githubusercontent.com/bgpeer/rules/main/geo/geoip/cn.srs",
+        "update_interval": "1d",
+        "http_client": {
+          "detour": "🎯直连"
+        }
+      }
     ]
   }
 }

--- a/xy-installer.py
+++ b/xy-installer.py
@@ -706,12 +706,14 @@ def link_to_proxy(u):
         if sec == "reality":
             d["reality-opts"] = {"public-key": qs.get("pbk", ""), "short-id": qs.get("sid", "")}
             if net == "grpc": d["network"] = "grpc"; d["grpc-opts"] = {"grpc-service-name": qs.get("serviceName") or qs.get("path", "")}
+            elif net == "xhttp": d["network"] = "xhttp"; d["xhttp-opts"] = {"path": qs.get("path", "/")}  # xray 专属
             else: d["network"] = "tcp"
         else:
             if insec: d["skip-cert-verify"] = "true"
             if net == "ws": d["network"] = "ws"; d["ws-opts"] = {"path": qs.get("path", "/"), "headers": {"Host": qs.get("host", host)}}
             elif net == "httpupgrade": d["network"] = "ws"; d["ws-opts"] = {"path": qs.get("path", "/"), "headers": {"Host": qs.get("host", host)}, "v2ray-http-upgrade": "true"}
             elif net == "grpc": d["network"] = "grpc"; d["grpc-opts"] = {"grpc-service-name": qs.get("serviceName") or qs.get("path", "")}
+            elif net == "xhttp": d["network"] = "xhttp"; d["xhttp-opts"] = {"path": qs.get("path", "/")}
             else: d["network"] = "tcp"
         return d
     if sch in ("hysteria2", "hy2"):
@@ -807,6 +809,8 @@ def proto_key(d):
     if t == "vmess":
         return "vmess-httpupgrade" if d.get("ws-opts", {}).get("v2ray-http-upgrade") else "vmess-ws"
     if t == "vless":
+        if d.get("network") == "xhttp":
+            return "vless-xhttp"                          # xray 专属，sing-box 不支持 → 不映射
         if d.get("reality-opts"):
             return "reality-grpc" if d.get("network") == "grpc" else "reality-vision"
         if d.get("flow"):
@@ -822,48 +826,91 @@ PROTO_TO_SBTAG = {
     "tuic": "🇺🇲 singbox_tuic", "anytls": "🇺🇲 AnyTLS", "vmess-httpupgrade": "🇺🇲 VMess_HTTPUpgrade_TLS",
 }
 
-def fill_singbox_outbound(ob, d):
-    """把 mihomo 节点 dict 的真实连接参数写进 sing-box 模板节点对象（保留其结构/utls/alpn 等）。"""
-    ob["server"] = d["server"]
-    if d.get("type") == "hysteria2":
-        ob["password"] = d["password"]
+def mihomo_to_sb_outbound(key, d):
+    """mihomo 节点 dict → 完整的 sing-box 出站对象（服务器端现生成，不依赖模板里的固定参数）。
+       不支持的类型(如 xhttp)返回 None，由调用方跳过。"""
+    tag = PROTO_TO_SBTAG.get(key)
+    if not tag:
+        return None                                      # xhttp 等 → 不写进 sing-box
+    srv = d["server"]; sni = d.get("servername") or d.get("sni") or srv
+    insec = bool(d.get("skip-cert-verify"))
+    utls = {"enabled": True, "fingerprint": "chrome"}
+    t = d.get("type")
+    if t == "vless":
+        ob = {"tag": tag, "type": "vless", "server": srv, "server_port": int(d["port"]),
+              "uuid": d["uuid"], "packet_encoding": "xudp",
+              "tls": {"enabled": True, "server_name": sni, "insecure": insec, "utls": utls}}
+        if d.get("flow"): ob["flow"] = d["flow"]
+        if d.get("reality-opts"):
+            ob["tls"]["reality"] = {"enabled": True,
+                                    "public_key": d["reality-opts"].get("public-key", ""),
+                                    "short_id": d["reality-opts"].get("short-id", "")}
+        if d.get("network") == "ws":
+            ob["transport"] = {"type": "ws", "path": d["ws-opts"].get("path", "/"),
+                               "headers": {"Host": d["ws-opts"].get("headers", {}).get("Host", sni)}}
+        elif d.get("network") == "grpc":
+            ob["transport"] = {"type": "grpc", "service_name": d.get("grpc-opts", {}).get("grpc-service-name", "")}
+        return ob
+    if t == "vmess":
+        net = "httpupgrade" if key == "vmess-httpupgrade" else "ws"
+        return {"tag": tag, "type": "vmess", "server": srv, "server_port": int(d["port"]),
+                "uuid": d["uuid"], "security": "none", "alter_id": 0,
+                "tls": {"enabled": True, "server_name": sni, "insecure": insec, "utls": utls},
+                "transport": {"type": net, "path": d["ws-opts"].get("path", "/"),
+                              "headers": {"Host": d["ws-opts"].get("headers", {}).get("Host", sni)}}}
+    if t == "trojan":
+        return {"tag": tag, "type": "trojan", "server": srv, "server_port": int(d["port"]),
+                "password": d["password"],
+                "tls": {"enabled": True, "server_name": sni, "insecure": insec,
+                        "alpn": ["http/1.1"], "utls": utls}}
+    if t == "hysteria2":
+        ob = {"tag": tag, "type": "hysteria2", "server": srv, "password": d["password"],
+              "tls": {"enabled": True, "server_name": sni, "insecure": insec, "alpn": ["h3"]}}
         if d.get("ports"):
-            ob["server_ports"] = [d["ports"].replace("-", ":")]; ob.pop("server_port", None)
+            ob["server_ports"] = [d["ports"].replace("-", ":")]; ob["hop_interval"] = "30s"
         else:
             ob["server_port"] = int(d["port"])
-    else:
-        ob["server_port"] = int(d["port"])
-    if d.get("uuid"):
-        ob["uuid"] = d["uuid"]
-    if d.get("password") and d.get("type") in ("trojan", "tuic", "anytls"):
-        ob["password"] = d["password"]
-    sn = d.get("servername") or d.get("sni")
-    if sn and isinstance(ob.get("tls"), dict):
-        ob["tls"]["server_name"] = sn
-    if d.get("reality-opts") and isinstance(ob.get("tls"), dict):
-        rob = ob["tls"].setdefault("reality", {"enabled": True})
-        rob["public_key"] = d["reality-opts"].get("public-key", "")
-        rob["short_id"] = d["reality-opts"].get("short-id", "")
-    if d.get("ws-opts") and isinstance(ob.get("transport"), dict):
-        ob["transport"]["path"] = d["ws-opts"].get("path", "/")
-        h = d["ws-opts"].get("headers", {}).get("Host")
-        if h:
-            ob["transport"].setdefault("headers", {})["Host"] = h
-    if d.get("grpc-opts") and isinstance(ob.get("transport"), dict):
-        ob["transport"]["service_name"] = d["grpc-opts"].get("grpc-service-name", "")
+        return ob
+    if t == "tuic":
+        return {"tag": tag, "type": "tuic", "server": srv, "server_port": int(d["port"]),
+                "uuid": d["uuid"], "password": d["password"], "congestion_control": "bbr",
+                "tls": {"enabled": True, "server_name": sni, "insecure": insec, "alpn": ["h3"]}}
+    if t == "anytls":
+        return {"tag": tag, "type": "anytls", "server": srv, "server_port": int(d["port"]),
+                "password": d["password"],
+                "tls": {"enabled": True, "server_name": sni, "insecure": insec,
+                        "alpn": ["h2", "http/1.1"], "utls": utls}}
+    return None
 
 def build_singbox_sub(nodes):
-    """nodes: [(proto_key, mihomo_dict)]。按 tag 把参数填进 sing-box 模板，写 SBOX_FILE。"""
+    """服务器端生成节点对象填 __PROXY__ 锚点、展开名称填 __PATTERN__ 锚点。模板不带任何连接参数。"""
     try:
-        cfg = json.loads(fetch_url(SBOX_TPL_URL))
+        txt = fetch_url(SBOX_TPL_URL)
     except Exception as e:
         print("sing-box 模板拉取失败，跳过:", e); return
-    by_tag = {ob.get("tag"): ob for ob in cfg.get("outbounds", [])}
+    objs = []
     for key, d in nodes:
-        tag = PROTO_TO_SBTAG.get(key)
-        if tag and tag in by_tag:
-            fill_singbox_outbound(by_tag[tag], d)
-    open(SBOX_FILE, "w").write(json.dumps(cfg, ensure_ascii=False, indent=2))
+        try:
+            ob = mihomo_to_sb_outbound(key, d)
+            if ob: objs.append(ob)
+        except Exception:
+            pass
+    if not objs:
+        return
+    tags = [o["tag"] for o in objs]
+    # 节点锚点：占位串换成真实节点对象
+    txt = txt.replace('"__PROXY__"', ",\n    ".join(json.dumps(o, ensure_ascii=False) for o in objs))
+    # 名称锚点：每个 "__PATTERN__:正则" 换成命中该正则的节点名列表
+    def expand(m):
+        rx = m.group(1)
+        sel = [t for t in tags if re.search(rx, t)]
+        return ", ".join(json.dumps(t, ensure_ascii=False) for t in sel) or '"DIRECT"'
+    txt = re.sub(r'"__PATTERN__:([^"]*)"', expand, txt)
+    try:
+        json.loads(txt)                                  # 落盘前校验合法
+    except Exception as e:
+        print("sing-box 配置生成后 JSON 不合法，跳过:", e); return
+    open(SBOX_FILE, "w").write(txt)
 
 # --- Shadowrocket [Proxy] 行：从 mihomo 参数转（名称带国旗前缀让分组正则命中）---
 def shadowrocket_line(name, d):


### PR DESCRIPTION
## 反馈

之前把 sing-box 连接参数写进仓库模板 —— 节点重装后参数就变，写死不对。应在服务器端做参数转换 + 名称筛选后填进 `outbounds`。

## 改动（双锚点）

- **`subbox-template.json` 改为锚点版**：10 个节点对象 → `"__PROXY__"`；各策略组/urltest 里的节点名列表 → `"__PATTERN__:🇺🇲.*"`。模板从此只有结构、无任何连接参数，其余随便改。
- **节点锚点 `__PROXY__`**：`mihomo_to_sb_outbound()` 把真实节点转成完整 sing-box 出站对象（vless/vmess/trojan/hy2/tuic/anytls；reality/ws/grpc/httpupgrade/hy2 端口跳跃），填入。
- **名称锚点 `__PATTERN__:正则`**：每处按正则展开成命中的节点名列表（协议增减也不会引用到不存在的节点）。
- 文本替换两锚点后 `json.loads` 校验再落盘。

## xhttp

xhttp 是 xray 专属、sing-box 不支持：`link_to_proxy` 保留 `network=xhttp`，`proto_key` 归为 `vless-xhttp`（不在映射表）→ sing-box 生成时**跳过**。

## 验证

10 协议 + 1 个 xhttp 节点实测：xhttp 被跳过（生成 10 个节点对象）；`__PROXY__`/`__PATTERN__` 全部展开无残留；`♻️随机` 展开到 10 个；reality/hy2 等对象结构与参考写法一致；最终 JSON 合法。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYvMbH716hPckedcKHV5Up

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYvMbH716hPckedcKHV5Up)_