### PR TITLE
新增「屏蔽中国域名和IP」功能（服务端路由 + 白名单放行）

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -59,6 +59,17 @@ NGINX_CONF = "/etc/nginx/conf.d/bgpeer.conf"
 WEBROOT    = "/var/www/bgpeer"
 NGINX_WS   = []                 # 运行期收集：ws 家族的 {path, port}，供 nginx location 反代
 
+# ---- 屏蔽中国域名/IP（服务端路由：CN 域名+IP → reject，白名单 CN 服务照常直连）----
+# 参考 bgpeer/vps-net 的 whitelist-inject.sh，但那是给 mack-a 注入白名单、CN 屏蔽靠 mack-a 底配；
+# nodekit 是干净配置，这里连 CN 屏蔽规则一起自建。规则集用 sing-box 远程 srs（每 24h 自更新）。
+CNBLOCK_FILE = BGP_DIR + "/cnblock.json"        # 记住是否开启屏蔽 + 白名单来源
+RULES_RAW    = "https://raw.githubusercontent.com/bgpeer/rules/main/geo"
+CN_SITE_URL  = RULES_RAW + "/geosite/geolocation-cn.srs"   # 全部 CN 域名
+CN_IP_URL    = RULES_RAW + "/geoip/cn.srs"                 # 全部 CN IP
+# 作者放行白名单：这些 CN 服务照常直连，其余 CN 一律拦（对齐 whitelist-inject.sh 的 WHITELIST_TAGS）
+CN_WHITELIST = ["bytedance", "tiktok", "wildrift", "bilibili",
+                "xiaohongshu", "alibaba", "tencent", "kuaishou", "geolocation-!cn"]
+
 # ---------------------------------------------------------------------------- 基础工具
 def sh(cmd, check=True):
     r = subprocess.run(cmd, shell=True, text=True, capture_output=True)
@@ -1155,6 +1166,13 @@ def run(sb_names, xr_names):
                   open(cfg, "w"), indent=2)
         write_service("xray", XRAY_BIN, cfg)
 
+    # 之前开过「屏蔽中国域名/IP」的话，重装重写了 config 会丢规则，这里自动重新注入
+    if sb_names and cnblock_load().get("enabled"):
+        try:
+            apply_cn_block()
+        except Exception as e:
+            print("CN 屏蔽重注入跳过（不影响节点）:", e)
+
     # 落盘保存，避免终端刷屏后找不到；同时打印到屏幕
     out_file = "/root/xy-nodes.txt"
     try:
@@ -1349,6 +1367,178 @@ def uninstall_all():
         sh(f"rm -rf {p}", check=False)
     print("已卸载完毕。")
 
+# ============================================================================ 屏蔽中国域名/IP
+def cnblock_load(): return _load_json(CNBLOCK_FILE) or {}
+def cnblock_save(d):
+    os.makedirs(BGP_DIR, exist_ok=True)
+    json.dump(d, open(CNBLOCK_FILE, "w"), ensure_ascii=False, indent=2)
+
+def _srs_ok(url):
+    """预检规则集能否下载（200 才注入，避免死链导致 sing-box 起不来）。"""
+    code = sh(f'curl -s -o /dev/null -w "%{{http_code}}" --max-time 15 {url}', check=False)
+    return code.strip() == "200"
+
+def _is_cnblk_rule(r):
+    """判断一条 route.rule 是不是本脚本注入的（引用了 cnblk- 开头的规则集）。"""
+    rs = r.get("rule_set")
+    if isinstance(rs, str):  return rs.startswith("cnblk-")
+    if isinstance(rs, list): return any(str(x).startswith("cnblk-") for x in rs)
+    return False
+
+def _whitelist_tags(cfg):
+    """取白名单 tag 列表：作者名单 / 自定义名单。
+       自定义链接可为纯文本（每行一个 tag，# 注释跳过），
+       也可直接指向 whitelist-inject.sh —— 自动抽取其中 WHITELIST_TAGS=(...) 数组。"""
+    mode = cfg.get("wl_mode", "author")
+    if mode == "none":
+        return []
+    if mode == "custom":
+        url = (cfg.get("wl_url") or "").strip()
+        if not url:
+            print("  未设置自定义放行名单链接，改用作者名单。"); return list(CN_WHITELIST)
+        try:
+            txt = fetch_url(url)
+        except Exception as e:
+            print("  拉取自定义名单失败，改用作者名单:", e); return list(CN_WHITELIST)
+        m = re.search(r"WHITELIST_TAGS=\(([^)]*)\)", txt, re.S)
+        if m:                                            # 直接喂 whitelist-inject.sh：抽数组
+            return re.findall(r'[A-Za-z0-9!_.\-]+', m.group(1))
+        tags = []                                        # 否则按纯文本：每行一个 tag
+        for ln in txt.splitlines():
+            ln = ln.strip()
+            if ln and not ln.startswith("#"):
+                tags.append(ln.split()[0])
+        return tags
+    return list(CN_WHITELIST)
+
+def apply_cn_block(cfg=None):
+    """把 CN 屏蔽 + 白名单放行规则注入 sing-box 服务端配置并重启（失败回滚）。"""
+    sb_cfg = f"{SB_DIR}/config.json"
+    if not os.path.exists(sb_cfg):
+        print("没检测到 sing-box 配置，请先『1.安装』。"); return False
+    cfg = cfg or cnblock_load()
+    try:
+        conf = json.load(open(sb_cfg))
+    except Exception as e:
+        print("读取 sing-box 配置失败:", e); return False
+    backup = json.loads(json.dumps(conf))                # 深拷贝，校验失败时回滚
+
+    # 直连出站需有 tag（白名单命中后 detour 到它放行）
+    obs = conf.get("outbounds") or [{"type": "direct"}]
+    direct_tag = ""
+    for o in obs:
+        if o.get("type") == "direct":
+            o.setdefault("tag", "direct"); direct_tag = o["tag"]; break
+    if not direct_tag:
+        obs.append({"type": "direct", "tag": "direct"}); direct_tag = "direct"
+    conf["outbounds"] = obs
+
+    route = conf.get("route") or {}
+    # 清掉本脚本上次注入的规则集/规则（cnblk- 前缀），保留其它
+    rsets = [r for r in route.get("rule_set", []) if not str(r.get("tag", "")).startswith("cnblk-")]
+    keep_rules = [r for r in route.get("rules", []) if not _is_cnblk_rule(r)]
+
+    wl_refs = []
+    print("  预检白名单规则集…")
+    for t in _whitelist_tags(cfg):
+        url = f"{RULES_RAW}/geosite/{t}.srs"
+        if _srs_ok(url):
+            tag = "cnblk-wl-" + t
+            rsets.append({"type": "remote", "tag": tag, "format": "binary", "url": url,
+                          "download_detour": direct_tag, "update_interval": "24h"})
+            wl_refs.append(tag)
+        else:
+            print(f"    跳过 {t}（拉不到）")
+    rsets.append({"type": "remote", "tag": "cnblk-cn-site", "format": "binary", "url": CN_SITE_URL,
+                  "download_detour": direct_tag, "update_interval": "24h"})
+    rsets.append({"type": "remote", "tag": "cnblk-cn-ip", "format": "binary", "url": CN_IP_URL,
+                  "download_detour": direct_tag, "update_interval": "24h"})
+
+    # 规则顺序：白名单放行（在前，命中即直连不被拦）→ CN 域名拦 → CN IP 拦 → 原有其它规则
+    inj = []
+    if wl_refs:
+        inj.append({"rule_set": wl_refs, "outbound": direct_tag})
+    inj.append({"rule_set": "cnblk-cn-site", "action": "reject"})
+    inj.append({"rule_set": "cnblk-cn-ip", "action": "reject"})
+
+    route["rule_set"] = rsets
+    route["rules"] = inj + keep_rules
+    conf["route"] = route
+    # 远程 rule_set 建议开 cache_file 持久化（否则每次重启都重新拉、且 sing-box 会告警）
+    exp = conf.get("experimental") or {}
+    cf = exp.get("cache_file") or {}
+    cf["enabled"] = True; cf.setdefault("path", f"{SB_DIR}/cache.db")
+    exp["cache_file"] = cf; conf["experimental"] = exp
+    json.dump(conf, open(sb_cfg, "w"), ensure_ascii=False, indent=2)
+
+    r = subprocess.run(f"{SB_BIN} check -c {sb_cfg}", shell=True, text=True, capture_output=True)
+    if r.returncode:
+        json.dump(backup, open(sb_cfg, "w"), ensure_ascii=False, indent=2)   # 回滚
+        print("注入后配置校验失败，已回滚未生效：\n" + (r.stderr or r.stdout).strip()); return False
+    sh("systemctl restart sing-box", check=False)
+    cfg["enabled"] = True; cnblock_save(cfg)
+    print(f"\n✓ 已开启屏蔽中国域名/IP：放行白名单 {len(wl_refs)} 组，其余 CN 域名+IP 一律拦截。")
+    return True
+
+def remove_cn_block():
+    """移除本脚本注入的 CN 屏蔽/白名单规则，恢复不拦截。"""
+    sb_cfg = f"{SB_DIR}/config.json"
+    if not os.path.exists(sb_cfg):
+        print("没检测到 sing-box 配置。"); return
+    try:
+        conf = json.load(open(sb_cfg))
+    except Exception as e:
+        print("读取配置失败:", e); return
+    route = conf.get("route") or {}
+    route["rule_set"] = [r for r in route.get("rule_set", []) if not str(r.get("tag", "")).startswith("cnblk-")]
+    route["rules"] = [r for r in route.get("rules", []) if not _is_cnblk_rule(r)]
+    if not route.get("rule_set") and not route.get("rules"):
+        conf.pop("route", None)
+    else:
+        conf["route"] = route
+    json.dump(conf, open(sb_cfg, "w"), ensure_ascii=False, indent=2)
+    sh("systemctl restart sing-box", check=False)
+    cfg = cnblock_load(); cfg["enabled"] = False; cnblock_save(cfg)
+    print("已关闭屏蔽，恢复为不拦截 CN。")
+
+def cn_block_menu():
+    while True:
+        cfg = cnblock_load()
+        on = cfg.get("enabled")
+        wl = {"author": "作者名单", "custom": "自定义名单", "none": "不放行"}.get(cfg.get("wl_mode", "author"), "作者名单")
+        print("\n" + "=" * 60 + "\n屏蔽中国域名和IP\n" + "=" * 60)
+        print(f"  当前状态: {'已开启 ✓' if on else '未开启'}    放行白名单: {wl}")
+        print(f"  自定义放行名单链接: {cfg.get('wl_url') or '(未设置)'}")
+        print("-" * 60)
+        print("  1 屏蔽中国域名和IP" + ("（已开，再选可关闭）" if on else ""))
+        print("  2 放行白名单（作者名单 / 自定义名单）")
+        print("  3 自定义放行名单脚本链接")
+        print("  4 退出")
+        c = _ask("选择: ").strip()
+        if c == "1":
+            if on:
+                if _ask("  已开启，关闭屏蔽? [y/N]: ").lower() in ("y", "yes"):
+                    remove_cn_block()
+            else:
+                apply_cn_block(cfg)
+        elif c == "2":
+            print("    1 作者名单   2 自定义名单   0 返回")
+            s = _ask("    选择: ").strip()
+            if s == "1":   cfg["wl_mode"] = "author"
+            elif s == "2": cfg["wl_mode"] = "custom"
+            else:          continue
+            cnblock_save(cfg)
+            print("    已设为", "作者名单" if cfg["wl_mode"] == "author" else "自定义名单")
+            if cfg.get("enabled"): apply_cn_block(cfg)    # 已开启则立即用新名单重注入
+        elif c == "3":
+            url = _ask("  自定义放行名单链接(纯文本 tag 列表，或直接指向 whitelist-inject.sh): ").strip()
+            if url:
+                cfg["wl_url"] = url; cfg["wl_mode"] = "custom"; cnblock_save(cfg)
+                print("  已保存，并切到自定义名单。")
+                if cfg.get("enabled"): apply_cn_block(cfg)
+        elif c in ("4", "0", ""):
+            return
+
 def main_menu():
     while True:
         print("\n" + "=" * 60)
@@ -1363,6 +1553,7 @@ def main_menu():
         print("  6. 更新脚本（不影响节点）")
         print("  7. 更新核心（sing-box / xray）")
         print("  8. 卸载")
+        print("  9. 屏蔽中国域名和IP（CN 域名+IP 拦截 / 白名单放行）")
         print("  0. 退出")
         print("-" * 60)
         c = _ask("请选择: ").strip()
@@ -1376,6 +1567,7 @@ def main_menu():
         elif c == "6":  update_script()
         elif c == "7":  update_cores()
         elif c == "8":  uninstall_all()
+        elif c == "9":  cn_block_menu()
         else:
             print("无效选择。"); continue
         _ask("\n按回车返回主菜单...")            # 停一下，别让菜单立刻盖住上面的输出


### PR DESCRIPTION
## 需求

参考 `bgpeer/vps-net` 的 `whitelist-inject.sh`，在 nodekit 脚本里做一个服务端「屏蔽中国域名和IP」按钮：让通过节点的流量到 CN 域名/IP 一律拦截，白名单内的 CN 服务照常放行。

## 菜单

主菜单新增 **9. 屏蔽中国域名和IP**，进去子菜单：

```
屏蔽中国域名和IP
  1 屏蔽中国域名和IP     （已开则再选可关闭）
  2 放行白名单
      1 作者名单
      2 自定义名单
      0 返回
  3 自定义放行名单脚本链接
  4 退出
```

## 实现

- **CN 屏蔽**：往 sing-box 服务端配置注入 route——CN 域名（`geolocation-cn.srs`）+ CN IP（`geoip/cn.srs`）走 `action: reject`；白名单规则放最前，命中即 `direct` 放行。
- **白名单**：作者名单对齐 whitelist-inject.sh 的 `WHITELIST_TAGS`；自定义名单支持纯文本 tag 列表，**也可直接把 `whitelist-inject.sh` 的链接填进去**，自动抽取里面的 `WHITELIST_TAGS=(...)` 数组。
- **健壮性**：规则集用远程 srs（每 24h 自更新），注入前 HTTP 预检、死链自动跳过；注入后 `sing-box check` 校验，**失败自动回滚**，不会把节点搞挂；开启 `experimental.cache_file` 持久化远程规则集。
- **持久化**：状态存 `/etc/bgpeer/cnblock.json`；重装会重写 config 丢规则，`run()` 里检测到之前开启过就**自动重新注入**。

CN 屏蔽作用于 sing-box（承载 10 个主协议）；xray 那个 xhttp 节点暂不覆盖（xray geosite/geoip 需另配 .dat，后续按需再加）。

## 测试

- 离线跑通注入变换：direct 出站自动补 tag、规则顺序正确、重复执行不叠加、关闭后 route 干净移除。
- 验证把真实 `whitelist-inject.sh` 当自定义链接可正确抽出 9 个白名单 tag。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYvMbH716hPckedcKHV5Up

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYvMbH716hPckedcKHV5Up)_