### PR TITLE
fix(mihomo): 内网域名走 system DNS + 本机域名钉进 hosts 跳过解析

### DIFF
--- a/sub-template.yaml
+++ b/sub-template.yaml
@@ -111,7 +111,7 @@ dns:
     "rule-set:Alibaba": *cn-dns
     "rule-set:Tencent": *cn-dns
     "rule-set:games-cn": *cn-dns
-    "rule-set:private": *cn-dns
+    "rule-set:private": ["system"]   # 内网域名(*.lan/*.local 等)只有本机/路由器的 DNS 知道，交给公共 DoH 必然解析失败
     "rule-set:cn-domain": *cn-dns
 
 hosts: 

--- a/xy-installer.py
+++ b/xy-installer.py
@@ -1959,6 +1959,42 @@ def _mihomo_direct_ip(tpl, targets):
         return tpl
     return re.sub(r"(?m)^rules:[ \t]*$", "rules:\n" + "\n".join(new), tpl, count=1)
 
+def _mihomo_hosts_pin(tpl, host, ip):
+    """mihomo：把本机域名钉进 hosts:，连节点时完全跳过 DNS 解析。
+
+       为什么值得做：节点域名能解析是所有节点能用的前置条件，默认它由
+       proxy-server-nameserver 里那串境外 DoH 在国内直连查，1.1.1.1/dns.google
+       这类在国内又慢又常被打断，等于每次冷启动都先卡在这一步。钉进 hosts 之后
+       这一步直接消失——resolver 查 hosts 命中就短路返回，根本走不到 DNS
+       (component/resolver/resolver.go 里 DefaultHosts.Search 在解析路径最前)，
+       比换任何 DNS 服务器都快，而且精确到这一个域名、不影响别的解析。
+       注：hosts 不受 use-hosts 开关门控（executor.go 的 updateHosts 无条件生效），
+       自定义模板里关了 use-hosts 也照样管用。
+
+       ⚠ 这会让订阅里出现本机真实 IP，与 _direct_targets「有域名就用域名、配置里
+       不出现裸 IP」的取舍相反。域名的 A 记录本来就是公开可查的，但分享订阅时这一行
+       等于把 IP 一起给出去了。
+
+       安全网：只在域名当前**确实解析到本机公网 IP** 时才钉。域名要是走了 CDN、
+       DDNS 指向别处或还没生效，钉死就会把节点连到错误的地址上，这种情况直接不写。
+       模板里没有 hosts: 段时原样返回。"""
+    if not re.match(r"^[A-Za-z0-9.-]+\.[A-Za-z]{2,}$", host or ""):
+        return tpl                                           # 本机是 IP 不是域名：没有可钉的域名
+    if not re.match(r"^\d+\.\d+\.\d+\.\d+$", ip or ""):
+        return tpl                                           # 拿不到本机公网 IP
+    try:                                                     # 多条 A 记录时只要包含本机 IP 就算数
+        a_records = {r[4][0] for r in socket.getaddrinfo(host, None, socket.AF_INET)}
+    except OSError:
+        return tpl                                           # 解析不了：无从校验，不冒险钉
+    if ip not in a_records:
+        return tpl                                           # 域名指向别处(CDN/DDNS/未生效)：钉了会连错地方
+    tpl = re.sub(r'(?m)^[ \t]*"%s"[ \t]*:[ \t]*[0-9a-fA-F.:]+[ \t]*$\n?' % re.escape(host),
+                 '', tpl)                                    # 幂等：先清旧的（换过 IP 也在这里被换掉）
+    if not re.search(r'(?m)^hosts:[ \t]*$', tpl):
+        return tpl
+    return re.sub(r'(?m)^(hosts:[ \t]*)$',
+                  lambda m: m.group(1) + f'\n  "{host}": {ip}', tpl, count=1)
+
 def _sb_direct_ip(cfg, targets):
     """sing-box：把直连规则插到 route.rules 最前（引用模板里的 🎯直连 出站）；
        就地改 cfg dict，交由 sb_dumps 按模板的紧凑风格序列化——不破坏格式。"""
@@ -2006,6 +2042,7 @@ def gen_mihomo(ylines, nodes, tpl_url):
     tpl = _fill_block(tpl, "__XY_GROUPS__", groups_yaml)
     tpl = tpl.replace("__XY_NAMES__", names_frag)          # 行内锚点：引用组名，原样替换
     tpl = _mihomo_direct_ip(tpl, _direct_targets(nodes))       # 各 VPS IP 直连（防管理时 SSH 走代理）
+    tpl = _mihomo_hosts_pin(tpl, _host(), _self_ip())          # 本机域名钉进 hosts：连节点时跳过 DNS 解析
     tpl = _mihomo_selfdns(tpl, _selfdns_doh())                 # 开关开启：把本机自建 DoH 加进 DNS（带兜底）
     open(CFG_FILE, "w").write(tpl)
 def gen_singbox(ylines, nodes, tpl_url):


### PR DESCRIPTION
两处 DNS 相关改动，互相独立。

## 1. `sub-template.yaml`：内网域名改由 system DNS 解析

`nameserver-policy` 里 `"rule-set:private"` 指向 `*cn-dns`，等于把 `*.lan` / `*.local` 这类内网域名交给阿里、腾讯的公共 DoH 解析——它们不可能知道你家路由器下的主机名，结果是必然解析失败。

改成 `["system"]`。注意**不能只是删掉这一条**：`private` 同时列在 `fake-ip-filter` 里，这些域名要走真解析，而 DNS 监听口应答走的是主 resolver（`nameserver` + `nameserver-policy`），不是 `direct-nameserver`——后者只给 DIRECT 出站在建连时用（`dns/resolver.go:615-624`）。所以删掉之后会落到 `nameserver` 那一串公共 DoH，一样解析不出来，必须显式指过去。

## 2. `xy-installer.py`：本机域名钉进 `hosts:`，连节点时跳过 DNS 解析

节点域名能解析是所有节点能用的前置条件，默认由 `proxy-server-nameserver` 里那串境外 DoH（1.1.1.1 / dns.google / quad9…）在国内直连查，又慢又常被打断，等于每次冷启动都先卡在这一步。

钉进 `hosts` 后这一步直接消失：resolver 查 hosts 命中即短路返回，走不到 DNS（`component/resolver/resolver.go` 里 `DefaultHosts.Search` 在解析路径最前面），比换任何 DNS 服务器都快，且精确到这一个域名、不影响其它解析。`hosts` 不受 `use-hosts` 门控（`hub/executor/executor.go` 的 `updateHosts` 无条件生效），自定义模板里关掉也照样管用。

**安全网**：只在域名当前确实解析到本机公网 IP 时才钉（多条 A 记录取包含关系）。走了 CDN、DDNS 指向别处或解析不出来时一律跳过，避免把节点连到错误地址。幂等，换 IP 会就地替换；模板无 `hosts:` 段时原样返回。

### 为什么没用 `proxy-server-nameserver-policy`

最初的方案是用它把节点域名钉到国内 DoH（带作用域，比全局改列表干净）。查证后放弃：**该键只存在于 Alpha 分支**，`v1.19.14` ~ `v1.19.18`（当前最新 stable）全都没有。而 mihomo 不做严格键校验——实测把键名故意打错一个字母，`mihomo -t` 照样报 successful。也就是说写进订阅后在所有 stable 内核的客户端上会被**静默忽略**：不报错、不生效，属于最难查的失败方式。

### 已知取舍

这会让订阅里出现本机真实 IP，与 `_direct_targets` 中「有域名就用域名、配置里不出现裸 IP（分享配置也不暴露真实 IP）」的既有取舍相反。域名 A 记录本就公开可查，但分享订阅时这一行等于把 IP 一并给出去。

## 验证

- `mihomo v1.19.16` 实跑 DNS 监听口：钉死后查该域名返回钉定 IP（hosts 压过 fake-ip），去掉该行返回 fake-ip `198.18.0.4`。
- `rule-set:private` 一条用反向对照确认真被解析：把值换成非法 scheme 会报 `DNS NameServer[0] unsupport scheme`。
- 注入逻辑单测：幂等、换 IP 就地替换，以及 A 记录不匹配 / 本机是 IP / 取不到 IP / 解析失败 / 模板无 `hosts:` 段五种情况全部 no-op。
- 注意 `mihomo -t` **校验不了 hosts 段**——`parseHosts` 里 `_ = tree.Insert(...)` 丢弃错误，非法 key 和值都会静默通过，所以才改用实跑验证。

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5bZ6JHN49z7zbHxVuxVyc)_