### PR TITLE
fix: 订阅重生成跟随用户当前的模板选择；自建DNS 菜单3 改成「使用方法」并写清当前信息

### DIFF
--- a/adguard-dns.py
+++ b/adguard-dns.py
@@ -132,12 +132,68 @@ def _first_setup():
     print(f"  4) 完成后后台地址就是 \033[1;32mhttp://{ip}:{WEB_PORT}\033[0m；想改端口防扫描，回菜单选 \033[1;32m5\033[0m 改（带回滚，安全）")
     _usage(WEB_PORT)
 
+SELFDNS_FLAG     = BGP_DIR + "/selfdns.on"        # 主脚本：自建 DNS 是否已写进订阅
+SELFDNS_CID_FILE = BGP_DIR + "/selfdns.clientid"  # 主脚本生成的 AdGuard ClientID
+
+def _selfdns_clientid():
+    """读主脚本生成的 ClientID（只读，不生成——它由菜单 6 打开写入订阅时创建）。"""
+    try:
+        return open(SELFDNS_CID_FILE).read().strip()
+    except OSError:
+        return ""
+
+def _doh_port():
+    """当前 DoH(HTTPS) 端口：从 AdGuardHome.yaml 的 tls.port_https 读，读不到按 10443。"""
+    try:
+        p = int(_yaml_val(_tls_block(open(_agh_yaml()).read()), "port_https") or 0)
+        return p or 10443
+    except (OSError, ValueError):
+        return 10443
+
+def _allowed_clients():
+    """AdGuardHome.yaml 里的访问白名单 allowed_clients；没这个键返回 None，空列表返回 []。"""
+    try:
+        return _yaml_list(open(_agh_yaml()).read(), "allowed_clients")
+    except OSError:
+        return None
+
 def _usage(port=None):
-    """一步步的使用说明：登录后台 → 开加密 → 设备指过来。写给不懂的人看。"""
+    """一步步的使用说明：当前配置一览 → 登录后台 → 开加密 → 设备指过来。写给不懂的人看。"""
     ip = _public_ip(); dom = _domain()
     port = port or _current_web_port() or WEB_PORT
-    G = "\033[1;32m"; Y = "\033[1;33m"; N = "\033[0m"     # 绿=要填的值，黄=提示
+    G = "\033[1;32m"; Y = "\033[1;33m"; R = "\033[1;31m"; C = "\033[1;36m"; N = "\033[0m"
+    dohp = _doh_port(); cid = _selfdns_clientid()
+    enc = _https_panel() is not None
+    allow = _allowed_clients()
+    doh_url = f"https://{dom}:{dohp}/dns-query" + (f"/{cid}" if cid else "")
+
     print("\n" + "  " + "=" * 56)
+    print(f"  {C}当前配置信息{N}（下面的值都是从你这台机实时读出来的）")
+    print("  " + "=" * 56)
+    print(f"    域名          : {G}{dom or '（无，只能用明文 53）'}{N}")
+    print(f"    公网 IP       : {G}{ip}{N}")
+    print(f"    后台端口      : {G}{port}{N}")
+    print(f"    加密(DoT/DoH) : {(G+'已开启'+N) if enc else (Y+'未开启 —— 第二步去开'+N)}")
+    print(f"    DoH 端口      : {G}{dohp}{N}        DoT 端口: {G}853{N}       明文: {G}53{N}")
+    if cid:
+        print(f"    {C}ClientID{N}      : {G}{cid}{N}")
+        print(f"                    {Y}这是给「访问设置 → 允许的客户端」用的{N}，填了它就只放行你自己；")
+        print(f"                    不填的话你的 DoH 挂在公网上，{R}谁扫到都能当免费解析器用{N}。")
+    else:
+        print(f"    ClientID      : {Y}还没有 —— 菜单『6 把自建DNS写入订阅配置』打开一次即生成{N}")
+    if allow:
+        print(f"    访问白名单    : {G}已设置{N} {allow}")
+        print(f"      {R}⚠ 白名单一旦设置，只有能带上 ClientID 的方式才进得来：{N}")
+        print(f"        · DoH  {G}可以{N}（ID 在网址末段）")
+        print(f"        · DoT / 明文53  {R}会被挡掉{N} —— DoT 传 ID 要靠 tls://<ID>.域名 的 SNI，")
+        print(f"          {R}需要泛域名证书{N}(*.域名)，而本机 acme 只签了单域名；明文 53 根本没有 ID 机制。")
+        print(f"        要继续用安卓 DoT / 电视明文，得把设备 IP 也加进白名单（家宽 IP 会变，不好使）。")
+    else:
+        print(f"    访问白名单    : {Y}未设置 —— 对全公网开放{N}"
+              + (f"（建议填入上面的 ClientID）" if cid else ""))
+    print(f"    写入订阅      : {(G+'已写入 mihomo/小火箭'+N) if os.path.exists(SELFDNS_FLAG) else (Y+'未写入（菜单 6 开关）'+N)}")
+
+    print("\n  " + "=" * 56)
     print("  怎么用它去广告 —— 照着下面三步做")
     print("  " + "=" * 56)
 
@@ -174,14 +230,16 @@ def _usage(port=None):
         print(f"        手机：设置 → 网络 → 专用DNS → 选『私人DNS提供商主机名』→ 填：{G}{dom}{N}")
         print(f"        需要：先做完第二步开加密；VPS 防火墙放行 {G}853{N}(TCP)")
         print(f"    ③ DoH 加密 —— 电脑浏览器 / 支持 DoH 的 App")
-        print(f"        DoH 地址：  {G}https://{dom}:10443/dns-query{N}")
-        print(f"        需要：VPS 防火墙放行 {G}10443{N}(TCP)")
+        print(f"        DoH 地址：  {G}{doh_url}{N}")
+        if cid:
+            print(f"        {Y}↑ 末段那串就是 ClientID，必须带上{N}（设了白名单之后不带会被拒）")
+        print(f"        需要：VPS 防火墙放行 {G}{dohp}{N}(TCP)")
 
     print("\n  " + "-" * 56)
     print("  三种 DNS 怎么选（一句话）：")
     print(f"    · 明文 53     简单通用、不加密 —— 电视/IoT/内网设备")
     print(f"    · DoT 853     加密、安卓系统原生支持、一次设置全系统去广告 {Y}【首选】{N}")
-    print(f"    · DoH 10443   加密、浏览器/App 用；因本机 443 被节点占，所以带端口")
+    print(f"    · DoH {dohp}   加密、浏览器/App 用；因本机 443 被节点占，所以带端口")
     print("\n  想拦更多广告：")
     print("    · 后台 → 过滤器 → DNS 拦截列表 → 添加名单（推荐 anti-AD：https://anti-ad.net/easylist.txt）")
     print("    · 后台 → 查询日志 → 找到广告域名 → 点『屏蔽』")
@@ -686,7 +744,7 @@ def menu():
         print("-" * 60)
         print("  1 安装（装 AdGuard Home + 起服务，之后网页后台点几下完成设置）")
         print("  2 卸载（彻底移除，不动节点；若写过订阅会自动从订阅撤掉自建DNS并刷新）")
-        print("  3 查看状态 / 设备怎么设置")
+        print("  3 使用方法（当前配置信息 + 设备怎么设置，照着填即可）")
         print("  4 腾出 53 端口（被 systemd-resolved 占用时用）")
         print("  5 改后台端口（随机 2000-5000 / 自定义，防扫描；带回滚）")
         print("  6 把自建DNS写入订阅配置（开/关：第一次写入·再点移除，自动刷新）")

--- a/xy-installer.py
+++ b/xy-installer.py
@@ -66,6 +66,7 @@ TOKENS_FILE  = BGP_DIR + "/tokens.json"      # 每格式独立订阅 token
 LINKS_FILE   = BGP_DIR + "/nodes.links"      # 本机节点链接（供多机聚合拉取的 .links 端点）
 PEERS_FILE   = BGP_DIR + "/peers.json"       # 聚合的成员机 .links 地址列表
 CUSTPL_FILE  = BGP_DIR + "/custom_tpl.json"  # 每格式自定义模板链接（gist/GitHub）
+TPLSRC_FILE  = BGP_DIR + "/tpl_source.json"  # 每格式当前用的是哪套模板："author" / "custom"
 BT_STATE     = BGP_DIR + "/bt.json"          # BT/PT 下载屏蔽开关状态
 SUBPORT_FILE = BGP_DIR + "/sub.port"         # 订阅托管端口（首装随机挑一次永久沿用，每台机器不同）
 _RAW         = "https://raw.githubusercontent.com/bgpeer/nodekit/main/"
@@ -2172,6 +2173,32 @@ def del_custpl(ext):
 def tpl_url_for(ext, custom=False):
     return (load_custpl().get(ext) if custom else "") or FMT[ext]["author"]
 
+def load_tplsrc():   return _load_json(TPLSRC_FILE)
+def set_tplsrc(ext, src):
+    """记住该格式当前用的是哪套模板（"author"/"custom"）。三个格式各记各的。"""
+    d = load_tplsrc(); d[ext] = src
+    os.makedirs(BGP_DIR, exist_ok=True); json.dump(d, open(TPLSRC_FILE, "w"), ensure_ascii=False, indent=2)
+
+def tpl_src_of(ext):
+    """该格式当前该用哪套模板。没有记录时的兜底：有自定义链接就算自定义（沿用老装行为），
+       否则作者模板——第一次用的人本来就是作者模板。"""
+    src = load_tplsrc().get(ext)
+    if src in ("author", "custom"):
+        return src if (src == "author" or load_custpl().get(ext)) else "author"
+    return "custom" if load_custpl().get(ext) else "author"
+
+def tpl_url_current(ext):
+    """按【用户当前的选择】取模板 URL —— 所有会重新生成订阅的功能都该走这里。
+
+       为什么不能一律优先自定义：多路复用开关、GitHub 中转、自建 DNS 这些功能都会顺手
+       重生成订阅。原先它们写死 custom=True，于是只要设过自定义链接，哪怕你后来在
+       『更新配置』里明确选了作者模板，下次一按开关又被悄悄换回自定义模板——用户看到的
+       配置跟他以为的不是同一份，而且没有任何提示。改成跟随最后一次的显式选择。
+       三个格式互相独立：可以 mihomo 用自己的、sing-box 用作者的。"""
+    if tpl_src_of(ext) == "custom":
+        return load_custpl().get(ext) or FMT[ext]["author"]
+    return FMT[ext]["author"]
+
 # ============================================================================ 多机聚合
 def load_peers():
     try: return [u for u in json.load(open(PEERS_FILE)) if u]
@@ -2281,7 +2308,7 @@ def build_subscription(all_links, new_token=False):
     os.makedirs(BGP_DIR, exist_ok=True)
     for ext, meta in FMT.items():
         try:
-            meta["gen"](ylines, nodes, tpl_url_for(ext, custom=True))
+            meta["gen"](ylines, nodes, tpl_url_current(ext))   # 跟随该格式当前选的模板
         except Exception as e:
             print(f"{meta['label']} 配置生成跳过:", e)
     open(HOST_FILE, "w").write(G["host"])              # 记住 host（域名优先）
@@ -2650,7 +2677,9 @@ def _validate_generated(ext, path):
     return True, ""
 
 def _regen_config(ext, url, which):
-    """用指定模板重生成单格式配置；不动节点、不换 token；失败回滚保留原配置。返回是否成功。"""
+    """用指定模板重生成单格式配置；不动节点、不换 token；失败回滚保留原配置。返回是否成功。
+       成功后记住这次用的是哪套模板（which），之后多路复用/中转/自建DNS 等功能重生成
+       订阅时会跟着这个选择走，不再被自定义链接单方面劫持。"""
     if not read_saved_links():
         print("  没有已保存节点。"); return False
     G["host"] = _host(); ensure_deps()
@@ -2671,7 +2700,10 @@ def _regen_config(ext, url, which):
             print("     " + ln)
         return False
     serve_sub()                                                     # 保持 token，URL 不变
+    set_tplsrc(ext, "custom" if which == "自定义" else "author")    # 记住选择，后续功能跟着走
     print(f"\n  ✅ 更新成功（{which}模板，节点/URL 未变）：\n  {sub_url(ext)}")
+    print(f"  ▸ {FMT[ext]['label']} 之后一律按【{which}模板】生成"
+          f"（多路复用/GitHub中转/自建DNS 改动时也跟着它）。")
     return True
 
 def update_one_config(ext):
@@ -2694,9 +2726,12 @@ def config_menu(ext):
     while True:
         cust = load_custpl().get(ext)
         print("\n" + "=" * 60 + f"\n{meta['label']} 配置\n" + "=" * 60)
+        src = tpl_src_of(ext)
         print(f"  配置文件: {meta['file']}")
         print(f"  当前订阅: {sub_url(ext)}")
         print(f"  自定义模板: {cust or '(未设置)'}")
+        print(f"  ▸ 当前生效: 【{'自定义模板' if src == 'custom' else '作者模板'}】"
+              f"  ← 多路复用/GitHub中转/自建DNS 重生成订阅时也用它")
         print("-" * 60)
         print("  1 修改配置（编辑器打开）")
         print("  2 修改订阅（显示当前 / 换 token）")
@@ -2719,8 +2754,8 @@ def config_menu(ext):
                 print("  1 更换   2 删除（改回作者模板）   0 返回")
                 s = _ask("  选择: ").strip()
                 if s == "2":
-                    del_custpl(ext)
-                    print("  ✓ 已删除自定义模板链接，之后『3 更新配置』默认用作者模板。")
+                    del_custpl(ext); set_tplsrc(ext, "author")   # 链接没了，当前选择同步切回作者
+                    print("  ✓ 已删除自定义模板链接，之后一律用作者模板。")
                     if _ask("  现在就用作者模板重新生成一次配置? [y/N]: ").lower() in ("y", "yes"):
                         _regen_config(ext, FMT[ext]["author"], "作者")   # 立即生效
                     continue


### PR DESCRIPTION
## 一、模板选择被自定义链接单方面劫持

`build_subscription()` 写死了 `tpl_url_for(ext, custom=True)`——**只要设过一次自定义模板链接，之后所有会重新生成订阅的功能都强制用自定义模板**，哪怕用户后来在「更新配置」里明确选了作者模板。

于是：按一下多路复用开关、GitHub 中转、自建 DNS，配置就被悄悄换回自定义模板，而且**没有任何提示**。用户看到的配置跟他以为的不是同一份。

> 这个 bug 就是这么暴露的：ClientID 明明写进去了，但同一份生成出来的配置里，DNS 段还是几天前的旧模板。

### 改动

- 新增 `TPLSRC_FILE`（`/etc/bgpeer/tpl_source.json`）记录**每个格式**当前用的是哪套模板，三个格式各记各的——可以 mihomo 用自己的、sing-box 用作者的。
- `_regen_config()` 成功后写入该记录；删除自定义链接时同步切回 `author`。
- `build_subscription()` 改用 `tpl_url_current(ext)` 跟随该记录。
- **无记录时的兜底**：有自定义链接就算自定义（沿用老装行为，不惊动已有用户），否则作者模板。
- 配置菜单顶部与更新成功后都显示「当前生效: 作者/自定义模板」，不再是隐形状态。

### 按需求描述逐条单测

| 场景 | 结果 |
|---|---|
| 第一次用（什么都没设） | 作者模板 |
| 设了自定义链接（老装兼容） | 自定义 |
| 在「更新配置」里选了自定义 | 自定义 |
| **又改选了作者模板** | **作者** ← 原来的 bug |
| 另一个格式互不影响 | 独立 |
| 删掉自定义链接 | 作者 |
| 异常态：记录为 custom 但链接已删 | 兜底回作者，不崩 |

## 二、自建 DNS 菜单 3「查看状态」→「使用方法」

原说明把 DoH 地址写成 `https://域名:10443/dns-query`——**端口写死、且不含 ClientID**。用户照着填，在设了白名单之后会被直接拒掉，而说明里根本没提 ClientID 的存在。

### 改动

顶部新增「当前配置信息」区块，全部**从本机实时读出来**：域名、公网 IP、后台端口、加密状态、DoH/DoT/明文端口、**ClientID**、访问白名单、是否已写入订阅。重要值高亮。

第三步的 DoH 地址带上 ClientID，并注明必须带。

**并高亮一条此前没人提过的坑**——一旦设了白名单：

```
⚠ 白名单一旦设置，只有能带上 ClientID 的方式才进得来：
  · DoH  可以（ID 在网址末段）
  · DoT / 明文53  会被挡掉 —— DoT 传 ID 要靠 tls://<ID>.域名 的 SNI，
    需要泛域名证书(*.域名)，而本机 acme 只签了单域名；明文 53 根本没有 ID 机制。
```

这条不写清楚的话，用户按建议设了白名单，就会把菜单里自己标着「**首选**」的安卓 DoT 打死，而且是静默失效。

## 验证

- 模板选择：上表七个场景全部单测通过。
- `_usage()`：用构造的 `AdGuardHome.yaml`（含 `port_https`、`allowed_clients`）实跑渲染，确认端口、ClientID、白名单警告均按实际配置正确输出。
- `py_compile` 双文件通过。

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5bZ6JHN49z7zbHxVuxVyc)_