### PR TITLE
块锚点缩进容错：__XY_NODES__ / __XY_GROUPS__ 顶格或缩进都行

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -1443,9 +1443,10 @@ def build_shadowrocket_sub(nodes, tpl_url):
     if not lines:
         return
     groups_txt, names_frag = _sr_country_groups(names_list)
-    out = (fetch_url(tpl_url).replace("__XY_NODES__", "\n".join(lines))
-                             .replace("__XY_GROUPS__", groups_txt)
-                             .replace("__XY_NAMES__", names_frag))
+    out = fetch_url(tpl_url)
+    out = _fill_block(out, "__XY_NODES__", "\n".join(lines))    # 块锚点整行替换，缩进容错
+    out = _fill_block(out, "__XY_GROUPS__", groups_txt)
+    out = out.replace("__XY_NAMES__", names_frag)               # 行内锚点
     open(SR_FILE, "w").write(out)
 
 # --- 三格式元数据：文件 / 作者模板 / 生成器；自定义模板存 CUSTPL_FILE ---
@@ -1469,13 +1470,19 @@ def _mihomo_country(names):
         gnames.append(OTHER_GROUP)
     return "\n".join(lines), "".join(f', "{g}"' for g in gnames)
 
+def _fill_block(tpl, anchor, block):
+    """按整行替换独占一行的块锚点：连同该行的前导缩进一起换成 block（block 自带缩进）。
+       这样锚点顶格或缩进都行——避免用户给 __XY_NODES__/__XY_GROUPS__ 缩两格导致 YAML 缩进错乱。"""
+    return re.sub(r"(?m)^[ \t]*" + re.escape(anchor) + r"[ \t]*$", lambda m: block, tpl)
+
 def gen_mihomo(ylines, nodes, tpl_url):
     groups_yaml, names_frag = _mihomo_country(_node_names(nodes))
-    # 三锚点各不为对方子串，替换顺序无所谓：__XY_NODES__ 建节点 / __XY_GROUPS__ 建国家组 / __XY_NAMES__ 引用组名
-    out = (fetch_url(tpl_url).replace("__XY_NODES__", "\n".join(ylines))
-                             .replace("__XY_GROUPS__", groups_yaml)
-                             .replace("__XY_NAMES__", names_frag))
-    open(CFG_FILE, "w").write(out)
+    tpl = fetch_url(tpl_url)
+    # 块锚点(独占一行)整行替换，缩进容错：__XY_NODES__ 建节点 / __XY_GROUPS__ 建国家组
+    tpl = _fill_block(tpl, "__XY_NODES__", "\n".join(ylines))
+    tpl = _fill_block(tpl, "__XY_GROUPS__", groups_yaml)
+    tpl = tpl.replace("__XY_NAMES__", names_frag)          # 行内锚点：引用组名，原样替换
+    open(CFG_FILE, "w").write(tpl)
 def gen_singbox(ylines, nodes, tpl_url):
     build_singbox_sub(nodes, tpl_url)
 def gen_shadow(ylines, nodes, tpl_url):


### PR DESCRIPTION
## 背景

mihomo(YAML)模板里,块锚点 `__XY_NODES__` / `__XY_GROUPS__` 若被**缩进**,原来的 `str.replace` 会把模板那几格缩进贴在**第一个节点**前面,导致首节点比其余多几格 → YAML 缩进错乱 → 配置直接崩。(顶格才对,但用户容易手滑缩进。)

## 改动

- 新增 `_fill_block(tpl, anchor, block)`:用 `re.sub` 按**整行**(含前导缩进)替换独占一行的块锚点,替换内容自带缩进 → 锚点顶格、缩 2 格、缩 4 格都能生成合法配置。
- `gen_mihomo` / `build_shadowrocket_sub` 的 `__XY_NODES__`、`__XY_GROUPS__` 改用它。
- `__XY_NAMES__` 是**行内**锚点(写在 `[...]` 列表里),仍用原样 `replace`。
- sing-box 走对象级替换、由 `sb_dumps` 统一缩进,本就不受影响。

## 验证

- mihomo 锚点**顶格 / 缩 2 格 / 缩 4 格** 生成的 YAML 均 `yaml.safe_load` 合法。
- 三格式真实模板回归:mihomo YAML / sing-box JSON 解析合法、国家组正常、无锚点残留。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV

---
_Generated by [Claude Code](https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV)_