### PR TITLE
feat: 两个都装时 xray 回车默认只装 vless-reality-xhttp

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ sudo python3 /tmp/xy.py
 
 可以只装 sing-box、只装 xray，或两个一起装。**端口/服务/配置都互不冲突**（两核心是独立进程、各绑各的随机端口、各写各的 config）。
 
-> 两核心有几个同名协议（`vless-ws`/`vmess-ws`/`trojan`）。两个一起装时，为避免客户端订阅里节点**重名报错**，xray 那份会自动加 `-xray` 后缀区分（如 `trojan-xray`）。不过这几个 sing-box 已能做且做得一样，xray 独有价值的只有 `vless-reality-xhttp`——想精简可只在 xray 勾它。
+> 两核心有几个同名协议（`vless-ws`/`vmess-ws`/`trojan`），sing-box 已能做且做得一样，xray 独有价值的只有 `vless-reality-xhttp`。所以**交互安装选「两个都装」时，xray 回车默认只装 `vless-reality-xhttp`**（sing-box 回车仍全装）；想让 xray 也全装,输 `0`/`all` 或点编号即可。只装 xray（选 2）时回车照常全装。
+>
+> 万一你让两核心装了同名协议，为避免客户端订阅**重名报错**，xray 那份会自动加 `-xray` 后缀区分（如 `trojan-xray`）。端口/服务/配置本来就互不冲突。
 
 ---
 

--- a/xy-installer.py
+++ b/xy-installer.py
@@ -2088,14 +2088,21 @@ def _ask(prompt=""):
     except (OSError, EOFError):
         return input(prompt).strip()
 
-def _pick(title, options):
-    """列出带编号的协议，返回选中的 key 列表；回车/0/all = 全选。"""
+def _pick(title, options, default=None):
+    """列出带编号的协议，返回选中的 key 列表。
+       回车 = default（缺省=全选）；0/all 永远=全选；也可逗号分隔编号自选。"""
     print("\n" + title)
     for i, name in enumerate(options, 1):
         print(f"  {i:>2}. {name}")
     print("   0. 全部")
-    raw = _ask("选择(逗号分隔编号, 回车=全部): ")
-    if raw == "" or raw == "0" or raw.lower() == "all":
+    if default is None:
+        hint = "回车=全部"
+    else:
+        hint = "回车=" + "、".join(default) + "，0/all=全部"
+    raw = _ask(f"选择(逗号分隔编号, {hint}): ")
+    if raw == "":
+        return list(default) if default is not None else list(options)
+    if raw == "0" or raw.lower() == "all":
         return list(options)
     picked = []
     for tok in raw.replace("，", ",").split(","):
@@ -2123,7 +2130,10 @@ def install_flow():
     if core in ("1", "3"):
         sb_names = _pick("【sing-box 协议】", list(SB))
     if core in ("2", "3"):
-        xr_names = _pick("【xray 协议】", list(XRAY))
+        # 两个都装时，xray 默认只装它独有的 vless-reality-xhttp（其余协议 sing-box 已有，避免重复）；
+        # 只装 xray(core=2) 时回车仍全装。想全装 xray 就输 0/all 或点编号。
+        xr_default = ["vless-reality-xhttp"] if core == "3" else None
+        xr_names = _pick("【xray 协议】", list(XRAY), default=xr_default)
     if not sb_names and not xr_names:
         print("没选任何协议，退出。"); return
 


### PR DESCRIPTION
## 需求

安装时:
- 选 **3（两个都装）**:sing-box 回车全装;xray 回车**只装 `vless-reality-xhttp`**(它独有的),想全装就输 `0`/`all` 或点编号
- 选 **1（只 sing-box）**:回车全装
- 选 **2（只 xray）**:回车全装

## 改动

`_pick()` 加了个 `default` 参数:

- `default=None`(缺省)→ 回车 = 全选(sing-box、以及只装 xray 的情况都走这个,行为不变)
- `default=[...]` → 回车 = 返回这个子集
- `0`/`all` 永远 = 全选;逗号编号自选,均不变

安装流程里,只有 **core=3(两个都装)** 时给 xray 传 `default=["vless-reality-xhttp"]`,其余情况 `default=None`。提示语会显示 `回车=vless-reality-xhttp，0/all=全部`,一眼就懂。

## 测试

| 场景 | 输入 | 结果 |
|------|------|------|
| 两个都装 · xray | 回车 | `[vless-reality-xhttp]` ✅ |
| 两个都装 · xray | `0` / `all` | 全部 6 个 ✅ |
| 两个都装 · xray | `1,4` | `[vless-reality-vision, vless-ws]` ✅ |
| 只装 xray | 回车 | 全部 6 个 ✅ |
| sing-box(任意) | 回车 | 全装(不变) ✅ |

语法检查通过。README 同步说明。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV

---
_Generated by [Claude Code](https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV)_