### PR TITLE
fix: Emby 健康检查改打 /System/Info/Public，并补回搜索框

### DIFF
--- a/SHA256SUMS
+++ b/SHA256SUMS
@@ -1,2 +1,2 @@
-233442b75844a594944eb1f1b3fc31b491f08bad4ff4f620d7674ec6d35ca9aa  media-stack.py
+65f0cdcdb94e9545c4d321590453af5f578ace2dab4f0e4800dd63bd79f047ce  media-stack.py
 06c572efea477f1d88617fd8f46bd7efa535d37645d0af619d73ca3f13a9d6fe  net-optimize.py

--- a/media-stack.py
+++ b/media-stack.py
@@ -520,8 +520,12 @@ layout:
     # 健康检查要打「实际在监听的那个容器:端口」，不是卡片名字对应的容器。
     # Emby 的对外入口是 MediaWarp（9000），Emby 自己在 8096 —— 早先这里拼成了
     # emby:9000，那个端口上什么都没有，卡片就一直显示错误码。
+    # 打专门的健康检查端点，别打根路径：Emby 的 / 会 302 跳到 /web/index.html，
+    # MediaWarp 原样透传，Homepage 收到跳转就把卡片标成异常（显示 RESPONSE）。
+    # /System/Info/Public 是 Emby 的公开信息接口，不需要认证、稳定返回 200 JSON。
     monitor = {
-        "emby":     f"http://mediawarp:{MEDIAWARP_PORT}",
+        "emby":     f"http://mediawarp:{MEDIAWARP_PORT}/System/Info/Public",
+        # OpenList 打根路径就正常返回 200，别改成 /ping —— 现在是好的，不动它
         "openlist": f"http://openlist:{OPENLIST_PORT}",
         "homepage": "http://homepage:3000",
     }
@@ -539,6 +543,9 @@ layout:
     cpu: true
     memory: true
     disk: /
+- search:
+    provider: duckduckgo
+    target: _blank
 """
     return settings, "\n".join(services) + "\n", widgets
 


### PR DESCRIPTION
## 问题

上一版（#165）把 `siteMonitor` 指对了容器（`mediawarp:9000`），卡片从 `500` 变成了 `RESPONSE`——连接通了，但仍然报错。

原因是打的**根路径**：Emby 的 `/` 会 302 跳转到 `/web/index.html`，MediaWarp 原样透传这个跳转，Homepage 收到重定向就把卡片标成异常。

## 改动

改打 `/System/Info/Public`——Emby 的公开信息接口，**不需要认证、稳定返回 200 JSON**，是这类健康检查的标准端点。

```
emby → http://mediawarp:9000/System/Info/Public
```

**OpenList 那条不动**：它打根路径本来就正常（卡片显示 `10 MS`），没必要改一个正在工作的东西。

顺带补回 Homepage 的**搜索框**——bash 版的 `widgets.yaml` 里有 `search` 这一项，移植时漏了。

## 验证

生成的配置经 PyYAML 解析：

| 卡片 | siteMonitor |
|---|---|
| Emby | `http://mediawarp:9000/System/Info/Public` ✓ |
| OpenList | `http://openlist:5244`（未改动）✓ |

widgets：`[{'resources': {...}}, {'search': {'provider': 'duckduckgo', 'target': '_blank'}}]` ✓

跑「15 → 4 更新」即可应用，会重刷 Homepage 配置并重启容器。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_