### PR TITLE
feat: xray 移除 ss2022；两核心同名节点自动去重

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ sudo python3 /tmp/xy.py
 | 核心 | 协议 |
 |------|------|
 | **sing-box** | vless-vision、vless-ws、vmess-ws、trojan、hy2(端口跳跃+salamander混淆)、reality-vision、reality-grpc、tuic、vmess-httpupgrade、anytls |
-| **xray** | vless-reality-xhttp（sing-box 不支持 xhttp，由 xray 承载） |
+| **xray** | vless-reality-xhttp（sing-box 不支持 xhttp，由 xray 承载）、vless-reality-vision、vless-reality-grpc、vless-ws、vmess-ws、trojan |
 
-可以只装 sing-box、只装 xray，或两个一起装（端口/服务互不冲突）。
+可以只装 sing-box、只装 xray，或两个一起装。**端口/服务/配置都互不冲突**（两核心是独立进程、各绑各的随机端口、各写各的 config）。
+
+> 两核心有几个同名协议（`vless-ws`/`vmess-ws`/`trojan`）。两个一起装时，为避免客户端订阅里节点**重名报错**，xray 那份会自动加 `-xray` 后缀区分（如 `trojan-xray`）。不过这几个 sing-box 已能做且做得一样，xray 独有价值的只有 `vless-reality-xhttp`——想精简可只在 xray 勾它。
 
 ---
 

--- a/xy-installer.py
+++ b/xy-installer.py
@@ -973,18 +973,12 @@ def xr_trojan(port, tag):
           f"&type=tcp&allowInsecure={1 if insec else 0}#{tag}")
     return ib, lk
 
-def xr_ss2022(port, tag):
-    method = "2022-blake3-aes-128-gcm"; key = ss2022_key(method)
-    ib = {"listen": "0.0.0.0", "port": port, "protocol": "shadowsocks", "tag": tag,
-          "settings": {"method": method, "password": key, "network": "tcp,udp"}}
-    lk = f"ss://{ss_userinfo(method, key)}@{G['host']}:{port}#{tag}"
-    return ib, lk
-
 XRAY = {"vless-reality-vision": xr_reality_vision,
         "vless-reality-grpc": xr_reality_grpc,
         "vless-reality-xhttp": xr_reality_xhttp,
         "vless-ws": xr_vless_ws, "vmess-ws": xr_vmess_ws,
-        "trojan": xr_trojan, "ss2022": xr_ss2022}
+        "trojan": xr_trojan}
+# 已移除 ss2022：纯全加密无伪装，易被 GFW 全加密流量探测识别；有 reality 完全无需它。
 
 # ============================================================================ 组装
 # reality 绑 443 的优先级：优先 sing-box reality-vision（Vision flow 最稳），依次往下。
@@ -1000,14 +994,21 @@ def pick_reality_443(sb_names, xr_names):
             return n
     return ""
 
-def build(table, names, pinned=None):
-    """pinned: {协议名: 固定端口}，用于把某个 reality 协议钉在 443；其余走随机端口。"""
+_USED_TAGS = set()   # 跨核心节点名去重：sb 先建、xray 后建，两核心同名协议(vless-ws/vmess-ws/trojan)给 xray 加后缀
+
+def build(table, names, pinned=None, core=""):
+    """pinned: {协议名: 固定端口}，用于把某个 reality 协议钉在 443；其余走随机端口。
+       core: 核心标识('sb'/'xray')，仅用于同名协议撞名时给节点名加后缀区分。"""
     pinned = pinned or {}
     inbounds, links = [], []
     for n in names:
         # 名称 = 用户前缀 + 协议名（默认无前缀，别人部署 US/SG 时自己填 🇺🇸/🇸🇬 等）
         port = pinned.get(n) or next_port()
-        ib, lk = table[n](port, G.get("prefix", "") + n)
+        tag = G.get("prefix", "") + n
+        if tag in _USED_TAGS:                    # sb 与 xray 都有该协议 → 客户端订阅会重名报错，加核心后缀区分
+            tag = f"{tag}-{core}" if core else tag + "-2"
+        _USED_TAGS.add(tag)
+        ib, lk = table[n](port, tag)
         inbounds.append(ib); links.append(lk)
     return inbounds, links
 
@@ -1681,6 +1682,7 @@ def run(sb_names, xr_names):
     NGINX_WS.clear()
     NGINX_STREAM.clear()
     _USED_PORTS.clear()                  # 本次安装重新随机分配端口
+    _USED_TAGS.clear()                   # 本次安装重新去重节点名
 
     # --- SNI 分流（--sni-split）：nginx stream+ssl_preread 让 reality 真正上 443，
     #     网站/ws 同在 443（按 SNI 不解密分流）。改 nginx 前先 preflight，
@@ -1717,7 +1719,7 @@ def run(sb_names, xr_names):
 
     if sb_names:
         install_singbox()
-        ins, lks = build(SB, sb_names, pin); all_links += lks
+        ins, lks = build(SB, sb_names, pin, core="sb"); all_links += lks
         if G.get("sni_split"):
             ensure_acme()                               # 确保证书就绪（本地 https server 要用）
             if not write_nginx_sni_split():             # 写 http(本地https)+stream(443分流)，失败已回滚
@@ -1734,7 +1736,7 @@ def run(sb_names, xr_names):
 
     if xr_names:
         install_xray()
-        ins, lks = build(XRAY, xr_names, pin); all_links += lks
+        ins, lks = build(XRAY, xr_names, pin, core="xray"); all_links += lks
         cfg = f"{XRAY_DIR}/config.json"
         json.dump({"log": {"loglevel": "warning"}, "inbounds": ins,
                    "outbounds": [{"protocol": "freedom", "tag": "direct"},


### PR DESCRIPTION
## 改动

### 1. 移除 ss2022（xray）
按需求把 ss2022 踢出 xray 菜单。理由:它是**裸的全加密协议、无伪装**,会被 GFW 的"全加密流量探测"识别,是整个阵容里抗封最弱的一环;而你已经有 reality(伪装严格更强),ss2022 属于纯冗余短板。`ss2022_key` 保留(shadow-tls 备用仍要用),只删了 xray 的入口和 `xr_ss2022`。

### 2. 两核心同名节点去重(修一个真 bug)
sing-box 和 xray 有 3 个**同名协议**:`vless-ws` / `vmess-ws` / `trojan`。

- **服务器层面本来就不冲突**:两核心是独立进程、各绑各的随机端口、各写各的 config,同时装没问题。
- **但客户端订阅会撞名**:两个一起装时,订阅里会出现两个都叫 `trojan` 的节点,mihomo/sing-box **拒绝重名节点、配置报错**。

`build()` 现在跨 sb+xray 两轮**记录已用节点名**,xray 侧撞名的自动加 `-xray` 后缀(如 `trojan-xray`),订阅不再重名。因 `proto_key()` 按协议参数判类型、与节点名无关,加后缀对协议识别/国家分组**零影响**。

### 3. README
- xray 行补全实际支持的 6 个协议(之前只写了 xhttp)
- 写清"两个一起装端口/服务/配置互不冲突",以及同名协议的 `-xray` 去重规则

## 测试

- ss2022 已从 XRAY 移除,`XRAY` 仅剩 6 个协议 ✅
- 模拟 `--sb all --xray all` 建名:`vless-ws`/`vmess-ws`/`trojan` 的 xray 版正确变成 `vless-ws-xray` 等,**全表无重名** ✅
- 语法检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV

---
_Generated by [Claude Code](https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV)_