### PR TITLE
feat: 主菜单底部加提示——退出后输入 bgpeer 可再次唤醒面板管理

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -2724,6 +2724,7 @@ def main_menu():
         print("  13. 卸载")
         print("  0. 退出")
         print("-" * 60)
+        print("  ▸ 退出后输入 \033[1;32mbgpeer\033[0m 可再次唤醒面板管理")
         c = _ask("请选择: ").strip()
         if c == "0" or c == "":
             print("再见。"); return


### PR DESCRIPTION
## 需求（用户）

在面板主页写一行字：输入 bgpeer 可再次唤醒面板管理。

## 改动

主菜单「0. 退出」下方的分隔线后、「请选择:」上方加一行提示（bgpeer 用绿色加粗高亮，和安装完成时的提示风格一致）：

```
  13. 卸载
  0. 退出
------------------------------------------------------------
  ▸ 退出后输入 bgpeer 可再次唤醒面板管理
请选择:
```

## 测试

语法检查通过；模拟运行主菜单确认提示行显示位置正确。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N79TMVPjciJCQS5WLqeoqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01N79TMVPjciJCQS5WLqeoqz)_