### PR TITLE
fix: 订阅托管服务 HTTP/HTTPS 漂移自愈（修 WRONG_VERSION_NUMBER）

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -1937,10 +1937,25 @@ def read_saved_links():
         pass
     return out
 
+def _sub_service_synced():
+    """正在跑的 xy-sub.service 的 HTTP/HTTPS 状态是否与应有的一致。
+       不一致多见于：升级脚本后订阅 URL 变成 https，但托管服务还是旧的明文 HTTP。"""
+    try:
+        svc = open("/etc/systemd/system/xy-sub.service").read()
+    except OSError:
+        return True                       # 还没有该服务（没装），不强制
+    return (ACME_CRT in svc) == _sub_https()
+
 def show_links():
     links = read_saved_links()
     if not links:
         print("\n还没有节点，请先『1.安装』。"); return
+    if not _sub_service_synced():         # HTTP/HTTPS 漂移 → 自动把托管服务同步到当前应有状态
+        try:
+            serve_sub()                   # 不换 token，仅切换 HTTP/HTTPS 并重启 xy-sub
+            print("（已把订阅托管服务同步到 " + ("HTTPS" if _sub_https() else "HTTP") + "，URL 不变）")
+        except Exception as e:
+            print("（订阅服务同步失败，可稍后『更新配置』重试）:", e)
     print("\n" + "=" * 60 + "\n分享链接:\n" + "=" * 60)
     print("\n".join(links))
     urls = sub_urls_text()


### PR DESCRIPTION
## 问题（用户实测）

客户端拉订阅报 `HandshakeException: WRONG_VERSION_NUMBER` —— 即客户端用 HTTPS 去连,服务器却回明文 HTTP。

## 根因

HTTPS 订阅那个改动:只要有域名+证书,`sub_url()` 就返回 `https://`。但正在跑的 `xy-sub` 托管服务用的是**上次启动时**的协议。升级脚本后:

- 显示的订阅 URL 变成了 `https://`(新代码算的)
- 但 `xy-sub.service` 还是旧的明文 `http.server`(没重跑过 `serve_sub`)

链接 https、服务 http → 客户端 TLS 握手撞上明文响应 → `WRONG_VERSION_NUMBER`。

## 修复

`show_links()`(菜单 2 节点/订阅）现在会**检测漂移并自愈**:比对 `xy-sub.service` 里有没有证书路径 vs `_sub_https()` 应有状态,不一致就重跑 `serve_sub()` 把托管服务切到正确协议(不换 token、URL 不变),并提示"已同步到 HTTPS/HTTP"。已一致时不做任何操作,无多余重启。

## 测试

| 服务现状 | 应为 | 结果 |
|---------|------|------|
| 旧 http.server | HTTPS | 不一致 → 自动重同步 ✅ |
| https 服务 | HTTPS | 一致，不动 ✅ |
| http 服务 | HTTP | 一致，不动 ✅ |
| 旧 http.server | HTTP | 一致，不churn ✅ |

语法检查通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV

---
_Generated by [Claude Code](https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV)_