### PR TITLE
ci(release): 更新说明从提交主题生成,直接提交也不再空

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,18 @@ jobs:
           new_ver='${{ steps.ver.outputs.new_ver }}'
           # 若上一步回写了版本号，要把 tag 打在回写后的那个提交上
           git fetch origin main
-          gh release create "v$new_ver" \
-            --target "$(git rev-parse origin/main)" \
-            --title "v$new_ver" \
-            --generate-notes
+          target="$(git rev-parse origin/main)"
+          prev_tag="$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1)"
+          # 更新说明：直接从提交主题生成——这样不管是 PR 合并（squash 后主题即 PR 标题）
+          # 还是直接在网页改文件提交，都能列出来，不再出现空说明。过滤掉发版/校验和这类
+          # 自动提交。取不到上一个 tag（首发）则退回 GitHub 自动生成。
+          if [ -n "$prev_tag" ]; then
+            notes="$(git log --no-merges --pretty='- %s' "$prev_tag..$target" \
+                     | grep -vE '^- (chore\(release\):|chore: auto-update SHA256SUMS)' || true)"
+            [ -z "$notes" ] && notes="- 维护性更新"
+            body="$(printf '## 更新内容\n\n%s\n\n**Full Changelog**: https://github.com/bgpeer/nodekit/compare/%s...v%s\n' \
+                    "$notes" "$prev_tag" "$new_ver")"
+            gh release create "v$new_ver" --target "$target" --title "v$new_ver" --notes "$body"
+          else
+            gh release create "v$new_ver" --target "$target" --title "v$new_ver" --generate-notes
+          fi


### PR DESCRIPTION
## 背景

v1.0.5 的发布说明是空的——因为它是直接在网页编辑 `sub-template.yaml` 触发的(没走 PR),而原来的 `--generate-notes` 只列 PR,找不到 PR 就只剩空的 compare 链接。

## 改动

- 发布说明改为**从上一个 tag 到 HEAD 的提交主题**生成:PR 合并(squash 后提交主题即 PR 标题)和直接提交都能列出,不再空
- 过滤掉 `chore(release):`、`chore: auto-update SHA256SUMS` 这类自动提交
- 首发(取不到上一个 tag)仍退回 GitHub `--generate-notes`
- 无有效提交时兜底显示"维护性更新",不会报错

## 验证

本地 git 模拟两场景:PR 合并 → 列出 `feat: ... (#102)`;直接改模板提交 → 列出 `更新 sub-template.yaml`。workflow YAML 与该步 bash 语法校验通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZFRiT1QvxvwkeqBe3m7Zk

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZFRiT1QvxvwkeqBe3m7Zk)_