### PR TITLE
修复脚本 review 发现的 6 个 bug + 若干加固

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ sudo python3 /tmp/xy.py
 - 注入后会确认 sing-box 正常启动，**万一起不来自动回滚**，绝不影响原本能用的节点。
 - 自定义白名单：可填纯文本 tag 列表，也可**直接指向一个 `whitelist-inject.sh` 脚本链接**，
   自动抽取其中的 `WHITELIST_TAGS=(...)` 数组。
+- 白名单按**域名**（geosite）放行：客户端需走远程 DNS 解析（本项目生成的订阅配置默认即是）；
+  若客户端本地解析后以裸 IP 出站，仍会被 CN IP 规则拦截。
 
 规则集来自 [`bgpeer/rules`](https://github.com/bgpeer/rules)，
 配套的 mack-a 白名单注入脚本见 [`bgpeer/vps-net`](https://github.com/bgpeer/vps-net)。

--- a/cn-block.py
+++ b/cn-block.py
@@ -9,7 +9,7 @@
 # 规则集用 sing-box 远程 srs（.srs binary），并挂 cron 每天北京时间 03:00 定点刷新：
 #   CN 域名 geosite/geolocation-cn.srs、CN IP geoip/cn.srs → reject
 #   白名单（作者名单对齐 vps-net/whitelist-inject.sh 的 WHITELIST_TAGS）→ 命中直连放行
-import os, re, sys, json, time, subprocess, urllib.request
+import os, re, sys, json, time, subprocess, urllib.request, urllib.error
 
 SB_DIR  = "/etc/sing-box"
 SB_BIN  = "/usr/local/bin/sing-box"
@@ -78,12 +78,28 @@ def fetch_url(url):
 def cnblock_load():
     try: return json.load(open(CNBLOCK_FILE))
     except Exception: return {}
+
+def _write_json(path, obj):
+    """原子写：先写临时文件再 replace，进程中途被杀也不会留下写了一半的配置。"""
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(obj, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, path)
+
 def cnblock_save(d):
     os.makedirs(BGP_DIR, exist_ok=True)
-    json.dump(d, open(CNBLOCK_FILE, "w"), ensure_ascii=False, indent=2)
+    _write_json(CNBLOCK_FILE, d)
 
 def _http_code(url):
-    return sh(f'curl -s -o /dev/null -w "%{{http_code}}" --max-time 15 {url}', check=False).strip()
+    """HEAD 探测 HTTP 状态码。不走 shell（url 可能含外部内容，避免注入）。"""
+    req = urllib.request.Request(url, method="HEAD", headers={"User-Agent": "xy-installer"})
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return str(r.status)
+    except urllib.error.HTTPError as e:
+        return str(e.code)
+    except Exception:
+        return "000"
 
 def _rule_url(rel):
     """选规则集 URL（rel 形如 'geosite/geolocation-cn.srs'）：
@@ -130,8 +146,14 @@ def _whitelist_tags(cfg):
         tags = []                                        # 否则按纯文本：每行一个 tag
         for ln in txt.splitlines():
             ln = ln.strip()
-            if ln and not ln.startswith("#"):
-                tags.append(ln.split()[0])
+            if not ln or ln.startswith("#"):
+                continue
+            t = ln.split()[0]
+            # 远端内容只当 tag 用，字符集收紧到规则集名允许的范围，防止混入奇怪内容
+            if re.fullmatch(r"[A-Za-z0-9!_.\-]+", t):
+                tags.append(t)
+            else:
+                print(f"  跳过非法 tag: {t!r}")
         return tags
     return list(CN_WHITELIST)
 
@@ -198,11 +220,19 @@ def apply_cn_block(cfg=None):
     cf = exp.get("cache_file") or {}
     cf["enabled"] = True; cf.setdefault("path", f"{SB_DIR}/cache.db")
     exp["cache_file"] = cf; conf["experimental"] = exp
-    json.dump(conf, open(sb_cfg, "w"), ensure_ascii=False, indent=2)
+    _write_json(sb_cfg, conf)
+
+    def _rollback():
+        """回滚到注入前配置，并把 enabled 状态对齐回滚后的实际情况——
+           重装后配置里已无 cnblk 规则时，不再让菜单显示『已开启』误导用户。"""
+        _write_json(sb_cfg, backup)
+        cfg["enabled"] = any(str(r.get("tag", "")).startswith("cnblk-")
+                             for r in (backup.get("route") or {}).get("rule_set", []))
+        cnblock_save(cfg)
 
     r = subprocess.run(f"{SB_BIN} check -c {sb_cfg}", shell=True, text=True, capture_output=True)
     if r.returncode:
-        json.dump(backup, open(sb_cfg, "w"), ensure_ascii=False, indent=2)   # 回滚
+        _rollback()
         print("注入后配置校验失败，已回滚未生效：\n" + (r.stderr or r.stdout).strip()); return False
     sh("systemctl restart sing-box", check=False)
     # 确认真的起来了；万一注入后起不来（比如规则集这会儿全拉不到），回滚到屏蔽前配置，
@@ -213,7 +243,7 @@ def apply_cn_block(cfg=None):
         if sh("systemctl is-active sing-box", check=False) == "active":
             active = True; break
     if not active:
-        json.dump(backup, open(sb_cfg, "w"), ensure_ascii=False, indent=2)
+        _rollback()
         sh("systemctl restart sing-box", check=False)
         print("注入后 sing-box 未能启动，已回滚到屏蔽前配置（节点照常可用）。可能是规则集暂时全拉不到，稍后再试。")
         return False
@@ -232,11 +262,14 @@ def remove_cn_block(silent=False):
             route = conf.get("route") or {}
             route["rule_set"] = [r for r in route.get("rule_set", []) if not str(r.get("tag", "")).startswith("cnblk-")]
             route["rules"] = [r for r in route.get("rules", []) if not _is_cnblk_rule(r)]
-            if not route.get("rule_set") and not route.get("rules"):
-                conf.pop("route", None)
-            else:
+            for k in ("rule_set", "rules"):                 # 清空的键不留着
+                if not route.get(k):
+                    route.pop(k, None)
+            if route:                                       # route 里还有 final 等其它键 → 保留
                 conf["route"] = route
-            json.dump(conf, open(sb_cfg, "w"), ensure_ascii=False, indent=2)
+            else:
+                conf.pop("route", None)
+            _write_json(sb_cfg, conf)
             sh("systemctl restart sing-box", check=False)
         except Exception as e:
             print("处理配置失败:", e)
@@ -254,16 +287,20 @@ def _cache_path():
         return f"{SB_DIR}/cache.db"
 
 def setup_cron():
-    """装每日定点刷新的 cron：北京时间 03:00 = UTC 19:00。"""
+    """装每日定点刷新的 cron：北京时间 03:00 = UTC 19:00。
+       Debian/Ubuntu 默认 cron 不支持 CRON_TZ（那是 cronie 的特性），
+       所以按服务器当前时区把 UTC 19:00 换算成本地时刻写入。"""
     try:
         if os.path.abspath(__file__) != SELF_PATH:      # 确保 cron 调的本地副本存在
             os.makedirs(BGP_DIR, exist_ok=True)
             import shutil; shutil.copy(os.path.abspath(__file__), SELF_PATH)
-        txt = ("# bgpeer 屏蔽规则集每日刷新（北京时间 03:00 = UTC 19:00）\n"
+        import datetime
+        local = (datetime.datetime.now(datetime.timezone.utc)
+                 .replace(hour=19, minute=0, second=0, microsecond=0).astimezone())
+        txt = (f"# bgpeer 屏蔽规则集每日刷新（北京时间 03:00 = UTC 19:00 = 本机 {local:%H:%M}）\n"
                "SHELL=/bin/bash\n"
                "PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin\n"
-               "CRON_TZ=UTC\n"
-               f"0 19 * * * root python3 {SELF_PATH} refresh >> {CRON_LOG} 2>&1\n")
+               f"{local.minute} {local.hour} * * * root python3 {SELF_PATH} refresh >> {CRON_LOG} 2>&1\n")
         open(CRON_FILE, "w").write(txt); os.chmod(CRON_FILE, 0o644)
     except OSError as e:
         print("  安装定时任务失败（不影响屏蔽，仅少了每日刷新）:", e)
@@ -289,10 +326,14 @@ def refresh():
         time.sleep(1)
         if sh("systemctl is-active sing-box", check=False) == "active":
             active = True; break
-    if not active and bak:                              # 起不来 → 回滚旧缓存
-        os.replace(bak, cache)
-        sh("systemctl restart sing-box", check=False)
-        print(time.strftime("%F %T"), "刷新后 sing-box 未启动，已回滚缓存"); return
+    if not active:                                      # 起不来 → 有旧缓存就回滚，无论如何要报出来
+        if bak:
+            os.replace(bak, cache)
+            sh("systemctl restart sing-box", check=False)
+            print(time.strftime("%F %T"), "刷新后 sing-box 未启动，已回滚缓存")
+        else:
+            print(time.strftime("%F %T"), "刷新后 sing-box 未启动（无缓存可回滚），请检查 systemctl status sing-box")
+        return
     if bak and os.path.exists(bak):
         try: os.remove(bak)
         except OSError: pass

--- a/xy-installer.py
+++ b/xy-installer.py
@@ -290,7 +290,11 @@ def check_domain_or_die():
 
 # ---------------------------------------------------------------------------- 核心安装
 def arch_tag():
-    return {"x86_64": "amd64", "aarch64": "arm64"}[os.uname().machine]
+    m = os.uname().machine
+    t = {"x86_64": "amd64", "aarch64": "arm64"}.get(m)
+    if not t:
+        raise SystemExit(f"不支持的 CPU 架构: {m}（sing-box/xray 预编译包仅支持 x86_64 / aarch64）")
+    return t
 
 def latest_gh_release(repo, fallback):
     """取 GitHub 最新正式版 tag（去掉前导 v）。取不到就用 fallback。
@@ -400,13 +404,17 @@ def setup_port_hopping(target_port, rng):
     tagc = "xy_hy2_portHopping"
     # 先清掉这段 UDP 上所有旧 DNAT 规则——不只本脚本的，还包括 mack-a 等残留的
     # “强制固定”规则（它们指向已死的旧端口，且可能排在前面先匹配，导致 hy2 不通）。
-    for line in sh("iptables -t nat -S PREROUTING", check=False).splitlines():
-        if not line.startswith("-A"):
+    # inbound 监听 :: 双栈，跳跃段 v4/v6 都要转发，否则 IPv6 客户端走 mport 全挂。
+    for ipt in ("iptables", "ip6tables"):
+        if not have(ipt):
             continue
-        if "portHopping" in line or f"--dport {lo}:{hi}" in line:
-            sh("iptables -t nat " + line.replace("-A", "-D", 1), check=False)
-    sh(f"iptables -t nat -A PREROUTING -p udp --dport {lo}:{hi} "
-       f"-m comment --comment {tagc} -j DNAT --to-destination :{target_port}", check=False)
+        for line in sh(f"{ipt} -t nat -S PREROUTING", check=False).splitlines():
+            if not line.startswith("-A"):
+                continue
+            if "portHopping" in line or f"--dport {lo}:{hi}" in line:
+                sh(f"{ipt} -t nat " + line.replace("-A", "-D", 1), check=False)
+        sh(f"{ipt} -t nat -A PREROUTING -p udp --dport {lo}:{hi} "
+           f"-m comment --comment {tagc} -j DNAT --to-destination :{target_port}", check=False)
     # 尽量持久化（重启后仍生效）；没有 netfilter-persistent 就装一下
     if not have("netfilter-persistent"):
         sh("DEBIAN_FRONTEND=noninteractive apt-get install -y iptables-persistent", check=False)
@@ -1246,8 +1254,9 @@ def install_shortcut():
         wrapper = ("#!/usr/bin/env bash\n"
                    'u="https://raw.githubusercontent.com/bgpeer/nodekit/main/xy-installer.py"\n'
                    'j="https://cdn.jsdelivr.net/gh/bgpeer/nodekit@main/xy-installer.py"\n'
-                   'curl -fsSL "$u" -o /tmp/xy.new 2>/dev/null || curl -fsSL "$j" -o /tmp/xy.new 2>/dev/null || true\n'
-                   '[ -s /tmp/xy.new ] && mv /tmp/xy.new /etc/bgpeer/xy-installer.py; rm -f /tmp/xy.new\n'
+                   't="$(mktemp)"\n'                     # 随机临时文件，避免固定路径被抢注
+                   'curl -fsSL "$u" -o "$t" 2>/dev/null || curl -fsSL "$j" -o "$t" 2>/dev/null || true\n'
+                   '[ -s "$t" ] && mv "$t" /etc/bgpeer/xy-installer.py; rm -f "$t"\n'
                    'exec python3 /etc/bgpeer/xy-installer.py "$@"\n')
         open("/usr/local/bin/bgpeer", "w").write(wrapper)
         os.chmod("/usr/local/bin/bgpeer", 0o755)
@@ -1363,7 +1372,8 @@ def update_cores():
     ensure_deps()
     if c in ("1", "3") and os.path.exists(SB_BIN):
         install_singbox(); sh("systemctl restart sing-box", check=False)
-        print("sing-box 现版本:", sh(f"{SB_BIN} version", check=False).splitlines()[0] if sh(f"{SB_BIN} version", check=False) else "?")
+        v = sh(f"{SB_BIN} version", check=False)
+        print("sing-box 现版本:", v.splitlines()[0] if v else "?")
     if c in ("2", "3") and os.path.exists(XRAY_BIN):
         install_xray(); sh("systemctl restart xray", check=False)
         print("xray 已更新")
@@ -1377,15 +1387,18 @@ def uninstall_all():
         sh(f"systemctl disable --now {svc}", check=False)
         sh(f"rm -f /etc/systemd/system/{svc}.service", check=False)
     sh("systemctl daemon-reload", check=False)
-    for line in sh("iptables -t nat -S PREROUTING", check=False).splitlines():
-        if line.startswith("-A") and "xy_hy2_portHopping" in line:
-            sh("iptables -t nat " + line.replace("-A", "-D", 1), check=False)
+    for ipt in ("iptables", "ip6tables"):
+        for line in sh(f"{ipt} -t nat -S PREROUTING", check=False).splitlines():
+            if line.startswith("-A") and "xy_hy2_portHopping" in line:
+                sh(f"{ipt} -t nat " + line.replace("-A", "-D", 1), check=False)
     sh("netfilter-persistent save", check=False)
     if os.path.exists(NGINX_CONF):                      # 移除本脚本的 nginx 前置块（不动用户其它站点）
         sh(f"rm -f {NGINX_CONF}", check=False)
         sh("nginx -t && systemctl reload nginx", check=False)
     for p in (SB_BIN, XRAY_BIN, SB_DIR, XRAY_DIR, "/etc/ssl/sb", SUB_DIR,
-              "/root/xy-nodes.txt", "/usr/local/bin/bgpeer", "/etc/bgpeer", WEBROOT):
+              "/root/xy-nodes.txt", "/usr/local/bin/bgpeer", "/etc/bgpeer", WEBROOT,
+              # cn-block 的每日刷新 cron 及日志：不清掉的话 cron 会每天调已删除的脚本报错
+              "/etc/cron.d/bgpeer-cnblock", "/var/log/bgpeer-cnblock.log"):
         sh(f"rm -rf {p}", check=False)
     print("已卸载完毕。")
 
@@ -1510,7 +1523,7 @@ def install_flow():
     sni = _ask("reality 借用目标站 SNI (回车=s0.awsstatic.com): ") or "s0.awsstatic.com"
     prefix = _ask("节点名称前缀(如 🇺🇸/🇯🇵/家宽，回车=无前缀): ")
     hy2p = ""
-    if not sb_names or "hy2" in sb_names:
+    if "hy2" in sb_names:
         hy2p = _ask("hy2 端口跳跃范围 起-止(回车=30000-31000): ")
     G["domain"], G["email"], G["sni"], G["prefix"], G["hy2_ports"], G["nginx"] = \
         domain, email, sni, prefix, hy2p, nginx
@@ -1523,7 +1536,7 @@ def install_flow():
     print("  nginx前置:", "是（443伪装站+webroot，ws类走443）" if nginx else "否")
     print("  名称前缀:", prefix or "(无)")
     print("  SNI:     ", sni)
-    if not sb_names or "hy2" in sb_names:
+    if "hy2" in sb_names:
         print("  hy2跳跃: ", hy2_range())
     print("-" * 60)
     if (_ask("确认开始? [Y/n]: ") or "y").lower() in ("n", "no"):


### PR DESCRIPTION
## cn-block.py

- **cron 时区**：Debian/Ubuntu 的 cron 不支持 `CRON_TZ`（那是 cronie 的特性），原来的 `0 19 * * *` 实际按服务器本地时区触发。改为按服务器当前时区把 UTC 19:00（北京 03:00）换算成本地时刻写入 cron 行，任何时区下都是北京时间 03:00 刷新
- **refresh() 漏报**：sing-box 重启失败且无缓存可回滚时，原来会误报"规则集已刷新"；现在正确记录"未启动，请检查 systemctl status"
- **remove 误删 route**：卸载屏蔽时只清空 `rule_set`/`rules`，不再连带删掉 route 里的 `final` 等其它键
- **命令注入加固**：自定义白名单纯文本模式的 tag 按 `[A-Za-z0-9!_.-]` 过滤；`_http_code` 从 shell 调 curl 改为 urllib HEAD 请求，远端内容不再进 shell
- **状态同步**：注入失败回滚后，`enabled` 按回滚后配置里是否还有 cnblk 规则对齐，菜单不再显示假"已开启"
- **原子写入**：JSON 配置统一"写临时文件 + os.replace"，进程中途被杀不留半截配置

## xy-installer.py

- **卸载残留**：卸载时清理 `/etc/cron.d/bgpeer-cnblock` 与日志，避免 cron 每天调用已删除的脚本报错
- **hy2 双栈**：端口跳跃补上 ip6tables 规则（安装/卸载同步），IPv6 客户端走 mport 不再全挂
- 交互安装仅在选了 hy2 时才询问跳跃范围（原先 xray-only 也会问）
- `arch_tag()` 遇到不支持架构给友好报错而非 KeyError
- bgpeer wrapper 用 `mktemp` 代替固定 `/tmp/xy.new`
- `update_cores()` 去掉重复的 version 调用

## README

- 补充白名单按域名（geosite）放行、客户端本地解析后裸 IP 出站仍会被 CN IP 规则拦截的说明

## 验证

- 两脚本 `py_compile` 通过
- 功能测试：route 键保留/整体移除、Asia/Shanghai 与 UTC 时区下 cron 换算（`0 3` / `0 19`）、恶意白名单内容被过滤且未执行、`_http_code` 对存在/不存在规则集返回 200/404、mock 校验失败后两种回滚状态同步、wrapper `bash -n` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV

---
_Generated by [Claude Code](https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV)_