### PR TITLE
mihomo 国家随机组加 hidden: true（不占面板卡片位，仍可在🌍全球加速里选）

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -1481,13 +1481,15 @@ def _mihomo_country(names):
     present = detect_countries(names)
     if not present:
         return "", ""
+    # hidden: true 让国家组不占面板卡片位（仍可在🌍全球加速里选到）；显式写在组上，
+    # 覆盖 <<: *COUNTRY_COMMON，自定义模板不改锚点也生效。
     lines, gnames = [], []
     for gname, pat, _ in present:
-        lines.append(f"  - {{name: \"{gname}\", <<: *COUNTRY_COMMON, filter: '{pat}'}}")
+        lines.append(f"  - {{name: \"{gname}\", <<: *COUNTRY_COMMON, filter: '{pat}', hidden: true}}")
         gnames.append(gname)
     if OTHER_GROUP and other_members(names, present):          # 有漏网节点才建"其他随机"
         allpat = "|".join(p for _, p, _ in present)
-        lines.append(f"  - {{name: \"{OTHER_GROUP}\", <<: *COUNTRY_COMMON, exclude-filter: '{allpat}'}}")
+        lines.append(f"  - {{name: \"{OTHER_GROUP}\", <<: *COUNTRY_COMMON, exclude-filter: '{allpat}', hidden: true}}")
         gnames.append(OTHER_GROUP)
     return "\n".join(lines), "".join(f', "{g}"' for g in gnames)
 


### PR DESCRIPTION
面板上自动生成的 `🇯🇵日本随机` / `🇺🇸美国随机` 作为独立卡片占位。给生成的国家随机组（含 `🎲其他随机`）显式加 `hidden: true`——面板不再显示为卡片，但仍能在「🌍全球加速」及服务组里选到（和已隐藏的 `♻️全部随机` 一致）。

## 改动

- `_mihomo_country`：每个国家组行加 `, hidden: true`。**显式写在组上，覆盖 `<<: *COUNTRY_COMMON`** → 自定义模板（如用户的 gist）不改锚点也立即生效。
- `hidden` 是 **mihomo(Clash)专属**；sing-box / 小火箭无此概念，不受影响、保持原样。

## 验证

- 日本/美国/其他随机三组均带 `hidden: true`、仍是 `url-test`+`include-all`、YAML 解析合法；
- 隐藏后仍被「🌍全球加速」引用、可在其中选择；
- sing-box JSON 不受影响、仍合法。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV

---
_Generated by [Claude Code](https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV)_