### PR TITLE
feat(mihomo-tpl): geox-url 补 mmdb + asn（修 Unsupported ASN type 报警）

### DIFF
--- a/sub-template.yaml
+++ b/sub-template.yaml
@@ -26,6 +26,17 @@ profile: {store-selected: true, store-fake-ip: true}
 ntp: {enable: true, server: time.apple.com, port: 123, interval: 30, dialer-proxy: "", write-to-system: false}
 experimental: {quic-go-disable-ecn: true}
 
+# geo 数据库：只用 mmdb（连接信息/国旗 + 万一有 GEOIP 规则）+ asn（IP-ASN 规则要它，
+# 缺了才会刷 "Unsupported ASN type: GeoLite2-Country"）。不加 dat——分流全走
+# rule-provider（本仓库 .mrs/.yaml），没有内置 GEOSITE/GEOIP 规则，mihomo 不会去下
+# geosite.dat/geoip.dat。mmdb/asn 走本机 GitHub 中转拉（关中转/无域名时回落 gh-proxy）。
+geodata-mode: false
+geo-auto-update: true
+geo-update-interval: 24
+geox-url:
+  mmdb: "https://gh-proxy.com/https://raw.githubusercontent.com/Loyalsoldier/geoip/release/GeoLite2-Country.mmdb"
+  asn: "https://gh-proxy.com/https://raw.githubusercontent.com/Loyalsoldier/geoip/release/GeoLite2-ASN.mmdb"
+
 external-controller-cors:
   allow-origins: ["*"]
   allow-private-network: true


### PR DESCRIPTION
## 起因

`telegram` / `anthropic` / `category-games-!cn` 三个 classical 规则集内含 `IP-ASN` 条目(上游 Loyalsoldier 带进来的):

```
telegram.yaml            IP-ASN,211157 / 44907 / 59930 ...
anthropic.yaml           IP-ASN,399358
category-games-!cn.yaml  IP-ASN,38118 / 62830 / 6507
```

客户端默认没有 ASN 库,mihomo 拿国家库去查 ASN、类型对不上,刷 `Unsupported ASN type: GeoLite2-Country`,那几条 IP-ASN 规则**静默失效**。

## 改法

模板加 `geox-url`,**只给 `mmdb` + `asn`**:

```yaml
geodata-mode: false
geo-auto-update: true
geo-update-interval: 24
geox-url:
  mmdb: "https://gh-proxy.com/https://raw.githubusercontent.com/Loyalsoldier/geoip/release/GeoLite2-Country.mmdb"
  asn:  "https://gh-proxy.com/https://raw.githubusercontent.com/Loyalsoldier/geoip/release/GeoLite2-ASN.mmdb"
```

- **不加 `geoip`/`geosite` 的 dat**——分流全走 rule-provider(本仓库 `.mrs`/`.yaml`),没有内置 GEOSITE/GEOIP 规则,mihomo 不会去下 dat
- 本仓库没有 mmdb 二进制库,故用 Loyalsoldier release 源;写成 `gh-proxy` 前缀形式 → **生成时自动走本机 GitHub 中转**,关中转/无域名时回落 `gh-proxy`
- 这样 IP-ASN 规则**真正生效**(而不是把它们删掉),报警消失

## 验证

| 检查 | 结果 |
|---|---|
| 中转开 → mmdb/asn 改写 | `本机域名:端口/token/gh/https://raw.../Loyalsoldier/...` ✅ |
| 中转关 → 回落 | 保留 `gh-proxy` 前缀 ✅ |
| 填占位符后整份 YAML 解析 | 通过 ✅ |
| `geox-url` 内容 | 只含 `mmdb`+`asn`,无 dat 键 ✅ |
| 完整 `gen_mihomo` 端到端 | 占位符 0 残留、asn 走中转、proxies/rule-providers 数量正常 ✅ |
| 与自建DNS 共存 | `nameserver` + `global-dns` 注入不冲突 ✅ |
| Loyalsoldier release 可拉取 | `GeoLite2-ASN/Country.mmdb` HTTP 200 ✅ |

> 客户端更到最新、重新拉一次订阅即可。若之前已缓存了一份错的 ASN 库,删掉客户端 geo 缓存目录里的 ASN `.mmdb` 再重启,让它按新 URL 重下正确的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZFRiT1QvxvwkeqBe3m7Zk

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZFRiT1QvxvwkeqBe3m7Zk)_