### PR TITLE
refactor: 两核心同名协议改用尾部 ¹/² 上标区分（替代 -xray 长后缀）

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ sudo python3 /tmp/xy.py
 
 > 两核心有几个同名协议（`vless-ws`/`vmess-ws`/`trojan`），sing-box 已能做且做得一样，xray 独有价值的只有 `vless-reality-xhttp`。所以**交互安装选「两个都装」时，xray 回车默认只装 `vless-reality-xhttp`**（sing-box 回车仍全装）；想让 xray 也全装,输 `0`/`all` 或点编号即可。只装 xray（选 2）时回车照常全装。
 >
-> 万一你让两核心装了同名协议，为避免客户端订阅**重名报错**，xray 那份会自动加 `-xray` 后缀区分（如 `trojan-xray`）。端口/服务/配置本来就互不冲突。
+> 万一你让两核心装了同名协议（`vless-ws`/`vmess-ws`/`trojan`），为避免客户端订阅**重名报错**，会给它们**尾部各加一个小上标区分**：sing-box 那份加 `¹`、xray 那份加 `²`（如 `trojan¹` / `trojan²`）。只标撞名的这几个，其余不动；上标短，手机上也显示得下。端口/服务/配置本来就互不冲突。
 
 ---
 

--- a/xy-installer.py
+++ b/xy-installer.py
@@ -1014,20 +1014,20 @@ def pick_reality_443(sb_names, xr_names):
             return n
     return ""
 
-_USED_TAGS = set()   # 跨核心节点名去重：sb 先建、xray 后建，两核心同名协议(vless-ws/vmess-ws/trojan)给 xray 加后缀
-
-def build(table, names, pinned=None, core=""):
+def build(table, names, pinned=None, dup=None, mark=""):
     """pinned: {协议名: 固定端口}，用于把某个 reality 协议钉在 443；其余走随机端口。
-       core: 核心标识('sb'/'xray')，仅用于同名协议撞名时给节点名加后缀区分。"""
+       dup/mark: 两核心同名协议(vless-ws/vmess-ws/trojan)集合 dup 里的，名字尾部加个小上标
+                 mark 区分（sing-box=¹ / xray=²），避免客户端订阅重名报错；比 -xray 后缀短，
+                 手机上也显示得下。"""
     pinned = pinned or {}
+    dup = dup or set()
     inbounds, links = [], []
     for n in names:
         # 名称 = 用户前缀 + 协议名（默认无前缀，别人部署 US/SG 时自己填 🇺🇸/🇸🇬 等）
         port = pinned.get(n) or next_port()
         tag = G.get("prefix", "") + n
-        if tag in _USED_TAGS:                    # sb 与 xray 都有该协议 → 客户端订阅会重名报错，加核心后缀区分
-            tag = f"{tag}-{core}" if core else tag + "-2"
-        _USED_TAGS.add(tag)
+        if n in dup:                             # 两核心都有该协议 → 尾部小上标区分（sb ¹ / xray ²）
+            tag += mark
         ib, lk = table[n](port, tag)
         inbounds.append(ib); links.append(lk)
     return inbounds, links
@@ -1913,7 +1913,7 @@ def run(sb_names, xr_names):
     NGINX_WS.clear()
     NGINX_STREAM.clear()
     _USED_PORTS.clear()                  # 本次安装重新随机分配端口
-    _USED_TAGS.clear()                   # 本次安装重新去重节点名
+    dup_protos = set(sb_names) & set(xr_names)   # 两核心同名协议 → 各自尾部加 ¹/² 区分
 
     # --- SNI 分流（--sni-split）：nginx stream+ssl_preread 让 reality 真正上 443，
     #     网站/ws 同在 443（按 SNI 不解密分流）。改 nginx 前先 preflight，
@@ -1950,7 +1950,7 @@ def run(sb_names, xr_names):
 
     if sb_names:
         install_singbox()
-        ins, lks = build(SB, sb_names, pin, core="sb"); all_links += lks
+        ins, lks = build(SB, sb_names, pin, dup=dup_protos, mark="¹"); all_links += lks
         if G.get("sni_split"):
             ensure_acme()                               # 确保证书就绪（本地 https server 要用）
             if not write_nginx_sni_split():             # 写 http(本地https)+stream(443分流)，失败已回滚
@@ -1967,7 +1967,7 @@ def run(sb_names, xr_names):
 
     if xr_names:
         install_xray()
-        ins, lks = build(XRAY, xr_names, pin, core="xray"); all_links += lks
+        ins, lks = build(XRAY, xr_names, pin, dup=dup_protos, mark="²"); all_links += lks
         cfg = f"{XRAY_DIR}/config.json"
         json.dump({"log": {"loglevel": "warning"}, "inbounds": ins,
                    "outbounds": [{"protocol": "freedom", "tag": "direct"},


### PR DESCRIPTION
## 需求（用户）

之前两核心同名协议撞名是给 xray 加 `-xray` 后缀（`trojan-xray`），**名字太长，手机里一截断就看不到区分**。改成尾部各加一个小上标，且两边都标才清楚：

```
sing-box:  vless-ws¹   vmess-ws¹   trojan¹
xray:      vless-ws²   vmess-ws²   trojan²
```

## 改动

- `build()` 改成按 `dup`(两核心同名协议集合) + `mark`(上标) 命名：`dup` 里的协议尾部加上标，其余不动
- `run()` 一次算出 `dup_protos = set(sb_names) & set(xr_names)`，`build(SB,…,mark="¹")` / `build(XRAY,…,mark="²")`
- 去掉运行期 `_USED_TAGS` 集合，改用确定性的 overlap 集合（更简单）
- README 同步

## 测试（模拟两核心全装）

- sing-box：只有 `vless-ws¹`/`vmess-ws¹`/`trojan¹` 带标，其余（vision/hy2/reality-*/tuic/anytls）不动 ✅
- xray：`vless-ws²`/`vmess-ws²`/`trojan²`，其余（reality-*/xhttp）不动 ✅
- 全 16 个节点**无重名** ✅
- 语法检查通过 ✅

> 旗子/名称主体都在，国家分组照常；只多一个尾部上标，短、手机显示得下。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV

---
_Generated by [Claude Code](https://claude.ai/code/session_011jormR2ZjCCtjyft42CreV)_