### PR TITLE
ci: net-optimize.py 推送后自动更新 SHA256SUMS

### DIFF
--- a/.github/workflows/sha256sums.yml
+++ b/.github/workflows/sha256sums.yml
@@ -1,0 +1,46 @@
+name: Auto-update SHA256SUMS
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'net-optimize.py'
+  workflow_dispatch: {}
+
+concurrency:
+  group: sha256sums-update
+  cancel-in-progress: true
+
+jobs:
+  update-sha256sums:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate SHA256SUMS
+        run: sha256sum net-optimize.py > SHA256SUMS
+
+      - name: Commit & Push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add SHA256SUMS
+          git diff --cached --quiet && echo "SHA256SUMS unchanged" && exit 0
+          git commit -m "chore: auto-update SHA256SUMS"
+          # SHA256SUMS 过期会导致所有 VPS 的自动更新校验失败，push 必须带重试
+          for i in 1 2 3 4 5; do
+            git fetch origin main
+            git rebase origin/main || { git rebase --abort || true; echo "Rebase failed."; exit 1; }
+            if git push origin HEAD:main; then
+              echo "Push success."; exit 0
+            fi
+            echo "Push rejected (race). retry=${i}"
+            sleep $((i*2))
+          done
+          echo "Failed to push after retries."
+          exit 1


### PR DESCRIPTION
## 需求（用户）

参考 vps-net 老仓库的 Auto-update SHA256SUMS 工作流，给本仓库也建一个，免得改完 `net-optimize.py` 忘了重算校验文件。

## 改动

新增 `.github/workflows/sha256sums.yml`，与老仓库同款逻辑，按本仓库适配：

- 触发：main 分支上 **`net-optimize.py`** 有变动时（老仓库监控的是 `net-optimize-ultimate.sh` + `whitelist-inject.sh`）；也可 `workflow_dispatch` 手动触发
- 生成：`sha256sum net-optimize.py > SHA256SUMS`
- 无变化则跳过提交；有变化提交 `chore: auto-update SHA256SUMS`，push 带 rebase + 5 次重试（SHA256SUMS 过期会导致所有 VPS 自动更新校验失败，不能丢）
- `concurrency` 去重，避免连续推送叠跑
- 相比老仓库补了 `permissions: contents: write`（新仓库 GITHUB_TOKEN 默认可能只读，显式声明更稳）
- 自动提交只动 SHA256SUMS，不会再次触发自己（paths 过滤）

## 测试

- YAML 语法校验通过
- `sha256sum -c SHA256SUMS` 确认当前校验文件与 net-optimize.py 匹配（工作流首跑会是 "unchanged" 跳过）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N79TMVPjciJCQS5WLqeoqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01N79TMVPjciJCQS5WLqeoqz)_