### PR TITLE
fix(sub): 节点直连规则改用域名后缀，覆盖 AdGuard DoT 的 ClientID 子域

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -1948,8 +1948,14 @@ def _direct_targets(nodes):
     return out
 
 def _direct_rule_text(kind, val):
-    """mihomo / 小火箭通用规则文本：IP 走 IP-CIDR(+no-resolve)，域名走 DOMAIN。"""
-    return f"IP-CIDR,{val}/32,DIRECT,no-resolve" if kind == "ip" else f"DOMAIN,{val},DIRECT"
+    """mihomo / 小火箭通用规则文本：IP 走 IP-CIDR(+no-resolve)，域名走 DOMAIN-SUFFIX。
+
+       域名用后缀而不是精确匹配，是因为节点域名底下会长出子域名：AdGuard 的 DoT 要带
+       ClientID 时用的是 <ID>.节点域名（见 adguard-dns.py 菜单 8）。精确匹配漏掉它，
+       那条查询就会掉进 MATCH 走代理——绕一圈再回到自己的 VPS，多一跳，代理挂了还可能
+       连不上。用后缀只扩到「本节点域名及其子域」，不扩到整个注册域，以后在同一个域名下
+       挂想走代理的东西仍有余地。"""
+    return f"IP-CIDR,{val}/32,DIRECT,no-resolve" if kind == "ip" else f"DOMAIN-SUFFIX,{val},DIRECT"
 
 def _ghrelay_token():
     """本机中转的 token（防别人蹭）；没有就生成一个存下来。存 BGP_DIR（不在 SUB_DIR，不会被静态服务下载）。"""
@@ -2096,7 +2102,9 @@ def _mihomo_direct_ip(tpl, targets):
 
 def _sb_direct_ip(cfg, targets):
     """sing-box：把直连规则插到 route.rules 最前（引用模板里的 🎯直连 出站）；
-       就地改 cfg dict，交由 sb_dumps 按模板的紧凑风格序列化——不破坏格式。"""
+       就地改 cfg dict，交由 sb_dumps 按模板的紧凑风格序列化——不破坏格式。
+       域名用 domain_suffix 而非 domain，理由同 _direct_rule_text：要覆盖节点域名
+       底下的子域（AdGuard DoT 的 <ClientID>.节点域名）。"""
     if not targets:
         return
     route = cfg.get("route")
@@ -2112,7 +2120,7 @@ def _sb_direct_ip(cfg, targets):
     add = []
     for kind, val in targets:
         rule = {"ip_cidr": [f"{val}/32"], "outbound": direct} if kind == "ip" \
-               else {"domain": [val], "outbound": direct}
+               else {"domain_suffix": [val], "outbound": direct}
         if rule not in rules and rule not in add:
             add.append(rule)
     if add:


### PR DESCRIPTION
## 问题

订阅里自动插入的节点直连规则，域名一直用的是精确匹配：

- mihomo / 小火箭：`DOMAIN,节点域名,DIRECT`
- sing-box：`{"domain": ["节点域名"], "outbound": "🎯直连"}`

`adguard-dns.py` 菜单 8 装完带 ClientID 的 DoT 之后，客户端实际连的是
`<ClientID>.节点域名`（AdGuard 用 SNI 里的子域来识别 ClientID）。精确匹配盖不住这个子域，
那条 DNS 流量就会掉到 `MATCH` 走代理——绕回自己的 VPS 多一跳，代理一挂还可能连不上 DNS。

## 改动

`xy-installer.py` 两处：

- `_direct_rule_text()`：域名分支 `DOMAIN` → `DOMAIN-SUFFIX`
- `_sb_direct_ip()`：`{"domain": [val]}` → `{"domain_suffix": [val]}`

IP 规则不动，仍是 `IP-CIDR,x.x.x.x/32,DIRECT,no-resolve`。

后缀只扩到「本节点域名及其子域」，不扩到整个注册域，所以同一个域名下以后要挂想走代理的
东西仍然有余地。

## 验证

生成后的配置：

- mihomo `-t` 校验通过；`sing-box check`（1.14.0-beta.7）通过
- 产出规则：`DOMAIN-SUFFIX,dmcn2.679588.xyz,DIRECT` ×4 + `IP-CIDR,1.2.3.4/32,DIRECT,no-resolve`
- sing-box 产出：`{"domain_suffix": ["dmcn2.679588.xyz"], "outbound": "🎯直连"}`
- `domain_suffix` 对照 sing-box 1.14 源码 `option/rule.go:148` 确认字段名正确

实跑对照（本地起 http.server，mihomo 只留一条直连规则 + `MATCH,REJECT`）：

| 规则写法 | `test.local` | `sub.test.local` |
| --- | --- | --- |
| `DOMAIN`（改前） | HTTP 200 命中直连 ✓ | HTTP 502 未命中，被 REJECT ✗ |
| `DOMAIN-SUFFIX`（改后） | HTTP 200 命中直连 ✓ | HTTP 200 命中直连 ✓ |

## 说明

规则里仍然会带上聚合订阅内其他机器的域名/IP，这是有意为之（见 `_direct_targets` 的注释）：
挂着聚合代理去管理任意一台成员机时，SSH／管理流量都走直连，不会被重启核心掐断。

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5bZ6JHN49z7zbHxVuxVyc)_