### PR TITLE
fix: 更新核心后 xray 也打印现版本号

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -2356,7 +2356,8 @@ def update_cores():
         print("sing-box 现版本:", v.splitlines()[0] if v else "?")
     if c in ("2", "3") and os.path.exists(XRAY_BIN):
         install_xray(); sh("systemctl restart xray", check=False)
-        print("xray 已更新")
+        v = sh(f"{XRAY_BIN} version", check=False)
+        print("xray 现版本:", v.splitlines()[0] if v else "?")
     setup_core_update_cron()                             # 顺手确保每月自动更新的 cron 在
     print("更新完成。")
 


### PR DESCRIPTION
## 问题（用户反馈）

「12 更新核心」跑完，sing-box 显示现版本号，xray 只显示「xray 已更新」不带版本。

## 原因与修复

不是 xray 输出格式变了，是面板代码本来就没打印：`update_cores()` 里 sing-box 分支有 `print("sing-box 现版本:", ...)`，xray 分支只有一句 `print("xray 已更新")`。现在 xray 分支也用同样方式打印 `xray version` 首行（每月自动更新的日志 `update_cores_auto` 一直两个都打，保持一致）。

## 测试

桩函数模拟「3 两个」更新：两核心版本号均正确打印（`sing-box version 1.12.9` / `Xray 26.3.27 ...`）。语法检查通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N79TMVPjciJCQS5WLqeoqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01N79TMVPjciJCQS5WLqeoqz)_