### PR TITLE
fix: CLI 协议名校验 + build 去重 + 修正文件头版本注释

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -4,8 +4,9 @@
 # ----------------------------------------------------------------------------
 # 设计原则（对应“逻辑和加密要做好”）：
 #   1. 密钥一律调用核心自带生成器，绝不在 Python 里手搓 x25519 / UUID
-#   2. 版本钉死：sing-box 1.11.x（避开 1.12 inbound sniff 迁移的破坏性改动）
-#                xray 25.x（reality 传输用 raw；ws 已 deprecated 但仍可用）
+#   2. 内核版本跟随 GitHub latest（和 mack-a 一致）：sing-box 下限 1.12
+#                （anytls inbound 是 1.12 才加的），xray reality 传输用 raw；
+#                拉不到 latest 时回落到 SB_VER / XRAY_VER 兜底常量
 #   3. 证书三态：reality 借目标站证书(无需域名) / hy2·tuic·anytls 自签 /
 #                ws·trojan 给域名走 acme.sh，不给则自签 + 链接带 insecure
 #   4. 加协议 = 往 SB / XRAY 表里加一个 builder，返回 (inbound, share_link)
@@ -1097,6 +1098,7 @@ def build(table, names, pinned=None, dup=None, mark=""):
                  手机上也显示得下。"""
     pinned = pinned or {}
     dup = dup or set()
+    names = list(dict.fromkeys(names))           # 去重保序：--sb hy2,hy2 不至于生成两个同 tag inbound
     inbounds, links = [], []
     for n in names:
         # 名称 = 用户前缀 + 协议名（默认无前缀，别人部署 US/SG 时自己填 🇺🇸/🇸🇬 等）
@@ -3561,4 +3563,11 @@ if __name__ == "__main__":
     xr = list(XRAY) if a.xray == "all" else [x for x in a.xray.split(",") if x]
     if not sb and not xr:
         ap.error("至少用 --sb 或 --xray 指定要装的协议")
+    # 协议名校验：拼错的名字必须在这里挡下——run() 会先卸载别人的安装(takeover)再 build，
+    # 放到 build() 里撞 KeyError 就成了「先把机器上的节点卸了、再崩 traceback」。
+    bad_sb = [n for n in sb if n not in SB]
+    bad_xr = [n for n in xr if n not in XRAY]
+    if bad_sb or bad_xr:
+        if bad_sb: ap.error(f"未知的 sing-box 协议: {','.join(bad_sb)}\n  可选: {','.join(SB)}")
+        ap.error(f"未知的 xray 协议: {','.join(bad_xr)}\n  可选: {','.join(XRAY)}")
     run(sb, xr)


### PR DESCRIPTION
## 背景

代码 review 提出三点,核对后全部属实,逐条修复。

## 1. (真 bug) CLI 协议名不校验,拼错崩 traceback

`--sb`/`--xray` 传入的协议名过去只做空串过滤,没跟 `SB`/`XRAY` 字典核对就进了 `build()`,`table[n]` 遇到不认识的键直接 `KeyError`(如 `--sb reality-vsion` 少个 i)。

**比 review 描述的更严重**:崩溃发生在 `run()` 深处,而 `run()` 会先执行 `takeover_cleanup()` 卸载机器上已有的安装(mack-a 等)——等于「先把节点卸了、再崩一段 traceback」。

修复:在 `run()` 之前、即任何破坏性动作之前比对字典,非法名列出全部可选值后 `ap.error` 干净退出。交互菜单走 `_pick` 不受影响,只有 CLI 直传会中招。

## 2. build() 对 names 去重

`--sb hy2,hy2` 会生成两个同 tag inbound,原靠 `core_check` 拦下报错(能捕获不脏装)。`build()` 开头加 `dict.fromkeys` 去重保序,更干净。

## 3. 修正文件头注释与实际矛盾

头部第 7 行「版本钉死：sing-box 1.11.x(避开 1.12)」是旧版残留,与下方 `SB_VER=1.12.0`、「必须 ≥1.12」及 `install_singbox` 实际跟随 GitHub latest 全部矛盾。改成与现状一致:跟随 latest、下限 1.12、拉不到回落兜底常量。

> review 另提的两点(`G["force"]` 布尔 vs 字符串、`"true"` 字符串风格)其本人已确认非 bug,不改动。

## 验证

以真实 `SB`/`XRAY` 键名比对:拼错 `reality-vsion`(sb)、`vless-reality-xhtp`(xray)均被挑出并退出 ✓;正确名组合放行 ✓;`hy2,hy2` 去重保序 ✓;`py_compile` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZFRiT1QvxvwkeqBe3m7Zk

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZFRiT1QvxvwkeqBe3m7Zk)_