### PR TITLE
feat: 进「12 更新核心」先显示两核心当前版本

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -2344,7 +2344,14 @@ def update_cores_auto():
             print(f"{ts} {name} 更新失败:", e)
 
 def update_cores():
-    print("\n更新核心:  1. sing-box   2. xray   3. 两个   0. 返回")
+    print("\n当前版本:")
+    for name, binpath in (("sing-box", SB_BIN), ("xray", XRAY_BIN)):
+        if os.path.exists(binpath):
+            v = sh(f"{binpath} version", check=False)
+            print(f"  {name}: {v.splitlines()[0] if v else '版本读取失败'}")
+        else:
+            print(f"  {name}: 未安装")
+    print("更新核心:  1. sing-box   2. xray   3. 两个   0. 返回")
     print(f"  （每月自动更新已开启：{_core_update_schedule_str()}）")
     c = _ask("选择: ")
     if c == "0" or not c:


### PR DESCRIPTION
## 需求（用户）

点进「12 更新核心」应该能直接看到当前版本，不用先更新一遍才知道。

## 改动

`update_cores()` 进入时先打印两核心的当前版本，再显示选项：

```
当前版本:
  sing-box: sing-box version 1.12.9
  xray: Xray 26.3.27 (Xray, Penetrates Everything.)
更新核心:  1. sing-box   2. xray   3. 两个   0. 返回
  （每月自动更新已开启：…）
```

未安装的核心标注「未安装」；`version` 命令读不出时显示「版本读取失败」。

## 测试

桩函数模拟两种场景（两核心全装 / 只装 sing-box）显示均正确；语法检查通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N79TMVPjciJCQS5WLqeoqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01N79TMVPjciJCQS5WLqeoqz)_