### PR TITLE
Revert #135：DNS 配置回到改动前的状态

### DIFF
--- a/sub-template.yaml
+++ b/sub-template.yaml
@@ -86,7 +86,6 @@ dns:
   proxy-server-nameserver: ["https://1.1.1.1/dns-query", "https://dns.google/dns-query", "https://cloudflare-dns.com/dns-query", "https://dns.quad9.net/dns-query", "https://dns.adguard.com/dns-query", "https://public.dns.iij.jp/dns-query", "tls://cloudflare-dns.com:853", "tls://dns.google:853"]  
   direct-nameserver-follow-policy: true
   nameserver-policy:
-    "rule-set:private": ["system"]   
     "rule-set:reject": ["https://dns.adguard.com/dns-query"]
     "rule-set:Google-zj": *global-dns
     "rule-set:OpenAI-zj": *global-dns
@@ -112,6 +111,7 @@ dns:
     "rule-set:Alibaba": *cn-dns
     "rule-set:Tencent": *cn-dns
     "rule-set:games-cn": *cn-dns
+    "rule-set:private": *cn-dns
     "rule-set:cn-domain": *cn-dns
 
 hosts: 

--- a/xy-installer.py
+++ b/xy-installer.py
@@ -1959,42 +1959,6 @@ def _mihomo_direct_ip(tpl, targets):
         return tpl
     return re.sub(r"(?m)^rules:[ \t]*$", "rules:\n" + "\n".join(new), tpl, count=1)
 
-def _mihomo_hosts_pin(tpl, host, ip):
-    """mihomo：把本机域名钉进 hosts:，连节点时完全跳过 DNS 解析。
-
-       为什么值得做：节点域名能解析是所有节点能用的前置条件，默认它由
-       proxy-server-nameserver 里那串境外 DoH 在国内直连查，1.1.1.1/dns.google
-       这类在国内又慢又常被打断，等于每次冷启动都先卡在这一步。钉进 hosts 之后
-       这一步直接消失——resolver 查 hosts 命中就短路返回，根本走不到 DNS
-       (component/resolver/resolver.go 里 DefaultHosts.Search 在解析路径最前)，
-       比换任何 DNS 服务器都快，而且精确到这一个域名、不影响别的解析。
-       注：hosts 不受 use-hosts 开关门控（executor.go 的 updateHosts 无条件生效），
-       自定义模板里关了 use-hosts 也照样管用。
-
-       ⚠ 这会让订阅里出现本机真实 IP，与 _direct_targets「有域名就用域名、配置里
-       不出现裸 IP」的取舍相反。域名的 A 记录本来就是公开可查的，但分享订阅时这一行
-       等于把 IP 一起给出去了。
-
-       安全网：只在域名当前**确实解析到本机公网 IP** 时才钉。域名要是走了 CDN、
-       DDNS 指向别处或还没生效，钉死就会把节点连到错误的地址上，这种情况直接不写。
-       模板里没有 hosts: 段时原样返回。"""
-    if not re.match(r"^[A-Za-z0-9.-]+\.[A-Za-z]{2,}$", host or ""):
-        return tpl                                           # 本机是 IP 不是域名：没有可钉的域名
-    if not re.match(r"^\d+\.\d+\.\d+\.\d+$", ip or ""):
-        return tpl                                           # 拿不到本机公网 IP
-    try:                                                     # 多条 A 记录时只要包含本机 IP 就算数
-        a_records = {r[4][0] for r in socket.getaddrinfo(host, None, socket.AF_INET)}
-    except OSError:
-        return tpl                                           # 解析不了：无从校验，不冒险钉
-    if ip not in a_records:
-        return tpl                                           # 域名指向别处(CDN/DDNS/未生效)：钉了会连错地方
-    tpl = re.sub(r'(?m)^[ \t]*"%s"[ \t]*:[ \t]*[0-9a-fA-F.:]+[ \t]*$\n?' % re.escape(host),
-                 '', tpl)                                    # 幂等：先清旧的（换过 IP 也在这里被换掉）
-    if not re.search(r'(?m)^hosts:[ \t]*$', tpl):
-        return tpl
-    return re.sub(r'(?m)^(hosts:[ \t]*)$',
-                  lambda m: m.group(1) + f'\n  "{host}": {ip}', tpl, count=1)
-
 def _sb_direct_ip(cfg, targets):
     """sing-box：把直连规则插到 route.rules 最前（引用模板里的 🎯直连 出站）；
        就地改 cfg dict，交由 sb_dumps 按模板的紧凑风格序列化——不破坏格式。"""
@@ -2042,7 +2006,6 @@ def gen_mihomo(ylines, nodes, tpl_url):
     tpl = _fill_block(tpl, "__XY_GROUPS__", groups_yaml)
     tpl = tpl.replace("__XY_NAMES__", names_frag)          # 行内锚点：引用组名，原样替换
     tpl = _mihomo_direct_ip(tpl, _direct_targets(nodes))       # 各 VPS IP 直连（防管理时 SSH 走代理）
-    tpl = _mihomo_hosts_pin(tpl, _host(), _self_ip())          # 本机域名钉进 hosts：连节点时跳过 DNS 解析
     tpl = _mihomo_selfdns(tpl, _selfdns_doh())                 # 开关开启：把本机自建 DoH 加进 DNS（带兜底）
     open(CFG_FILE, "w").write(tpl)
 def gen_singbox(ylines, nodes, tpl_url):


### PR DESCRIPTION
按要求把 #135 的两处改动整体撤回，DNS 相关配置恢复到 `9516262` 时的状态。

## 撤回的内容

- `sub-template.yaml`：`"rule-set:private"` 由 `["system"]` 改回 `*cn-dns`，并放回原来的位置（`games-cn` 之后、`cn-domain` 之前）。
- `xy-installer.py`：删除 `_mihomo_hosts_pin()` 及其在 `gen_mihomo()` 中的调用，不再往订阅的 `hosts:` 段写入本机域名。

## 保留的内容（不属于 #135，未受影响）

回退过程中与 `294fd23` 产生了冲突（那个提交把 `rule-set:private` 挪到了 `nameserver-policy` 顶部），已手工解决，只撤回 #135 引入的部分。以下改动全部原样保留：

- `75e9a62` — `SCRIPT_VERSION` 保持 `1.0.37`
- `55970dc` — `pg-anchor` 段删掉的那行注释保持删除状态

## 验证

回退后相对 `9516262` 的完整差异只剩下这两项他人改动，`#135` 引入的内容已全部消失：

```
sub-template.yaml | 1 -    # 55970dc 删掉的注释
xy-installer.py   | 2 +-   # SCRIPT_VERSION 1.0.36 → 1.0.37
```

`xy-installer.py` 通过 `py_compile`。`SHA256SUMS` 只跟踪 `net-optimize.py`，本次回退不涉及。

## 注意

`v1.0.37` 已经带着 #135 的改动发布过。已安装该版本的机器需要更新脚本并重新生成订阅，才能去掉配置里已写入的 `hosts:` 钉死行；客户端随后重拉订阅。

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5bZ6JHN49z7zbHxVuxVyc)_