### PR TITLE
security(mihomo): lan-allowed-ips 收窄到私有网段，堵住代理口对公网开放

### DIFF
--- a/sub-template.yaml
+++ b/sub-template.yaml
@@ -19,7 +19,7 @@ keep-alive-interval: 30
 bind-address: "*"
 authentication: ["meta:88888888"]
 skip-auth-prefixes: ["127.0.0.1/8", "::1/128"]
-lan-allowed-ips: ["0.0.0.0/0", "::/0"]
+lan-allowed-ips: ["127.0.0.1/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "169.254.0.0/16", "::1/128", "fc00::/7", "fe80::/10"]
 lan-disallowed-ips: []
 global-ua: "Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Mobile Safari/537.36"
 profile: {store-selected: true, store-fake-ip: true}


### PR DESCRIPTION
## 问题

mihomo 订阅模板 `sub-template.yaml` 之前:
```yaml
allow-lan: true
bind-address: "*"
authentication: ["meta:88888888"]
lan-allowed-ips: ["0.0.0.0/0", "::/0"]   # ← 对任意来源IP(含公网)开放
```
代理口(mixed 7893 等)对**任意来源 IP 开放**,仅靠弱口令 `meta:88888888` 挡着。设备若有公网 IP / 被端口转发,近似**开放代理**,易被滥用连累 IP。(`secret: 88888888` 是面板 API 的,但 `external-controller` 绑 127.0.0.1,只本机可达,风险低,未改。)

## 改动(按 owner 选择:只限内网、口令不动)

`lan-allowed-ips` 收窄到私有/环回/链路本地网段:
```yaml
lan-allowed-ips: ["127.0.0.1/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16",
                  "169.254.0.0/16", "::1/128", "fc00::/7", "fe80::/10"]
```
- **公网来源一律拒绝**——即使设备有公网 IP,互联网也连不进代理口。
- **家里局域网共享照常**(allow-lan 的本意):192.168/10/172.16 网段的设备仍可用。
- 认证口令 `meta:88888888`、`secret`、`bind-address` 按需求**不动**(内网可信,弱口令风险大幅降低)。

CGNAT 段 `100.64.0.0/10` 特意不放行(避免移动网络下对同段其他用户开放)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZFRiT1QvxvwkeqBe3m7Zk)_