### PR TITLE
feat: xhttp 显式写出 host，不再依赖客户端的回退

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -1097,8 +1097,11 @@ def xr_reality_xhttp(port, tag):
     ib = {"listen": "0.0.0.0", "port": port, "protocol": "vless", "tag": tag,
           "settings": {"clients": [{"id": uid}], "decryption": "none"},
           "streamSettings": st}
+    # host 显式带上、并与 sni 保持一致：mihomo 留空时会回退到 servername，结果一样，
+    # 但写出来就不依赖客户端的回退实现，换客户端/版本也不会变。
     lk = (f"vless://{uid}@{G['host']}:{port}?encryption=none&security=reality"
-          f"&sni={G['sni']}&fp=chrome&pbk={pub}&sid={sid}&type=xhttp&path={path}#{tag}")
+          f"&sni={G['sni']}&fp=chrome&pbk={pub}&sid={sid}&type=xhttp"
+          f"&host={G['sni']}&path={path}#{tag}")
     return ib, lk
 
 def _xr_tls(certfile, keyfile):
@@ -1241,14 +1244,16 @@ def link_to_proxy(u):
             if mlkem_ok():
                 d["reality-opts"]["support-x25519mlkem768"] = "true"
             if net == "grpc": d["network"] = "grpc"; d["grpc-opts"] = {"grpc-service-name": qs.get("serviceName") or qs.get("path", "")}
-            elif net == "xhttp": d["network"] = "xhttp"; d["xhttp-opts"] = {"path": qs.get("path", "/")}  # xray 专属
+            # xhttp 的 host 显式写出：mihomo 留空会回退到 servername(结果相同)，
+            # 但别的客户端未必这么回退，写死更稳。xray 专属传输。
+            elif net == "xhttp": d["network"] = "xhttp"; d["xhttp-opts"] = {"path": qs.get("path", "/"), "host": qs.get("host") or qs.get("sni") or host}
             else: d["network"] = "tcp"
         else:
             if insec: d["skip-cert-verify"] = "true"
             if net == "ws": d["network"] = "ws"; d["ws-opts"] = {"path": qs.get("path", "/"), "headers": {"Host": qs.get("host", host)}}
             elif net == "httpupgrade": d["network"] = "ws"; d["ws-opts"] = {"path": qs.get("path", "/"), "headers": {"Host": qs.get("host", host)}, "v2ray-http-upgrade": "true"}
             elif net == "grpc": d["network"] = "grpc"; d["grpc-opts"] = {"grpc-service-name": qs.get("serviceName") or qs.get("path", "")}
-            elif net == "xhttp": d["network"] = "xhttp"; d["xhttp-opts"] = {"path": qs.get("path", "/")}
+            elif net == "xhttp": d["network"] = "xhttp"; d["xhttp-opts"] = {"path": qs.get("path", "/"), "host": qs.get("host") or qs.get("sni") or host}
             else: d["network"] = "tcp"
             if qs.get("smux") == "1" and d.get("network") == "ws": d["smux"] = _SMUX
         return d


### PR DESCRIPTION
## 先说清楚：原来的配置并没有坏

查了 mihomo 的源码（`adapter/outbound/vless.go`），XHTTP 的 Host 取值顺序是：

```go
requestHost := v.option.XHTTPOpts.Host
if requestHost == "" {
    if v.option.ServerName != "" {
        requestHost = v.option.ServerName
    } else {
        requestHost = v.option.Server
    }
}
```

`xhttp-opts.host` → `servername` → 服务器地址。而我们生成的配置一直有 `servername`（reality 的 sni），所以留空时 mihomo 实际用的就是 `www.oracle.com`，和显式写出来完全一致。

## 但还是值得写出来

依赖回退不是好事：别的客户端未必这么兜，mihomo 自己将来也可能改。Host 头与 SNI 保持一致本来就是伪装的要求，显式写出来一眼可见，不用去翻源码猜。

## 改动

- reality xhttp 分享链接补上 `&host=<sni>`
- mihomo 的 `xhttp-opts` 两个分支（reality / 非 reality）都补 `host`，取值顺序 `qs.host` → `qs.sni` → 服务器地址

`host` 是 mihomo `XHTTPOptions` 里的合法字段（`proxy:"host,omitempty"`），已核对结构体定义。

## 验证

直接调用脚本里的 `link_to_proxy()` 转换：

| 场景 | 产物 |
|---|---|
| reality xhttp（新链接带 host） | `{'path': '/f077c3', 'host': 'www.oracle.com'}` ✓ |
| **老链接（不带 host）** | `{'path': '/f077c3', 'host': 'www.oracle.com'}` — 回退到 sni，兼容 ✓ |
| CDN xhttp（非 reality） | `{'path': '/p1', 'host': 'cdn.example.com'}` ✓ |
| grpc 回归 | `{'grpc-service-name': 'gsvc'}`，未受影响 ✓ |

老的分享链接（历史上生成、已经导进客户端的那些）不需要重新导入，转换时照样能兜到 sni。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_