### PR TITLE
抗 GitHub 429 限流：拉取加重试 + jsDelivr 镜像兜底

### DIFF
--- a/cn-block.py
+++ b/cn-block.py
@@ -8,7 +8,7 @@
 # 规则集用 sing-box 远程 srs（每 24h 自更新）：
 #   CN 域名 geosite/geolocation-cn.srs、CN IP geoip/cn.srs → reject
 #   白名单（作者名单对齐 vps-net/whitelist-inject.sh 的 WHITELIST_TAGS）→ 命中直连放行
-import os, re, sys, json, subprocess, urllib.request
+import os, re, sys, json, time, subprocess, urllib.request
 
 SB_DIR  = "/etc/sing-box"
 SB_BIN  = "/usr/local/bin/sing-box"
@@ -48,9 +48,28 @@ def _ask(prompt=""):
     except (OSError, EOFError):
         return input(prompt).strip()
 
+def _mirrors(url):
+    """raw.githubusercontent 常被限流(429)，补上 jsDelivr 镜像作兜底。"""
+    urls = [url]
+    m = re.match(r"https://raw\.githubusercontent\.com/([^/]+)/([^/]+)/([^/]+)/(.+)", url)
+    if m:
+        o, repo, br, path = m.groups()
+        urls.append(f"https://cdn.jsdelivr.net/gh/{o}/{repo}@{br}/{path}")
+        urls.append(f"https://fastly.jsdelivr.net/gh/{o}/{repo}@{br}/{path}")
+    return urls
+
 def fetch_url(url):
-    req = urllib.request.Request(url, headers={"User-Agent": "xy-installer"})
-    return urllib.request.urlopen(req, timeout=15).read().decode()
+    """带重试 + 镜像兜底的拉取，缓解 GitHub 429 限流。"""
+    last = None
+    for rd in range(2):
+        for u in _mirrors(url):
+            try:
+                req = urllib.request.Request(u, headers={"User-Agent": "xy-installer"})
+                return urllib.request.urlopen(req, timeout=15).read().decode()
+            except Exception as e:
+                last = e
+        time.sleep(2 * (rd + 1))
+    raise last
 
 def cnblock_load():
     try: return json.load(open(CNBLOCK_FILE))

--- a/xy-installer.py
+++ b/xy-installer.py
@@ -14,7 +14,7 @@
 #    并对照你 VPS 上实际 sing-box/xray 版本确认 schema（版本会漂）。
 # 目标系统：debian / ubuntu（apt）。用法见文件末尾 --help。
 # ============================================================================
-import os, json, base64, secrets, uuid, argparse, subprocess, urllib.request, urllib.parse, shutil, socket, re
+import os, json, base64, secrets, uuid, argparse, subprocess, urllib.request, urllib.parse, shutil, socket, re, time
 
 # 版本：安装时优先取 GitHub 最新正式版；下面是取不到时的兜底。
 # ⚠ sing-box 必须 ≥1.12（anytls inbound 是 1.12 才加的，1.11 会 FATAL: unknown inbound type: anytls）
@@ -774,9 +774,28 @@ def link_to_proxy(u):
         return {"name": nm("ss"), "type": "ss", "server": host, "port": port, "cipher": method, "password": pw, "udp": "true"}
     return None
 
+def _mirrors(url):
+    """raw.githubusercontent 常被限流(429)，补上 jsDelivr 镜像作兜底。"""
+    urls = [url]
+    m = re.match(r"https://raw\.githubusercontent\.com/([^/]+)/([^/]+)/([^/]+)/(.+)", url)
+    if m:
+        o, repo, br, path = m.groups()
+        urls.append(f"https://cdn.jsdelivr.net/gh/{o}/{repo}@{br}/{path}")
+        urls.append(f"https://fastly.jsdelivr.net/gh/{o}/{repo}@{br}/{path}")
+    return urls
+
 def fetch_url(url):
-    req = urllib.request.Request(url, headers={"User-Agent": "xy-installer"})
-    return urllib.request.urlopen(req, timeout=15).read().decode()
+    """带重试 + 镜像兜底的拉取，缓解 GitHub 429 限流。"""
+    last = None
+    for rd in range(2):                                 # 两轮，轮间退避
+        for u in _mirrors(url):
+            try:
+                req = urllib.request.Request(u, headers={"User-Agent": "xy-installer"})
+                return urllib.request.urlopen(req, timeout=15).read().decode()
+            except Exception as e:
+                last = e
+        time.sleep(2 * (rd + 1))
+    raise last
 
 def _host():
     return open(HOST_FILE).read().strip() if os.path.exists(HOST_FILE) else (G.get("host") or public_ip())
@@ -1217,9 +1236,13 @@ def install_shortcut():
     try:
         os.makedirs("/etc/bgpeer", exist_ok=True)
         open("/etc/bgpeer/xy-installer.py", "w").write(open(__file__).read())
+        # raw.githubusercontent 常被 GitHub 限流(429)，加 jsDelivr 镜像兜底；
+        # 只有真的下到非空内容才覆盖本地，拉不到就继续用本地缓存（不会退回旧版失败）。
         wrapper = ("#!/usr/bin/env bash\n"
                    'u="https://raw.githubusercontent.com/bgpeer/nodekit/main/xy-installer.py"\n'
-                   'curl -fsSL "$u" -o /etc/bgpeer/xy-installer.py 2>/dev/null || true\n'
+                   'j="https://cdn.jsdelivr.net/gh/bgpeer/nodekit@main/xy-installer.py"\n'
+                   'curl -fsSL "$u" -o /tmp/xy.new 2>/dev/null || curl -fsSL "$j" -o /tmp/xy.new 2>/dev/null || true\n'
+                   '[ -s /tmp/xy.new ] && mv /tmp/xy.new /etc/bgpeer/xy-installer.py; rm -f /tmp/xy.new\n'
                    'exec python3 /etc/bgpeer/xy-installer.py "$@"\n')
         open("/usr/local/bin/bgpeer", "w").write(wrapper)
         os.chmod("/usr/local/bin/bgpeer", 0o755)


### PR DESCRIPTION
## 现象

`raw.githubusercontent.com` 被 GitHub 限流（HTTP 429 Too Many Requests）时：
- `bgpeer` 拉不到最新脚本，回退到本地旧缓存 → 显示旧菜单
- 点「更新脚本」也直接报 `HTTP Error 429`

不是脚本 bug，是短时间对 raw 请求过多触发限流。

## 修改

- `fetch_url` 改为**带重试 + jsDelivr 镜像兜底**（`cdn.jsdelivr.net` / `fastly.jsdelivr.net`），raw 429 时自动走 CDN，CDN 不受 GitHub 那套限流影响。
- `bgpeer` wrapper 同样加 jsDelivr 兜底，且**只有下到非空内容才覆盖本地缓存**（拉不到就继续用本地，不会因为半个空文件把脚本搞坏）。
- `xy-installer.py` 与 `cn-block.py` 两边同步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYvMbH716hPckedcKHV5Up

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYvMbH716hPckedcKHV5Up)_