### PR TITLE
fix(sub-server): TLS 握手挪到工作线程,修订阅/中转整个服务被堵死

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -1329,6 +1329,7 @@ cert = sys.argv[4] if len(sys.argv) > 4 else ''
 key  = sys.argv[5] if len(sys.argv) > 5 else ''
 ALLOW = ('raw.githubusercontent.com', 'objects.githubusercontent.com', 'github.com', 'codeload.github.com')
 class H(http.server.SimpleHTTPRequestHandler):
+    timeout = 30                     # 读请求超时：卡住的客户端不会永久占着线程
     def __init__(self, *a, **k):
         super().__init__(*a, directory=directory, **k)
     def log_message(self, *a):
@@ -1366,11 +1367,28 @@ class H(http.server.SimpleHTTPRequestHandler):
             self.end_headers(); self.wfile.write(data)
         except Exception:
             self.send_error(502)
-httpd = http.server.ThreadingHTTPServer(('0.0.0.0', port), H)
+class S(http.server.ThreadingHTTPServer):
+    """TLS 握手必须在工作线程里做。若像以前那样 wrap 监听 socket，accept() 会在主循环
+       内完成握手——只要有客户端连上却不握手（mihomo 并发拉几十个规则集时很常见），
+       主循环就被堵死、后续订阅/中转全部连不上（表现为 active 但 EOF/超时、队列堆积）。"""
+    daemon_threads = True
+    request_queue_size = 128          # 默认 5 太小，并发拉规则时瞬间排满
+    ctx = None
+    def process_request_thread(self, request, client_address):
+        if self.ctx is not None:
+            try:
+                request.settimeout(20)                    # 握手不能无限等
+                request = self.ctx.wrap_socket(request, server_side=True)
+            except Exception:
+                try: self.shutdown_request(request)
+                except Exception: pass
+                return
+        super().process_request_thread(request, client_address)
+httpd = S(('0.0.0.0', port), H)
 if cert and key:
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     ctx.load_cert_chain(cert, key)
-    httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
+    httpd.ctx = ctx
 httpd.serve_forever()
 '''
 


### PR DESCRIPTION
## 真机现象

换端口后订阅、中转、图标全部连不上;但服务 `active (running)`、`ss` 显示端口在 `LISTEN`,**本机 curl 也不通**。

铁证在 `ss` 输出:`LISTEN 6 5 0.0.0.0:38628` —— **Recv-Q=6 > Send-Q(backlog)=5**,accept 队列爆满、没人处理。

## 根因

以前是 `httpd.socket = ctx.wrap_socket(httpd.socket)` —— wrap **监听 socket**,于是 `accept()` 会在**主循环里**完成 TLS 握手。只要有客户端连上却不完成握手(mihomo 并发拉几十个规则集时极常见),主循环就被堵死,后续所有连接进不来。

**本地复现:仅 3 个"连上不握手"的连接就能让整个服务全挂**(订阅+中转+图标)。这是原有缺陷,加了 GitHub 中转后并发量剧增,把它彻底暴露。

## 修复

- **不再 wrap 监听 socket**;改在 `process_request_thread` 里**按连接 wrap**(握手在工作线程)
- `request_queue_size` 5 → **128**(并发拉规则不至于瞬间排满)
- 握手 **20s 超时** + handler `timeout=30s`,卡住的客户端不会永久占线程
- `daemon_threads = True`

## 验证

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 3 个卡住连接期间请求订阅 | ❌ 超时(全挂) | ✅ 200 |
| 20 个卡住连接期间 | — | ✅ 200 |
| 中转 + token | — | ✅ 200 |
| 顺序 30 次请求 | — | ✅ 30/30 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZFRiT1QvxvwkeqBe3m7Zk

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZFRiT1QvxvwkeqBe3m7Zk)_