### PR TITLE
fix(adguard): 初装向导统一用默认 3000，改端口交给菜单 5

### DIFF
--- a/adguard-dns.py
+++ b/adguard-dns.py
@@ -119,18 +119,18 @@ def install():
         print("\n  ✓ AdGuard Home 已安装并启动。")
     else:
         print("\n  已安装，但服务暂未在运行——稍等或看 `systemctl status AdGuardHome`。")
-    _first_setup(_pick_web_port(0) or WEB_PORT)          # 装时就随机挑一个 2000-5000 的后台端口（固定不跳）
+    _first_setup()          # 初装向导统一走默认 3000（先保证进得去），装好后再用菜单 5 改端口（带回滚，锁不死）
 
-def _first_setup(sug):
+def _first_setup():
     ip = _public_ip()
     print("\n  === 下一步：打开网页后台完成初始化（2 分钟）===")
     print(f"  1) 浏览器打开安装向导：\033[1;32mhttp://{ip}:{WEB_PORT}\033[0m（先在防火墙放行 {WEB_PORT}/TCP）")
     print("  2) 向导里两个端口按这样填（\033[1;33m别用默认的 80\033[0m）：")
-    print(f"     · 网页管理界面 端口 → 填 \033[1;32m{sug}\033[0m（我随机生成的·防扫描，固定用它不会跳；想省事填 {WEB_PORT} 也行，之后可用菜单 5 改）")
+    print(f"     · 网页管理界面 端口 → 就填默认的 \033[1;32m{WEB_PORT}\033[0m（\033[1;33m初装先用它保证进得去\033[0m；想换防扫描端口，装好后回菜单选 5 改，改完连不上会自动回滚、锁不死）")
     print("     · DNS 服务器 端口 → 保持 \033[1;32m53\033[0m（装前已帮你腾好；仍报红就回菜单选 4 腾53）")
     print("  3) 设管理员账号密码 → 完成。广告过滤（AdGuard DNS filter）默认就是开的。")
-    print(f"  4) 完成后后台地址变成 \033[1;32mhttp://{ip}:{sug}\033[0m（防火墙放行 {sug}、可关掉 {WEB_PORT}）")
-    _usage(sug)
+    print(f"  4) 完成后后台地址就是 \033[1;32mhttp://{ip}:{WEB_PORT}\033[0m；想改端口防扫描，回菜单选 \033[1;32m5\033[0m 改（带回滚，安全）")
+    _usage(WEB_PORT)
 
 def _usage(port=None):
     """一步步的使用说明：登录后台 → 开加密 → 设备指过来。写给不懂的人看。"""


### PR DESCRIPTION
## 问题

自建 DNS（AdGuard Home）初装向导里，原本建议在「网页管理界面 端口」直接填一个随机端口（防扫描）。但 AGH 完成向导后会**跳到那个端口**，如果防火墙没同步放行，浏览器就打不开后台，容易把人锁在管理界面外面。

## 修复

改成用户反馈的正确顺序：**初装先用默认 `3000` 保证进得去**，装好后再用菜单 `5`（`change_web_port`，改完连不上会**自动回滚**、锁不死）改成随机端口防扫描。

- `_first_setup` 不再预挑随机端口；向导「网页管理界面 端口」建议填默认 `WEB_PORT`（3000），完成后后台地址即 `http://IP:3000`；防扫描改端口引导到菜单 5。
- `_pick_web_port` 仅菜单 5 仍在用，保留。

README 第 237 / 241 行本就描述「初装 3000 → 菜单 5 改端口」，本次改动让脚本与文档一致，无需改文档。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZFRiT1QvxvwkeqBe3m7Zk)_