### PR TITLE
CN 屏蔽拆成独立文件 cn-block.py，菜单加「卸载」

### DIFF
--- a/cn-block.py
+++ b/cn-block.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# cn-block.py —— 屏蔽中国域名/IP（sing-box 服务端路由）+ 白名单放行
+# 独立文件，方便单独维护；nodekit 主脚本(xy-installer.py)通过子进程调用：
+#   python3 cn-block.py            交互菜单
+#   python3 cn-block.py apply      按已存状态重新注入（未开启则直接跳过）——重装后自动调用
+#   python3 cn-block.py remove     卸载屏蔽规则
+#
+# 规则集用 sing-box 远程 srs（每 24h 自更新）：
+#   CN 域名 geosite/geolocation-cn.srs、CN IP geoip/cn.srs → reject
+#   白名单（作者名单对齐 vps-net/whitelist-inject.sh 的 WHITELIST_TAGS）→ 命中直连放行
+import os, re, sys, json, subprocess, urllib.request
+
+SB_DIR  = "/etc/sing-box"
+SB_BIN  = "/usr/local/bin/sing-box"
+BGP_DIR = "/etc/bgpeer"
+CNBLOCK_FILE = BGP_DIR + "/cnblock.json"        # 记住是否开启 + 白名单来源
+RULES_RAW    = "https://raw.githubusercontent.com/bgpeer/rules/main/geo"
+CN_SITE_URL  = RULES_RAW + "/geosite/geolocation-cn.srs"   # 全部 CN 域名
+CN_IP_URL    = RULES_RAW + "/geoip/cn.srs"                 # 全部 CN IP
+# 作者放行白名单：这些 CN 服务照常直连，其余 CN 一律拦
+CN_WHITELIST = ["bytedance", "tiktok", "wildrift", "bilibili",
+                "xiaohongshu", "alibaba", "tencent", "kuaishou", "geolocation-!cn"]
+
+def sh(cmd, check=True):
+    r = subprocess.run(cmd, shell=True, text=True, capture_output=True)
+    if check and r.returncode:
+        raise RuntimeError((r.stderr or r.stdout).strip())
+    return r.stdout.strip()
+
+def _ask(prompt=""):
+    """交互输入：优先读 /dev/tty，使 curl|python3 管道下仍可交互。"""
+    try:
+        with open("/dev/tty", "r") as t:
+            print(prompt, end="", flush=True)
+            line = t.readline()
+            if line == "":
+                raise EOFError
+            return line.rstrip("\n").strip()
+    except (OSError, EOFError):
+        return input(prompt).strip()
+
+def fetch_url(url):
+    req = urllib.request.Request(url, headers={"User-Agent": "xy-installer"})
+    return urllib.request.urlopen(req, timeout=15).read().decode()
+
+def cnblock_load():
+    try: return json.load(open(CNBLOCK_FILE))
+    except Exception: return {}
+def cnblock_save(d):
+    os.makedirs(BGP_DIR, exist_ok=True)
+    json.dump(d, open(CNBLOCK_FILE, "w"), ensure_ascii=False, indent=2)
+
+def _srs_ok(url):
+    """预检规则集能否下载（200 才注入，避免死链导致 sing-box 起不来）。"""
+    code = sh(f'curl -s -o /dev/null -w "%{{http_code}}" --max-time 15 {url}', check=False)
+    return code.strip() == "200"
+
+def _is_cnblk_rule(r):
+    """判断一条 route.rule 是不是本脚本注入的（引用了 cnblk- 开头的规则集）。"""
+    rs = r.get("rule_set")
+    if isinstance(rs, str):  return rs.startswith("cnblk-")
+    if isinstance(rs, list): return any(str(x).startswith("cnblk-") for x in rs)
+    return False
+
+def _whitelist_tags(cfg):
+    """取白名单 tag 列表：作者名单 / 自定义名单。
+       自定义链接可为纯文本（每行一个 tag，# 注释跳过），
+       也可直接指向 whitelist-inject.sh —— 自动抽取其中 WHITELIST_TAGS=(...) 数组。"""
+    mode = cfg.get("wl_mode", "author")
+    if mode == "none":
+        return []
+    if mode == "custom":
+        url = (cfg.get("wl_url") or "").strip()
+        if not url:
+            print("  未设置自定义放行名单链接，改用作者名单。"); return list(CN_WHITELIST)
+        try:
+            txt = fetch_url(url)
+        except Exception as e:
+            print("  拉取自定义名单失败，改用作者名单:", e); return list(CN_WHITELIST)
+        m = re.search(r"WHITELIST_TAGS=\(([^)]*)\)", txt, re.S)
+        if m:                                            # 直接喂 whitelist-inject.sh：抽数组
+            return re.findall(r'[A-Za-z0-9!_.\-]+', m.group(1))
+        tags = []                                        # 否则按纯文本：每行一个 tag
+        for ln in txt.splitlines():
+            ln = ln.strip()
+            if ln and not ln.startswith("#"):
+                tags.append(ln.split()[0])
+        return tags
+    return list(CN_WHITELIST)
+
+def apply_cn_block(cfg=None):
+    """把 CN 屏蔽 + 白名单放行规则注入 sing-box 服务端配置并重启（失败回滚）。"""
+    sb_cfg = f"{SB_DIR}/config.json"
+    if not os.path.exists(sb_cfg):
+        print("没检测到 sing-box 配置，请先在主脚本『1.安装』。"); return False
+    cfg = cfg or cnblock_load()
+    try:
+        conf = json.load(open(sb_cfg))
+    except Exception as e:
+        print("读取 sing-box 配置失败:", e); return False
+    backup = json.loads(json.dumps(conf))                # 深拷贝，校验失败时回滚
+
+    # 直连出站需有 tag（白名单命中后 detour 到它放行）
+    obs = conf.get("outbounds") or [{"type": "direct"}]
+    direct_tag = ""
+    for o in obs:
+        if o.get("type") == "direct":
+            o.setdefault("tag", "direct"); direct_tag = o["tag"]; break
+    if not direct_tag:
+        obs.append({"type": "direct", "tag": "direct"}); direct_tag = "direct"
+    conf["outbounds"] = obs
+
+    route = conf.get("route") or {}
+    # 清掉本脚本上次注入的规则集/规则（cnblk- 前缀），保留其它
+    rsets = [r for r in route.get("rule_set", []) if not str(r.get("tag", "")).startswith("cnblk-")]
+    keep_rules = [r for r in route.get("rules", []) if not _is_cnblk_rule(r)]
+
+    wl_refs = []
+    print("  预检白名单规则集…")
+    for t in _whitelist_tags(cfg):
+        url = f"{RULES_RAW}/geosite/{t}.srs"
+        if _srs_ok(url):
+            tag = "cnblk-wl-" + t
+            rsets.append({"type": "remote", "tag": tag, "format": "binary", "url": url,
+                          "download_detour": direct_tag, "update_interval": "24h"})
+            wl_refs.append(tag)
+        else:
+            print(f"    跳过 {t}（拉不到）")
+    rsets.append({"type": "remote", "tag": "cnblk-cn-site", "format": "binary", "url": CN_SITE_URL,
+                  "download_detour": direct_tag, "update_interval": "24h"})
+    rsets.append({"type": "remote", "tag": "cnblk-cn-ip", "format": "binary", "url": CN_IP_URL,
+                  "download_detour": direct_tag, "update_interval": "24h"})
+
+    # 规则顺序：白名单放行（在前，命中即直连不被拦）→ CN 域名拦 → CN IP 拦 → 原有其它规则
+    inj = []
+    if wl_refs:
+        inj.append({"rule_set": wl_refs, "outbound": direct_tag})
+    inj.append({"rule_set": "cnblk-cn-site", "action": "reject"})
+    inj.append({"rule_set": "cnblk-cn-ip", "action": "reject"})
+
+    route["rule_set"] = rsets
+    route["rules"] = inj + keep_rules
+    conf["route"] = route
+    # 远程 rule_set 建议开 cache_file 持久化（否则每次重启都重新拉、且 sing-box 会告警）
+    exp = conf.get("experimental") or {}
+    cf = exp.get("cache_file") or {}
+    cf["enabled"] = True; cf.setdefault("path", f"{SB_DIR}/cache.db")
+    exp["cache_file"] = cf; conf["experimental"] = exp
+    json.dump(conf, open(sb_cfg, "w"), ensure_ascii=False, indent=2)
+
+    r = subprocess.run(f"{SB_BIN} check -c {sb_cfg}", shell=True, text=True, capture_output=True)
+    if r.returncode:
+        json.dump(backup, open(sb_cfg, "w"), ensure_ascii=False, indent=2)   # 回滚
+        print("注入后配置校验失败，已回滚未生效：\n" + (r.stderr or r.stdout).strip()); return False
+    sh("systemctl restart sing-box", check=False)
+    cfg["enabled"] = True; cnblock_save(cfg)
+    print(f"\n✓ 已开启屏蔽中国域名/IP：放行白名单 {len(wl_refs)} 组，其余 CN 域名+IP 一律拦截。")
+    return True
+
+def remove_cn_block(silent=False):
+    """移除本脚本注入的 CN 屏蔽/白名单规则，恢复不拦截。"""
+    sb_cfg = f"{SB_DIR}/config.json"
+    if os.path.exists(sb_cfg):
+        try:
+            conf = json.load(open(sb_cfg))
+            route = conf.get("route") or {}
+            route["rule_set"] = [r for r in route.get("rule_set", []) if not str(r.get("tag", "")).startswith("cnblk-")]
+            route["rules"] = [r for r in route.get("rules", []) if not _is_cnblk_rule(r)]
+            if not route.get("rule_set") and not route.get("rules"):
+                conf.pop("route", None)
+            else:
+                conf["route"] = route
+            json.dump(conf, open(sb_cfg, "w"), ensure_ascii=False, indent=2)
+            sh("systemctl restart sing-box", check=False)
+        except Exception as e:
+            print("处理配置失败:", e)
+    try: os.remove(CNBLOCK_FILE)                          # 卸载即清状态，之后重装不会再自动注入
+    except OSError: pass
+    if not silent:
+        print("已卸载屏蔽，恢复为不拦截 CN。")
+
+def menu():
+    while True:
+        cfg = cnblock_load()
+        on = cfg.get("enabled")
+        wl = {"author": "作者名单", "custom": "自定义名单", "none": "不放行"}.get(cfg.get("wl_mode", "author"), "作者名单")
+        print("\n" + "=" * 60 + "\n屏蔽中国域名和IP\n" + "=" * 60)
+        print(f"  当前状态: {'已开启 ✓' if on else '未开启'}    放行白名单: {wl}")
+        print(f"  自定义放行名单链接: {cfg.get('wl_url') or '(未设置)'}")
+        print("-" * 60)
+        print("  1 屏蔽中国域名和IP" + ("（已开，再选可关闭）" if on else ""))
+        print("  2 放行白名单（作者名单 / 自定义名单）")
+        print("  3 自定义放行名单脚本链接")
+        print("  4 卸载（不想屏蔽了，直接清掉规则）")
+        print("  5 退出")
+        c = _ask("选择: ").strip()
+        if c == "1":
+            if on:
+                if _ask("  已开启，关闭屏蔽? [y/N]: ").lower() in ("y", "yes"):
+                    remove_cn_block()
+            else:
+                apply_cn_block(cfg)
+        elif c == "2":
+            print("    1 作者名单   2 自定义名单   0 返回")
+            s = _ask("    选择: ").strip()
+            if s == "1":   cfg["wl_mode"] = "author"
+            elif s == "2": cfg["wl_mode"] = "custom"
+            else:          continue
+            cnblock_save(cfg)
+            print("    已设为", "作者名单" if cfg["wl_mode"] == "author" else "自定义名单")
+            if cfg.get("enabled"): apply_cn_block(cfg)    # 已开启则立即用新名单重注入
+        elif c == "3":
+            url = _ask("  自定义放行名单链接(纯文本 tag 列表，或直接指向 whitelist-inject.sh): ").strip()
+            if url:
+                cfg["wl_url"] = url; cfg["wl_mode"] = "custom"; cnblock_save(cfg)
+                print("  已保存，并切到自定义名单。")
+                if cfg.get("enabled"): apply_cn_block(cfg)
+        elif c == "4":
+            remove_cn_block()
+        elif c in ("5", "0", ""):
+            return
+
+def main():
+    act = sys.argv[1] if len(sys.argv) > 1 else ""
+    if act == "apply":                                   # 主脚本重装后调用：仅在已开启时重注入
+        if cnblock_load().get("enabled"):
+            apply_cn_block()
+    elif act == "remove":
+        remove_cn_block()
+    else:
+        menu()
+
+if __name__ == "__main__":
+    main()

--- a/xy-installer.py
+++ b/xy-installer.py
@@ -59,16 +59,10 @@ NGINX_CONF = "/etc/nginx/conf.d/bgpeer.conf"
 WEBROOT    = "/var/www/bgpeer"
 NGINX_WS   = []                 # 运行期收集：ws 家族的 {path, port}，供 nginx location 反代
 
-# ---- 屏蔽中国域名/IP（服务端路由：CN 域名+IP → reject，白名单 CN 服务照常直连）----
-# 参考 bgpeer/vps-net 的 whitelist-inject.sh，但那是给 mack-a 注入白名单、CN 屏蔽靠 mack-a 底配；
-# nodekit 是干净配置，这里连 CN 屏蔽规则一起自建。规则集用 sing-box 远程 srs（每 24h 自更新）。
-CNBLOCK_FILE = BGP_DIR + "/cnblock.json"        # 记住是否开启屏蔽 + 白名单来源
-RULES_RAW    = "https://raw.githubusercontent.com/bgpeer/rules/main/geo"
-CN_SITE_URL  = RULES_RAW + "/geosite/geolocation-cn.srs"   # 全部 CN 域名
-CN_IP_URL    = RULES_RAW + "/geoip/cn.srs"                 # 全部 CN IP
-# 作者放行白名单：这些 CN 服务照常直连，其余 CN 一律拦（对齐 whitelist-inject.sh 的 WHITELIST_TAGS）
-CN_WHITELIST = ["bytedance", "tiktok", "wildrift", "bilibili",
-                "xiaohongshu", "alibaba", "tencent", "kuaishou", "geolocation-!cn"]
+# 屏蔽中国域名/IP 功能拆到独立文件 cn-block.py，方便单独维护；主脚本只负责拉取+调用。
+CNBLOCK_FILE   = BGP_DIR + "/cnblock.json"       # cn-block.py 存的状态（这里只读它判断是否已开启）
+CN_BLOCK_LOCAL = BGP_DIR + "/cn-block.py"        # 本地缓存的 cn-block.py
+CN_BLOCK_URL   = _RAW + "cn-block.py"            # 仓库里的 cn-block.py（每次尽量拉最新）
 
 # ---------------------------------------------------------------------------- 基础工具
 def sh(cmd, check=True):
@@ -1167,9 +1161,9 @@ def run(sb_names, xr_names):
         write_service("xray", XRAY_BIN, cfg)
 
     # 之前开过「屏蔽中国域名/IP」的话，重装重写了 config 会丢规则，这里自动重新注入
-    if sb_names and cnblock_load().get("enabled"):
+    if sb_names:
         try:
-            apply_cn_block()
+            cn_block_reapply()
         except Exception as e:
             print("CN 屏蔽重注入跳过（不影响节点）:", e)
 
@@ -1367,177 +1361,33 @@ def uninstall_all():
         sh(f"rm -rf {p}", check=False)
     print("已卸载完毕。")
 
-# ============================================================================ 屏蔽中国域名/IP
-def cnblock_load(): return _load_json(CNBLOCK_FILE) or {}
-def cnblock_save(d):
+# ============================================================================ 屏蔽中国域名/IP（独立文件）
+def ensure_cn_block():
+    """把仓库里的 cn-block.py 拉到本地（每次尽量拉最新）；拉不到就用本地缓存。"""
     os.makedirs(BGP_DIR, exist_ok=True)
-    json.dump(d, open(CNBLOCK_FILE, "w"), ensure_ascii=False, indent=2)
-
-def _srs_ok(url):
-    """预检规则集能否下载（200 才注入，避免死链导致 sing-box 起不来）。"""
-    code = sh(f'curl -s -o /dev/null -w "%{{http_code}}" --max-time 15 {url}', check=False)
-    return code.strip() == "200"
-
-def _is_cnblk_rule(r):
-    """判断一条 route.rule 是不是本脚本注入的（引用了 cnblk- 开头的规则集）。"""
-    rs = r.get("rule_set")
-    if isinstance(rs, str):  return rs.startswith("cnblk-")
-    if isinstance(rs, list): return any(str(x).startswith("cnblk-") for x in rs)
-    return False
-
-def _whitelist_tags(cfg):
-    """取白名单 tag 列表：作者名单 / 自定义名单。
-       自定义链接可为纯文本（每行一个 tag，# 注释跳过），
-       也可直接指向 whitelist-inject.sh —— 自动抽取其中 WHITELIST_TAGS=(...) 数组。"""
-    mode = cfg.get("wl_mode", "author")
-    if mode == "none":
-        return []
-    if mode == "custom":
-        url = (cfg.get("wl_url") or "").strip()
-        if not url:
-            print("  未设置自定义放行名单链接，改用作者名单。"); return list(CN_WHITELIST)
-        try:
-            txt = fetch_url(url)
-        except Exception as e:
-            print("  拉取自定义名单失败，改用作者名单:", e); return list(CN_WHITELIST)
-        m = re.search(r"WHITELIST_TAGS=\(([^)]*)\)", txt, re.S)
-        if m:                                            # 直接喂 whitelist-inject.sh：抽数组
-            return re.findall(r'[A-Za-z0-9!_.\-]+', m.group(1))
-        tags = []                                        # 否则按纯文本：每行一个 tag
-        for ln in txt.splitlines():
-            ln = ln.strip()
-            if ln and not ln.startswith("#"):
-                tags.append(ln.split()[0])
-        return tags
-    return list(CN_WHITELIST)
-
-def apply_cn_block(cfg=None):
-    """把 CN 屏蔽 + 白名单放行规则注入 sing-box 服务端配置并重启（失败回滚）。"""
-    sb_cfg = f"{SB_DIR}/config.json"
-    if not os.path.exists(sb_cfg):
-        print("没检测到 sing-box 配置，请先『1.安装』。"); return False
-    cfg = cfg or cnblock_load()
     try:
-        conf = json.load(open(sb_cfg))
-    except Exception as e:
-        print("读取 sing-box 配置失败:", e); return False
-    backup = json.loads(json.dumps(conf))                # 深拷贝，校验失败时回滚
-
-    # 直连出站需有 tag（白名单命中后 detour 到它放行）
-    obs = conf.get("outbounds") or [{"type": "direct"}]
-    direct_tag = ""
-    for o in obs:
-        if o.get("type") == "direct":
-            o.setdefault("tag", "direct"); direct_tag = o["tag"]; break
-    if not direct_tag:
-        obs.append({"type": "direct", "tag": "direct"}); direct_tag = "direct"
-    conf["outbounds"] = obs
-
-    route = conf.get("route") or {}
-    # 清掉本脚本上次注入的规则集/规则（cnblk- 前缀），保留其它
-    rsets = [r for r in route.get("rule_set", []) if not str(r.get("tag", "")).startswith("cnblk-")]
-    keep_rules = [r for r in route.get("rules", []) if not _is_cnblk_rule(r)]
-
-    wl_refs = []
-    print("  预检白名单规则集…")
-    for t in _whitelist_tags(cfg):
-        url = f"{RULES_RAW}/geosite/{t}.srs"
-        if _srs_ok(url):
-            tag = "cnblk-wl-" + t
-            rsets.append({"type": "remote", "tag": tag, "format": "binary", "url": url,
-                          "download_detour": direct_tag, "update_interval": "24h"})
-            wl_refs.append(tag)
-        else:
-            print(f"    跳过 {t}（拉不到）")
-    rsets.append({"type": "remote", "tag": "cnblk-cn-site", "format": "binary", "url": CN_SITE_URL,
-                  "download_detour": direct_tag, "update_interval": "24h"})
-    rsets.append({"type": "remote", "tag": "cnblk-cn-ip", "format": "binary", "url": CN_IP_URL,
-                  "download_detour": direct_tag, "update_interval": "24h"})
-
-    # 规则顺序：白名单放行（在前，命中即直连不被拦）→ CN 域名拦 → CN IP 拦 → 原有其它规则
-    inj = []
-    if wl_refs:
-        inj.append({"rule_set": wl_refs, "outbound": direct_tag})
-    inj.append({"rule_set": "cnblk-cn-site", "action": "reject"})
-    inj.append({"rule_set": "cnblk-cn-ip", "action": "reject"})
-
-    route["rule_set"] = rsets
-    route["rules"] = inj + keep_rules
-    conf["route"] = route
-    # 远程 rule_set 建议开 cache_file 持久化（否则每次重启都重新拉、且 sing-box 会告警）
-    exp = conf.get("experimental") or {}
-    cf = exp.get("cache_file") or {}
-    cf["enabled"] = True; cf.setdefault("path", f"{SB_DIR}/cache.db")
-    exp["cache_file"] = cf; conf["experimental"] = exp
-    json.dump(conf, open(sb_cfg, "w"), ensure_ascii=False, indent=2)
-
-    r = subprocess.run(f"{SB_BIN} check -c {sb_cfg}", shell=True, text=True, capture_output=True)
-    if r.returncode:
-        json.dump(backup, open(sb_cfg, "w"), ensure_ascii=False, indent=2)   # 回滚
-        print("注入后配置校验失败，已回滚未生效：\n" + (r.stderr or r.stdout).strip()); return False
-    sh("systemctl restart sing-box", check=False)
-    cfg["enabled"] = True; cnblock_save(cfg)
-    print(f"\n✓ 已开启屏蔽中国域名/IP：放行白名单 {len(wl_refs)} 组，其余 CN 域名+IP 一律拦截。")
-    return True
-
-def remove_cn_block():
-    """移除本脚本注入的 CN 屏蔽/白名单规则，恢复不拦截。"""
-    sb_cfg = f"{SB_DIR}/config.json"
-    if not os.path.exists(sb_cfg):
-        print("没检测到 sing-box 配置。"); return
-    try:
-        conf = json.load(open(sb_cfg))
-    except Exception as e:
-        print("读取配置失败:", e); return
-    route = conf.get("route") or {}
-    route["rule_set"] = [r for r in route.get("rule_set", []) if not str(r.get("tag", "")).startswith("cnblk-")]
-    route["rules"] = [r for r in route.get("rules", []) if not _is_cnblk_rule(r)]
-    if not route.get("rule_set") and not route.get("rules"):
-        conf.pop("route", None)
-    else:
-        conf["route"] = route
-    json.dump(conf, open(sb_cfg, "w"), ensure_ascii=False, indent=2)
-    sh("systemctl restart sing-box", check=False)
-    cfg = cnblock_load(); cfg["enabled"] = False; cnblock_save(cfg)
-    print("已关闭屏蔽，恢复为不拦截 CN。")
+        open(CN_BLOCK_LOCAL, "w").write(fetch_url(CN_BLOCK_URL))
+    except Exception:
+        pass
+    return os.path.exists(CN_BLOCK_LOCAL)
 
 def cn_block_menu():
-    while True:
-        cfg = cnblock_load()
-        on = cfg.get("enabled")
-        wl = {"author": "作者名单", "custom": "自定义名单", "none": "不放行"}.get(cfg.get("wl_mode", "author"), "作者名单")
-        print("\n" + "=" * 60 + "\n屏蔽中国域名和IP\n" + "=" * 60)
-        print(f"  当前状态: {'已开启 ✓' if on else '未开启'}    放行白名单: {wl}")
-        print(f"  自定义放行名单链接: {cfg.get('wl_url') or '(未设置)'}")
-        print("-" * 60)
-        print("  1 屏蔽中国域名和IP" + ("（已开，再选可关闭）" if on else ""))
-        print("  2 放行白名单（作者名单 / 自定义名单）")
-        print("  3 自定义放行名单脚本链接")
-        print("  4 退出")
-        c = _ask("选择: ").strip()
-        if c == "1":
-            if on:
-                if _ask("  已开启，关闭屏蔽? [y/N]: ").lower() in ("y", "yes"):
-                    remove_cn_block()
-            else:
-                apply_cn_block(cfg)
-        elif c == "2":
-            print("    1 作者名单   2 自定义名单   0 返回")
-            s = _ask("    选择: ").strip()
-            if s == "1":   cfg["wl_mode"] = "author"
-            elif s == "2": cfg["wl_mode"] = "custom"
-            else:          continue
-            cnblock_save(cfg)
-            print("    已设为", "作者名单" if cfg["wl_mode"] == "author" else "自定义名单")
-            if cfg.get("enabled"): apply_cn_block(cfg)    # 已开启则立即用新名单重注入
-        elif c == "3":
-            url = _ask("  自定义放行名单链接(纯文本 tag 列表，或直接指向 whitelist-inject.sh): ").strip()
-            if url:
-                cfg["wl_url"] = url; cfg["wl_mode"] = "custom"; cnblock_save(cfg)
-                print("  已保存，并切到自定义名单。")
-                if cfg.get("enabled"): apply_cn_block(cfg)
-        elif c in ("4", "0", ""):
-            return
+    """打开独立的 cn-block.py 交互菜单（屏蔽 CN 域名/IP + 白名单）。"""
+    if not ensure_cn_block():
+        print("拉取 cn-block.py 失败，且本地无缓存。请检查网络。"); return
+    subprocess.run(f"python3 {CN_BLOCK_LOCAL}", shell=True)
+
+def cn_block_reapply():
+    """重装后调用：若之前开启过屏蔽，用 cn-block.py 重新注入（未开启则内部直接跳过）。"""
+    if not cnblock_load().get("enabled"):
+        return
+    if ensure_cn_block():
+        subprocess.run(f"python3 {CN_BLOCK_LOCAL} apply", shell=True)
+
+def cnblock_load():
+    try: return json.load(open(CNBLOCK_FILE))
+    except Exception: return {}
+
 
 def main_menu():
     while True:


### PR DESCRIPTION
## 改动

### 1. 拆成独立文件 `cn-block.py`
屏蔽中国域名/IP 的全部逻辑移到独立文件，方便单独维护。主脚本只负责拉取最新版并调用：

- 菜单第 9 项 → `python3 /etc/bgpeer/cn-block.py`（交互菜单）
- 重装后自动 → `python3 /etc/bgpeer/cn-block.py apply`（仅在之前开启过时才重注入）
- 每次进入都先从仓库拉最新 `cn-block.py`，拉不到就用本地缓存

`cn-block.py` 也能完全脱离主脚本单跑：`apply` / `remove` 命令行参数，无参数 = 交互菜单。

### 2. 菜单加「卸载」
```
屏蔽中国域名和IP
  1 屏蔽中国域名和IP    （已开则再选可关闭）
  2 放行白名单（作者名单 / 自定义名单）
  3 自定义放行名单脚本链接
  4 卸载（不想屏蔽了，直接清掉规则）
  5 退出
```
「4 卸载」= 移除注入的路由规则 + 删除状态文件 `/etc/bgpeer/cnblock.json`，之后重装也不会再自动注入。

## 测试
- 独立跑通 `cn-block.py`：apply 注入顺序正确（白名单直连 → CN 域名 reject → CN IP reject），卸载后 route 干净移除、状态文件删除。
- 主脚本 `apply` 子命令在未开启时内部直接跳过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYvMbH716hPckedcKHV5Up

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYvMbH716hPckedcKHV5Up)_