### PR TITLE
fix(xray): reality 补 minClientVer=1.0.0，兼容 xray 26.7.11+ 自动升级

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ sudo python3 /tmp/xy.py
   续期后自动重启 sing-box / xray（有 nginx 顺带 reload）使新证书生效，无需手动干预
 - **内核自动更新**：安装后自动挂 cron，**每月北京时间 2 号凌晨 04:00** 把 sing-box / xray 更新到最新并重启一次
   （无新版则跳过）；也可随时进管理面板 **16 更新核心** 手动立即更新。日志在 `/var/log/bgpeer-coreupdate.log`
+- **xray 26.7.11+ reality 兼容自愈**：xray 从 v26.7.11 起，reality 服务端**默认 `minClientVer=26.3.27`**，会
+  **静默拒掉上报旧版本的客户端**（mihomo/Clash 系内核硬编码 reality 版本 `1.8.2`、sing-box、旧 xray）——表现为
+  升级 xray 后 reality 节点客户端**连不上、也不报错**（全被丢进 fallback）。本脚本给 xray reality 入站显式写
+  `minClientVer: "1.0.0"`（接受所有客户端）规避：**新装**即带；**老装**在「更新核心」或下次打开面板时**自动补上并重启 xray**
+  （只在缺失时补一次，之后不再动）。sing-box 内核无此改动、不受影响。
 
 ---
 

--- a/xy-installer.py
+++ b/xy-installer.py
@@ -1010,10 +1010,14 @@ SB = {"vless-vision": sb_vless_vision,
 # xray 协议表 —— builder 返回 (inbound_dict, share_link)
 # ============================================================================
 def _xr_reality_stream(priv, sid, network, extra=None):
+    # minClientVer=1.0.0：xray v26.7.11+ 的 reality 服务端默认 minClientVer=26.3.27，会静默
+    # 拒掉上报旧版本的客户端（mihomo/Clash 系硬编码 1.8.2、sing-box、旧 xray）→ 连不上。
+    # 显式设成 1.0.0（接受所有客户端），兼容优先，避免自动升级 xray 后老客户端集体连不上。
     st = {"network": network, "security": "reality",
           "realitySettings": {"show": False, "dest": f"{G['sni']}:443",
                               "xver": 0, "serverNames": [G["sni"]],
-                              "privateKey": priv, "shortIds": [sid]}}
+                              "privateKey": priv, "shortIds": [sid],
+                              "minClientVer": "1.0.0"}}
     if extra:
         st.update(extra)
     return st
@@ -2643,6 +2647,37 @@ def _core_update_schedule_str():
     local = datetime.datetime(2001, 6, 2, 4, 0, tzinfo=bj).astimezone()
     return f"每月 {local.day} 号 {local:%H:%M}（本机时区，= 北京每月 2 号 04:00）"
 
+def _xray_heal_minclientver(restart=True):
+    """给现有 xray reality 入站补 minClientVer（缺才补）。
+       xray v26.7.11+ reality 服务端默认 minClientVer=26.3.27，静默拒掉上报旧版本的客户端
+       (mihomo/Clash 系硬编码 1.8.2、sing-box、旧 xray)。补成 1.0.0(接受所有客户端)。
+       只在确有缺失时改配置+校验+重启；校验不过则回滚。改了返回 True。"""
+    cfg = f"{XRAY_DIR}/config.json"
+    if not os.path.exists(cfg):
+        return False
+    try:
+        data = json.load(open(cfg))
+    except Exception:
+        return False
+    changed = False
+    for ib in data.get("inbounds", []):
+        rs = (ib.get("streamSettings") or {}).get("realitySettings")
+        if isinstance(rs, dict) and not rs.get("minClientVer"):
+            rs["minClientVer"] = "1.0.0"
+            changed = True
+    if not changed:
+        return False
+    old = open(cfg).read()
+    json.dump(data, open(cfg, "w"), indent=2)
+    if os.path.exists(XRAY_BIN):
+        ok, msg = core_check(XRAY_BIN, cfg)
+        if not ok:
+            open(cfg, "w").write(old)                        # 回滚，绝不留坏配置
+            return False
+    if restart:
+        sh("systemctl restart xray", check=False)
+    return True
+
 def update_cores_auto():
     """非交互更新已安装的内核到最新并重启（cron 每月调用）。起不来会记进日志。"""
     ensure_deps()
@@ -2659,6 +2694,8 @@ def update_cores_auto():
             print(f"{ts} {name} 更新完成（{act}）: {ver}")
         except Exception as e:
             print(f"{ts} {name} 更新失败:", e)
+    if _xray_heal_minclientver():                            # 升级到 xray 26.7.11+ 后补 minClientVer，兼容旧客户端
+        print(f"{ts} xray reality 已补 minClientVer=1.0.0（兼容 mihomo/旧客户端）")
 
 def update_cores():
     print("\n当前版本:")
@@ -2682,6 +2719,8 @@ def update_cores():
         install_xray(); sh("systemctl restart xray", check=False)
         v = sh(f"{XRAY_BIN} version", check=False)
         print("xray 现版本:", v.splitlines()[0] if v else "?")
+        if _xray_heal_minclientver():
+            print("已给 reality 补 minClientVer=1.0.0（xray 26.7.11+ 默认会拒旧客户端，补上兼容 mihomo 等）")
     setup_core_update_cron()                             # 顺手确保每月自动更新的 cron 在
     print("更新完成。")
 
@@ -3993,6 +4032,11 @@ def cdn_menu():
             return
 
 def main_menu():
+    # 一次性自愈：xray 26.7.11+ 默认 minClientVer=26.3.27 会拒旧客户端(mihomo 硬编码 1.8.2 等)，
+    # 给缺这项的 reality 入站补 1.0.0。只在首次(确有缺失时)改配置+重启 xray，之后即为 no-op。
+    if _xray_heal_minclientver():
+        print("  ⓘ 已给 xray reality 补 minClientVer=1.0.0：新版 xray(26.7.11+)默认会静默拒掉\n"
+              "     mihomo/Clash 等上报旧版本的客户端，补上后它们又能连了（xray 已后台重启一次）。")
     while True:
         print("\n" + "=" * 60)
         print(f"  bgpeer 一键脚本 v{SCRIPT_VERSION}  （sing-box + xray 多协议 / 订阅）")


### PR DESCRIPTION
## 背景（来自用户群里截图的问题）

Xray-core **v26.7.11** 起，REALITY **服务端**默认 `minClientVer=26.3.27`（[commit af7eb68](https://github.com/XTLS/Xray-core/commit/af7eb68028732a8ee3c0e5d6ab2b8a657bb2e770)），会**静默拒掉上报旧版本的客户端**：
- mihomo / Clash 系内核 reality 版本**硬编码 1.8.2**（[mihomo #2967](https://github.com/MetaCubeX/mihomo/issues/2967)）
- sing-box、旧版 xray 客户端

表现：升级 xray 后 reality 节点客户端**连不上、也不报错**，全被丢进 fallback（[Xray #6482](https://github.com/XTLS/Xray-core/issues/6482)、[3x-ui #5922](https://github.com/MHSanaei/3x-ui/issues/5922)）。

**nodekit 受影响**：nodekit 是服务端，且**每月自动升级 xray 到最新**——xray 一升到 26.7.11+，用户的 xray-reality 节点就会对上述客户端集体失效。修复点正好在服务端。

## 改动

- **`_xr_reality_stream`**：显式写 `minClientVer: "1.0.0"`（接受所有客户端）。**新装/重装即带**。
- **`_xray_heal_minclientver()`**（新增自愈）：扫 xray `config.json`，给 reality 入站中**缺** `minClientVer` 的补 `1.0.0` → 改配置 → `core_check` 校验（不过则回滚）→ 重启 xray。idempotent，只在缺失时补一次。
- **接入三处自愈老装**：
  - `update_cores_auto()`（cron 每月自动更新后）
  - `update_cores()`（手动「更新核心」后）
  - `main_menu()` 打开面板时（一次性，之后 no-op）
- README 增补说明。

## 取值说明

`minClientVer="1.0.0"` 是显式非零值——不会被 xray 当作"未设置"而回落到 26.3.27 默认；且低于所有真实客户端上报版本（mihomo 1.8.2、sing-box、xray 均 ≥ 1.0.0），兼容优先。sing-box 内核无此改动、不受影响，故只改 xray reality。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZFRiT1QvxvwkeqBe3m7Zk)_