### PR TITLE
feat: reality 伪装 SNI 安装时从大厂池随机挑

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ sudo python3 xy-installer.py --sb all --domain a.example.com --nginx
 ```
 
 常用参数：`--sb` / `--xray`（协议，逗号分隔或 `all`）、`--domain`、`--email`、
-`--sni`（reality 借用目标站，默认 `s0.awsstatic.com`）、`--prefix`（节点名前缀）、
+`--sni`（reality 借用目标站，**不填=从内置大厂池随机挑一个**，避免所有人挤在同一个 SNI）、`--prefix`（节点名前缀）、
 `--hy2-ports`（hy2 端口跳跃范围，默认 `30000-31000`；填 `off` 关闭跳跃、走单端口）、`--nginx`、
 `--no-reality-443`（默认会把主力 reality 绑 443 抗封端口，加此参数则不绑）、
 `--yes`（检测到 mack-a 等现有安装直接接管）。
@@ -372,10 +372,12 @@ sudo python3 xy-installer.py --sb all --domain a.example.com --nginx
 
 装机时脚本会自动做两项检查，帮你把伪装做扎实（都只提示、不阻断安装）：
 
-- **Reality SNI 预检**：选了 reality 系列协议时，装前会探测你借用的 SNI 目标是否
-  **可达 + 支持 TLS1.3 + HTTP/2**。不合格会给黄色警告并建议换站
-  （推荐 `www.microsoft.com` / `addons.mozilla.org` / `s0.awsstatic.com` / `dl.google.com`
-  这类大流量、支持 h2、不套 CDN、不在国内的站）。借用不合格的站会让 reality 握手特征更容易被识别。
+- **Reality SNI 随机池 + 预检**：安装时**默认从内置的大厂/技术站池里随机挑一个**当 reality 借用目标
+  （cisco/oracle/python/intel/dell/苹果CDN/微软 等 21 个，实测 TLS1.3+h2+X25519、国内可达、不套乱 CDN）——
+  避免所有人都按回车挤在同一个 SNI 上被针对。想指定就 `--sni 域名` 或交互里输入。选了 reality 系列协议时，
+  装前还会探测借用目标是否**可达 + 支持 TLS1.3 + HTTP/2**，不合格给黄色警告并建议换站。
+  > ⚠️ 伪装目标要用**国内可达的国外大站**：别用被墙的站（google/youtube 等），更**不能用国内域名**
+  > （国外 IP 配国内 SNI = IP 与 SNI 极度不匹配，最容易被识别）。
 - **无域名自签提示**：不给域名时，依赖证书的 TLS 协议（vless-vision / trojan / ws 家族 / anytls）
   只能走**自签证书 + 客户端 `allowInsecure`**——内容仍加密（各协议有自己的密码/UUID），
   但失去证书校验、且自签本身是明显特征。**想要更强伪装：优先用 `reality-*` 系列**

--- a/xy-installer.py
+++ b/xy-installer.py
@@ -576,8 +576,17 @@ def check_domain_or_die():
         raise SystemExit(f"{R}\n❌ 80 端口被占用，acme standalone 无法验证。先停掉占用 80 的服务"
                          f"（nginx/caddy 等）再装，或域名留空用自签，或用 nginx 前置模式。{N}")
 
-# 建议的 reality 借用目标：都是大流量、支持 TLS1.3+h2、不在国内、不套 CDN 的站
-SNI_SUGGESTIONS = "www.microsoft.com / addons.mozilla.org / s0.awsstatic.com / dl.google.com"
+# reality 借用目标池：都是大厂/技术站，实测 TLS1.3+h2+X25519、国内可达、不套乱 CDN。
+# 安装时默认从这里随机挑一个（避免所有人都按回车挤在同一个 SNI 上被针对）。
+REALITY_SNI_POOL = [
+    "www.cisco.com", "www.oracle.com", "www.ibm.com", "www.vmware.com",
+    "www.python.org", "www.mysql.com", "www.mongodb.com", "redis.io", "www.swift.com",
+    "www.intel.com", "www.amd.com", "www.qualcomm.com", "www.dell.com",
+    "www.samsung.com", "academy.nvidia.com",
+    "swcdn.apple.com", "updates.cdn-apple.com", "cdn-dynmedia-1.microsoft.com",
+    "www.bing.com", "www.tesla.com", "s0.awsstatic.com",
+]
+SNI_SUGGESTIONS = " / ".join(REALITY_SNI_POOL[:6]) + " 等"
 
 def _reality_sni_ok(sni):
     """探测 reality 借用目标站是否支持 TLS1.3 + HTTP/2。返回 (ok, 说明)。
@@ -3575,7 +3584,8 @@ def install_flow():
     if domain:
         nginx = "1" if (_ask("用 nginx 前置(443伪装站+webroot证书, ws类藏443)? [y/N]: ")
                         .lower() in ("y", "yes")) else ""
-    sni = _ask("reality 借用目标站 SNI (回车=s0.awsstatic.com): ") or "s0.awsstatic.com"
+    _sni_rand = secrets.choice(REALITY_SNI_POOL)         # 回车就用这个随机挑的（不同机器各不同，不扎堆）
+    sni = _ask(f"reality 借用目标站 SNI (回车=随机挑，本次随机到 {_sni_rand}): ") or _sni_rand
     prefix = _ask("节点名称前缀(如 🇺🇸/🇯🇵/家宽，回车=无前缀): ")
     hy2p = ""
     if "hy2" in sb_names:
@@ -3645,7 +3655,7 @@ if __name__ == "__main__":
     ap.add_argument("--xray", default="", help="xray 协议，逗号分隔，或 all")
     ap.add_argument("--domain", default="", help="有域名则走 acme 真证书")
     ap.add_argument("--email", default="", help="acme 注册邮箱")
-    ap.add_argument("--sni", default="s0.awsstatic.com", help="reality 借用的目标站")
+    ap.add_argument("--sni", default="", help="reality 借用的目标站（不填=从内置大厂池随机挑一个）")
     ap.add_argument("--prefix", default="", help="节点名称前缀(如 🇺🇸/🇯🇵)，默认无")
     ap.add_argument("--hy2-ports", default="", help="hy2 端口跳跃范围 起-止，默认 30000-31000；填 off 关闭跳跃走单端口")
     ap.add_argument("--nginx", action="store_true",
@@ -3661,7 +3671,7 @@ if __name__ == "__main__":
     a = ap.parse_args()
 
     G["domain"], G["email"], G["sni"], G["prefix"], G["hy2_ports"], G["nginx"], G["force"] = \
-        a.domain, a.email, a.sni, a.prefix, a.hy2_ports, ("1" if a.nginx else ""), a.yes
+        a.domain, a.email, (a.sni or secrets.choice(REALITY_SNI_POOL)), a.prefix, a.hy2_ports, ("1" if a.nginx else ""), a.yes
     G["reality443"] = "" if a.no_reality_443 else "1"   # 默认把 reality 绑 443（抗封端口）
     G["sni_split"] = "1" if a.sni_split else ""         # 最强：nginx SNI 分流，全上 443
     G["smux"] = "1" if a.smux else ""                   # ws 类多路复用，默认关


### PR DESCRIPTION
## 背景

reality 伪装 SNI 默认是固定的 `s0.awsstatic.com`,所有人按回车都用它 → 都挤在同一个 SNI,人多了容易被针对。

## 改动

- 新增 `REALITY_SNI_POOL`(21 个大厂/技术站:cisco/oracle/python/intel/dell/samsung/苹果CDN/微软/bing/tesla/aws 等,均实测 **TLS1.3 + h2 + X25519**、国内可达、无 edu/gov)
- **安装时默认从池里随机挑一个**当 reality 借用目标:
  - 交互:回车 = 随机挑,并显示本次挑到哪个
  - CLI:`--sni` 不填 = 随机挑(想指定照常 `--sni 域名`)
- 不同机器各自随机、互不扎堆
- README 说明 + 提醒:伪装目标要用国内可达的国外大站,别用被墙站(google/youtube)、**更不能用国内域名**(国外IP配国内SNI 最易被识别)

## 验证

`py_compile` 通过;池 21 个、含 s0.awsstatic.com、无 edu/gov;`secrets.choice` 200 次覆盖全部 21 个(多机不扎堆)。所有域名此前已逐个实测 TLS1.3+h2+X25519。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZFRiT1QvxvwkeqBe3m7Zk

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZFRiT1QvxvwkeqBe3m7Zk)_