### PR TITLE
fix: 单条放行菜单里直接贴域名也认

### DIFF
--- a/cn-block.py
+++ b/cn-block.py
@@ -589,8 +589,14 @@ def custom_allow_menu():
         print(f"\n  {Y}域名按后缀匹配{N}：填 example.com，它和它的所有子域都放行")
         print("  1 添加（可一次多个，逗号分隔）   2 删除   0 返回")
         c = _ask("  选择: ").strip()
+        # 直接在这里贴域名/IP 也认。上面写着「1 添加（可一次多个，逗号分隔）」，
+        # 紧接着就是「选择」，很容易让人以为在这儿直接输 —— 实际使用中就是这么
+        # 填了一次、看到「还没添加」以为功能坏了。与其让他白填，不如认下来。
+        pre = ""
+        if c not in ("", "0", "1", "2") and re.search(r"[.:]", c):
+            pre, c = c, "1"
         if c == "1":
-            s = _ask("  输入域名或IP(可逗号分隔，如 baidu.com,1.2.3.4,10.0.0.0/8): ").strip()
+            s = pre or _ask("  输入域名或IP(可逗号分隔，如 baidu.com,1.2.3.4,10.0.0.0/8): ").strip()
             if not s:
                 continue
             added = 0


### PR DESCRIPTION
## 问题

菜单长这样：

```
域名按后缀匹配：填 example.com，它和它的所有子域都放行
1 添加（可一次多个，逗号分隔）   2 删除   0 返回
选择： 
```

「可一次多个，逗号分隔」紧接着就是「选择：」，很容易让人以为在这儿直接输域名。实际使用中就是这么填了一次 `quark.cn,open-api-drive.quark.cn`，回车后看到「（还没添加）」，以为是功能坏了。

## 改动

在「选择」处输入**带点或冒号**的内容，直接当域名/IP 走添加流程，不用先按 `1`。

菜单数字 `0`/`1`/`2` 的行为完全不变，其它无效输入照旧提示。

## 验证

| 输入 | 归类 |
|---|---|
| `1` / `2` / `0` / 空 | 菜单原有行为 ✓ |
| `quark.cn` | 当作域名直接添加 ✓ |
| `quark.cn,open-api-drive.quark.cn` | 当作域名直接添加 ✓ |
| `1.2.3.4` / `10.0.0.0/8` / `2403:71c0::/32` | 当作 IP 直接添加 ✓ |
| `abc` / `3` | 无效选择（不误判）✓ |

实际的校验和去重仍走原有的 `parse_wl_entry()`，格式不对照样会被拦下并提示。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_