### PR TITLE
fix: 按本机核心版本决定是否下发 X25519MLKEM768（旧核心兜底）

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,9 +209,11 @@ sudo python3 xy-installer.py --sb all --domain a.example.com --nginx
 
 订阅里还默认开了两项客户端增强（服务端已同步支持，均自动生成、无需手动配置）：
 
-- **X25519MLKEM768 后量子密钥交换**：所有 `reality-*` 节点在 mihomo 订阅里带
+- **X25519MLKEM768 后量子密钥交换**：`reality-*` 节点在 mihomo 订阅里带
   `reality-opts.support-x25519mlkem768: true`，握手改用抗量子的混合 KEX，也能进一步
-  打散 reality 的 ClientHello 指纹。服务端 xray/sing-box 新核心默认支持（本脚本每月自动更新核心）。
+  打散 reality 的 ClientHello 指纹。此字段由客户端主动发起，**旧核心会握手失败**，
+  故脚本会**先检测本机核心版本**（sing-box ≥ 1.12.0、xray ≥ 25.5.16 才下发；
+  版本读不出或过旧则自动省略，保连通性优先）。本脚本每月自动更新核心，正常无需担心。
 - **smux 多路复用**：仅 **ws / httpupgrade** 家族两头开 `h2mux`（mihomo `smux`、
   sing-box `multiplex`），多条请求复用一条底层连接、少握手更省延迟。
   vision / reality / grpc / QUIC(hy2、tuic) / anytls **一律不开**（它们要么自带更优复用、

--- a/xy-installer.py
+++ b/xy-installer.py
@@ -1015,6 +1015,31 @@ def _yfmt(v):
     if isinstance(v, list): return "[" + ", ".join(_yfmt(x) for x in v) + "]"
     return str(v)
 
+# X25519MLKEM768 后量子 KEX 需要新核心：sing-box>=1.12.0、xray>=25.5.16。
+# 客户端主动发起该握手，若服务端核心太旧会直接握手失败，故装机核心太旧时不下发此字段。
+_MLKEM_MIN = {SB_BIN: (1, 12, 0), XRAY_BIN: (25, 5, 16)}
+_MLKEM_CACHE = None
+
+def _core_ver(binpath):
+    """读核心版本号 → (a,b,c) 元组；读不到返回 None。"""
+    out = sh(f"{binpath} version", check=False)
+    m = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", out)
+    return tuple(int(x or 0) for x in m.groups()) if m else None
+
+def mlkem_ok():
+    """已装核心是否都够新以支持 X25519MLKEM768（保守：装了但版本读不出/太旧 → False）。"""
+    global _MLKEM_CACHE
+    if _MLKEM_CACHE is not None:
+        return _MLKEM_CACHE
+    ok = True
+    for binpath, floor in _MLKEM_MIN.items():
+        if os.path.exists(binpath):
+            v = _core_ver(binpath)
+            if v is None or v < floor:
+                ok = False
+    _MLKEM_CACHE = ok
+    return ok
+
 # ws 家族 smux 多路复用（mihomo 客户端；服务端 sing-box 同步开 multiplex）
 _SMUX = {"enabled": "true", "protocol": "h2mux",
          "max-connections": 4, "min-streams": 4, "padding": "true"}
@@ -1038,9 +1063,10 @@ def link_to_proxy(u):
         d["tls"] = "true"; d["client-fingerprint"] = qs.get("fp", "chrome")
         if qs.get("sni"): d["servername"] = qs["sni"]
         if sec == "reality":
-            # X25519MLKEM768 后量子密钥交换：mihomo 客户端字段，服务端 reality 默认已支持
-            d["reality-opts"] = {"public-key": qs.get("pbk", ""), "short-id": qs.get("sid", ""),
-                                 "support-x25519mlkem768": "true"}
+            d["reality-opts"] = {"public-key": qs.get("pbk", ""), "short-id": qs.get("sid", "")}
+            # X25519MLKEM768 后量子 KEX：仅当本机核心够新才下发，避免旧核心握手失败
+            if mlkem_ok():
+                d["reality-opts"]["support-x25519mlkem768"] = "true"
             if net == "grpc": d["network"] = "grpc"; d["grpc-opts"] = {"grpc-service-name": qs.get("serviceName") or qs.get("path", "")}
             elif net == "xhttp": d["network"] = "xhttp"; d["xhttp-opts"] = {"path": qs.get("path", "/")}  # xray 专属
             else: d["network"] = "tcp"


### PR DESCRIPTION
## 背景

上个 PR 给所有 `reality-*` 节点无条件加了 `support-x25519mlkem768: true`。这个字段是 **mihomo 客户端主动发起**的后量子握手——如果服务端核心太旧不认它，reality 握手会**直接失败、节点连不上**。虽然本脚本每月自动更新核心，但别人拿脚本部署、又没触发过更新的老机器有翻车风险。

## 改动

新增核心版本检测，只在本机核心够新时才下发该字段：

- `mlkem_ok()`：读本机已装核心版本，全部达标才返回 True
  - sing-box ≥ **1.12.0**
  - xray ≥ **25.5.16**（[官方 discussion #4787](https://github.com/XTLS/Xray-core/discussions/4787) 确认的最低客户端支持版本）
- **保守策略**：某个核心装了但版本读不出/低于门槛 → 不下发（连通性优先，宁可不开后量子也不让节点连不上）；核心没装则不构成约束
- 版本读一次缓存，避免每个节点都 `xxx version` 一遍
- README 对应说明改为「按核心版本自动判断下发」

## 测试

8 种组合全部符合预期：

| 场景 | 结果 |
|------|------|
| 两核心都够新 | 下发 ✅ |
| 更高版本 | 下发 ✅ |
| sing-box 过旧 | 省略 |
| xray 过旧 | 省略 |
| 仅装 sing-box（新） | 下发 ✅ |
| 仅装 xray（旧） | 省略 |
| 版本号读不出 | 省略（保守） |
| xray 25.5.15（差一版） | 省略 |

smux 多路复用不受影响，仍正常生成。

> 注：本分支上一个 PR(#52) 已 squash 合并，按流程从最新 main 重启分支提交本次改动；同时保留了你在 main 上手动改过的模板文件，未覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV

---
_Generated by [Claude Code](https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV)_