### PR TITLE
refactor(install): 去掉交互式 acme 注册邮箱提问，默认即可

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -3894,7 +3894,7 @@ def install_flow():
         print("没选任何协议，退出。"); return
 
     domain = _ask("\n域名(有则走 acme 真证书, 回车=自签): ")
-    email = _ask("acme 注册邮箱(回车=默认): ") if domain else ""
+    email = ""   # 证书自动续期、默认占位邮箱即可签发，不再交互问；想指定用命令行 --email
     nginx = ""
     if domain:
         nginx = "1" if (_ask("用 nginx 前置(443伪装站+webroot证书, ws类藏443)? [y/N]: ")


### PR DESCRIPTION
## 背景

装节点填了域名后，会多问一句「acme 注册邮箱(回车=默认)」。但这个邮箱只用于 Let's Encrypt 给你发**证书到期提醒**，而 nodekit 的证书是 **acme.sh 自动续期**的（记了 reloadcmd，到期自动续、自动重载），那封提醒邮件根本用不上；默认占位邮箱 `a@a.com` 也能正常签发。对「给不懂的人用」的脚本来说，多这一句看不懂的问题反而是负担。

## 改动

- 交互式安装去掉 `acme 注册邮箱` 这一步，`email` 直接置空（下游 `G["email"] or "a@a.com"` 自动回落到默认占位邮箱，签发行为不变）。
- 命令行 `--email` 参数**保留**，想指定真邮箱的高级用户仍可用；README 的 CLI 参数说明无需改动。

不影响证书申请/续期的任何实际行为，纯粹少一步交互。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZFRiT1QvxvwkeqBe3m7Zk)_