### PR TITLE
证书续期后重启 sing-box/xray 使新证书生效

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ sudo python3 /tmp/xy.py
 - root 权限
 - Python 3
 - 有域名走 acme 真证书更稳；无域名则自签证书 + 公网 IP 直连（域名需 A 记录直连指向本机）
+- **证书自动续签**：走域名真证书时用 acme.sh 签发，acme.sh 会装每日 cron 自动续期（约 60 天一次），
+  续期后自动重启 sing-box / xray（有 nginx 顺带 reload）使新证书生效，无需手动干预
 
 ---
 

--- a/xy-installer.py
+++ b/xy-installer.py
@@ -179,8 +179,13 @@ def ensure_acme():
         if r.returncode and not skipped:
             raise RuntimeError("acme 签发失败(检查域名解析是否指向本机、80 端口是否可达):\n" + out)
         os.makedirs(os.path.dirname(ACME_CRT), exist_ok=True)
-        # 装证书后让 acme 自动 reload nginx（续期时也会）
-        reload_hook = f" --reloadcmd 'systemctl reload nginx'" if G.get("nginx") else ""
+        # reloadcmd 会被 acme.sh 记住，续期时自动执行。sing-box/xray 是启动时把证书读进
+        # 内存的、不会自动重载证书文件，所以续期后必须重启它们，否则磁盘证书更新了、进程还用
+        # 旧证书，约 90 天后客户端撞上过期证书。有 nginx 顺带 reload；服务不存在则静默跳过。
+        reload_hook = (" --reloadcmd '"
+                       "systemctl reload nginx 2>/dev/null; "
+                       "systemctl restart sing-box 2>/dev/null; "
+                       "systemctl restart xray 2>/dev/null; true'")
         sh(f"{acme} --install-cert -d {G['domain']} --ecc "
            f"--fullchain-file {ACME_CRT} --key-file {ACME_KEY}{reload_hook}")
     return ACME_CRT, ACME_KEY, False


### PR DESCRIPTION
## 问题

走域名真证书时用 acme.sh 签发，acme.sh 装了每日 cron 会自动续期（约 60 天一次）。但之前 `--install-cert --reloadcmd` **只在 nginx 模式下 reload nginx**：

- 非 nginx 模式（最常见）没有 reloadcmd。sing-box / xray 是启动时把证书读进内存的，不会自动重载证书文件。
- 结果：续期把新证书拷回了磁盘，但运行中的进程仍用旧证书，约 **90 天后客户端撞上过期证书**。

## 修改

- `--reloadcmd` 改为**始终重启 sing-box / xray**（有 nginx 顺带 reload nginx，服务不存在则静默跳过）。acme.sh 会记住这条命令并在每次续期时执行，新证书即时生效。
- README 补充「证书自动续签」说明。

> 注：nginx 模式下 ws 家族藏在 nginx 443 后，但 Vision/trojan/hy2/tuic/anytls 等仍由 sing-box 直接持证书，所以两种模式都需要重启 sing-box。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYvMbH716hPckedcKHV5Up

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYvMbH716hPckedcKHV5Up)_