### PR TITLE
修复 xray vless-reality-xhttp 连不上：去掉 xhttp 客户端的 vision flow

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -622,9 +622,10 @@ def xr_reality_xhttp(port, tag):
     priv, pub = reality_keys(XRAY_BIN, "x25519")
     st = _xr_reality_stream(priv, sid, "xhttp",
                             {"xhttpSettings": {"path": path}})
+    # xhttp 传输不支持 xtls-rprx-vision flow（那是 raw/tcp 专属），客户端也没带 flow，
+    # 服务端这里若强设 vision flow 会导致握手对不上 → 连不上，所以留空。
     ib = {"listen": "0.0.0.0", "port": port, "protocol": "vless", "tag": tag,
-          "settings": {"clients": [{"id": uid, "flow": "xtls-rprx-vision"}],
-                       "decryption": "none"},
+          "settings": {"clients": [{"id": uid}], "decryption": "none"},
           "streamSettings": st}
     lk = (f"vless://{uid}@{G['host']}:{port}?encryption=none&security=reality"
           f"&sni={G['sni']}&fp=chrome&pbk={pub}&sid={sid}&type=xhttp&path={path}#{tag}")


### PR DESCRIPTION
## 问题

面板里 `vless-reality-xhttp` 节点⚡超时连不上。

## 原因

`xr_reality_xhttp` 服务端 inbound 给客户端设了 `flow: xtls-rprx-vision`，但：
- `xtls-rprx-vision` 只能用于 raw/tcp（Vision），**xhttp 传输不支持 flow**
- 生成的分享链接里也没有带 `flow`

结果服务端要 vision 握手、客户端不发 flow，握手对不上 → 连不上。

## 修改

xhttp 的客户端去掉 `flow`（reality xhttp 本来就不该带 flow）。

跟 xray 作者的声明无关，是配置参数问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYvMbH716hPckedcKHV5Up

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYvMbH716hPckedcKHV5Up)_