### PR TITLE
style(cdn): 卸载提示统一为 all=全部（与新增一致）

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -3178,8 +3178,8 @@ def cdn_remove():
     for i, n in enumerate(nodes, 1):
         print(f"   {i}. {n['domain']}:{n['cf_port']} [{n['proto']}/{n['core']}]"
               f"{'（已写入订阅）' if n.get('in_sub') else ''}")
-    print("   a 全部")
-    sel = _ask("  选择(编号；可多选，逗号分隔如 1,3；a 全部；回车取消): ").strip().lower()
+    print("   all 全部")
+    sel = _ask("  选择(编号；可多选，逗号分隔如 1,3；all=全部；回车取消): ").strip().lower()
     if not sel:
         return
     if sel in ("a", "all", "0"):


### PR DESCRIPTION
## 需求（用户）

新增菜单写「all=全部」，卸载菜单写「a 全部」，文案不一致——统一成「all=全部」。

## 改动

卸载菜单的显示文案从 `a 全部` 改为 `all 全部` / 提示 `all=全部`，与新增菜单一致。输入侧 `a`/`all`/`0` 仍都接受，行为不变。

语法检查通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N79TMVPjciJCQS5WLqeoqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01N79TMVPjciJCQS5WLqeoqz)_