### PR TITLE
fix(cdn): 代码审查修补——清单按域名分组 / 失败清残留 / 空订阅提示

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -2942,14 +2942,18 @@ def _cdn_link(st):
             f"&type=ws&host={dom}&path={path}&fp=chrome#{tag}")
 
 def _cdn_checklist(nodes):
-    """Cloudflare 侧照做清单（多条时各自的域名都要配一遍，端口列出全部）。"""
+    """Cloudflare 侧照做清单：按域名分组（同域名的多条只需配一次，端口合起来放行）。"""
     ip = public_ip()
-    ports = "/".join(str(n["cf_port"]) for n in nodes)
-    print("\n  ── Cloudflare 侧设置（下面每个域名各照做一次，脚本代替不了点鼠标）──")
-    print("  1. 域名加进 Cloudflare（免费版即可），改用 CF 的 DNS。")
-    print(f"  2. 每个域名加 A 记录 → {ip}（本机 IP），代理开【橙色云 Proxied】（必须橙云，灰云不生效）。")
-    print("  3. SSL/TLS 加密模式选【Full 完全】（不要 Full strict，源站是自签证书）。")
-    print(f"  4. VPS 安全组/防火墙放行入站 TCP：{ports}（CF 从这些口回源到本机）。")
+    by_dom = {}
+    for n in nodes:                                       # 保序去重，同域名归并端口
+        by_dom.setdefault(n["domain"], []).append(str(n["cf_port"]))
+    all_ports = "、".join(str(n["cf_port"]) for n in nodes)
+    print("\n  ── Cloudflare 侧设置（每个域名照做一次，脚本代替不了点鼠标）──")
+    for dom, ports in by_dom.items():
+        print(f"  · 域名 {dom}：在 Cloudflare 加 A 记录 → {ip}，代理开【橙色云 Proxied】"
+              f"（必须橙云）；要放行的端口：{'、'.join(ports)}")
+    print("  · SSL/TLS 加密模式选【Full 完全】（不要 Full strict，源站是自签证书）。")
+    print(f"  · VPS 安全组/防火墙放行入站 TCP：{all_ports}（CF 从这些口回源到本机）。")
     print("  客户端连的是 CF 的 IP，本机真 IP 不暴露；真 IP 被墙这些 CDN 节点仍可用。")
 
 def _state_prefix():
@@ -3028,7 +3032,11 @@ def _cdn_build_one(nodes, proto, core, domain, prefix):
     try:
         write_service(svc, binpath, conf)
     except RuntimeError as e:
-        print(f"  ✗ {proto} 服务启动失败（跳过）：", e); return None
+        print(f"  ✗ {proto} 服务启动失败（跳过）：", e)
+        for p in (crt, key, conf):                        # 起不来就把这条的残留文件清掉
+            try: os.remove(p)
+            except OSError: pass
+        return None
     node = {"id": nid, "proto": proto, "core": core, "domain": domain, "cred": cred,
             "path": path, "cf_port": port, "tag": f"{prefix}CDN·{proto}", "svc": svc,
             "crt": crt, "key": key, "conf": conf, "in_sub": False}
@@ -3160,6 +3168,9 @@ def cdn_write_sub():
         n["in_sub"] = writing
     _cdn_save(nodes)
     print(f"  ✓ 已{'写入' if writing else '移出'}全部 CDN 节点并刷新三格式订阅。客户端重新拉订阅即可生效。")
+    if not writing and not read_saved_links():
+        # 移出后订阅里一个节点都不剩：build_subscription 对空列表不再刷新，托管的旧订阅内容不会自动清空
+        print("  ℹ️ 订阅里已无任何节点，之前托管的订阅内容不会再更新；如需彻底清空可到菜单 2「节点/订阅」重置。")
 
 def _cdn_drop(node):
     """停服务、删单元、删该条的证书/配置。"""


### PR DESCRIPTION
## 背景

用户要求对整个脚本做一次完整审查。整体质量很好，未发现影响日常使用的严重 bug；以下是审查后修补的几处**边角问题**。

## 修补

1. **`_cdn_checklist` 按域名分组**：批量新增共用一个域名时，旧文案「下面每个域名各照做一次」会让人误以为要多个域名。改为按域名分组，同域名多条把端口合并列出，多域名时各列各的。
2. **`_cdn_build_one` 失败清残留**：某条协议服务启动失败（`write_service` 抛错）时，把已写入的证书/配置删掉，不留孤儿文件。
3. **空订阅提示**：CDN-only（无主节点）且把 CDN 节点全部「移出订阅」时，`build_subscription` 对空列表会 return False 不刷新，托管的旧订阅内容不会自动清空——现明确提示用户（避免误以为已清空）。

## 审查其它结论（无需改）

- 端口无冲突：主安装 15000–45000 / CDN 固定口 2053–8443 / 订阅 20080 互不重叠；8443 与 sni-split 本地 https 重叠已由 `port_free` 探测兜底（占用则自动跳过）。
- 多节点端口/服务/凭据分配、旧单节点格式迁移、写入/移出订阅、卸载多选 —— 回归均通过。
- CDN 节点带国旗前缀会进国家 urltest 组：属正确行为（延时高，urltest 平时不会选中，仅在直连节点全挂时兜底＝正是灾备语义）。

## 测试

回归全绿：批量装 4 条（证书文件 12 个）→ 写入订阅（build 收到 4 节点）→ CDN-only 全移出（提示「已无任何节点」）→ 卸载 1,3（剩 2 条、证书文件同步剩 2）→ 全卸（state 清除）。`_cdn_checklist` 单域名批量 / 多域名混合均输出正确。语法检查通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N79TMVPjciJCQS5WLqeoqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01N79TMVPjciJCQS5WLqeoqz)_