### PR TITLE
fix: 进「节点/订阅」自动补生成 .links 地址（老安装找不到地址）

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -2066,10 +2066,12 @@ def show_links():
     links = read_saved_links()
     if not links:
         print("\n还没有节点，请先『1.安装』。"); return
-    if not _sub_service_synced():         # HTTP/HTTPS 漂移 → 自动把托管服务同步到当前应有状态
+    # HTTP/HTTPS 漂移，或老安装升级上来还没 .links 端点 → 自动补一次 serve_sub
+    if not _sub_service_synced() or not links_url():
         try:
-            serve_sub()                   # 不换 token，仅切换 HTTP/HTTPS 并重启 xy-sub
-            print("（已把订阅托管服务同步到 " + ("HTTPS" if _sub_https() else "HTTP") + "，URL 不变）")
+            serve_sub()                   # 不换 token，仅补 .links / 切换 HTTP-HTTPS 并重启 xy-sub
+            print("（订阅托管服务已同步：" + ("HTTPS" if _sub_https() else "HTTP") +
+                  "，并已生成本机 .links 地址，URL 不变）")
         except Exception as e:
             print("（订阅服务同步失败，可稍后『更新配置』重试）:", e)
     print("\n" + "=" * 60 + "\n分享链接:\n" + "=" * 60)


### PR DESCRIPTION
## 问题（用户实测）

进「3 聚合节点链接」提示去「2 节点/订阅」复制 `.links` 地址,但**菜单 2 底部没显示地址**——因为 `.links` 端点是 PR #67 才加的,老安装升级上来后托管服务没重生成过 token,地址就没冒出来（跟之前 HTTPS 漂移同类问题）。

## 修复

`show_links()` 现在在「没有 `.links` 地址（token 缺失）」时也自动跑一次 `serve_sub()`（原本只在 HTTP/HTTPS 漂移时跑）。这样打开「2 节点/订阅」就一定会生成并在底部打印本机的 `.links` 地址,复制它粘到主机聚合菜单即可。

## 测试

- 无 links token → `links_url()` 返回空 → 触发 serve_sub 补生成 ✅
- 有 token → 正常返回地址 ✅
- 语法检查通过 ✅

> 提醒用户:`.links` 地址在**每台机器各自的「2 节点/订阅」底部**,是那台机器自己的地址；到成员机复制、回主机粘贴。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV

---
_Generated by [Claude Code](https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV)_