### PR TITLE
fix: 更新时先把脚本自己换成最新版，修复的配置才到得了机器上

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -25,8 +25,12 @@ import string
 import subprocess
 import sys
 import time
+import urllib.request
 
-SCRIPT_VERSION = "1.0.0"
+SCRIPT_VERSION = "1.1.0"
+
+# 本脚本在仓库里的地址，「更新」时用它把自己换成最新版
+SELF_URL = "https://raw.githubusercontent.com/bgpeer/nodekit/main/media-stack.py"
 
 # ---- 节点（xy-installer.py）的落盘状态，只读 ----
 BGP_DIR    = "/etc/bgpeer"
@@ -753,7 +757,11 @@ case "${1:-info}" in
   restart) shift; dc restart "$@" && echo "已重启" ;;
   start|up)   dc up -d ;;
   stop|down)  dc down ;;
-  update)  dc pull && dc up -d && echo "已更新到最新镜像" ;;
+  update)
+    # 走脚本的更新流程，而不是只 pull 镜像 —— 两条路必须做同一件事，
+    # 否则从这里更新的人拿不到配置修复，只会以为"更新过了还是老样子"
+    S=/etc/bgpeer/media-stack.py
+    if [[ -f "$S" ]]; then python3 "$S" update; else dc pull && dc up -d; fi ;;
   strm)
     docker restart autofilm >/dev/null 2>&1 || { echo "autofilm 没在运行"; exit 1; }
     echo "已触发 strm 生成，Ctrl-C 可退出日志跟踪:"; docker logs -f --tail 50 autofilm ;;
@@ -923,29 +931,76 @@ def rebuild_cfg_from_disk(d):
     return cfg
 
 
+def self_update():
+    """把脚本自己换成仓库里的最新版；换过了返回 True，调用方应立刻 re-exec。
+
+    没有这一步，「更新」只是按【这台机器上现有的那份脚本】重新生成一遍配置 ——
+    仓库里修好的东西永远到不了机器上。之前 Homepage 的健康检查地址在仓库里改了
+    两轮，用户那边 services.yaml 却一字未变，就是卡在这里。
+
+    URL 上带时间戳绕开 CDN 缓存：raw.githubusercontent 和各家镜像都会缓存几分钟
+    到几小时，不绕开的话「刚推的修复」拉下来还是旧的，看起来就像改了没用。
+    """
+    me = os.path.realpath(__file__)
+    if not os.access(me, os.W_OK):
+        return False
+    try:
+        req = urllib.request.Request(f"{SELF_URL}?_t={int(time.time())}",
+                                     headers={"User-Agent": "media-stack"})
+        body = urllib.request.urlopen(req, timeout=20).read().decode()
+    except Exception as e:
+        warn(f"拉取最新脚本失败（{e}）")
+        print(f"  {DIM}继续用本机这份 v{SCRIPT_VERSION} 刷新配置。{RST}")
+        return False
+    # 只接受长得像本脚本的内容，别把一页 404/限流提示写进去，那会直接废掉这个文件
+    if "SCRIPT_VERSION" not in body or len(body) < 10000:
+        warn("拉到的内容不像 media-stack.py，已忽略，继续用本机这份。")
+        return False
+    try:
+        if body == open(me, encoding="utf-8").read():
+            return False
+    except OSError:
+        return False
+    m = re.search(r'SCRIPT_VERSION\s*=\s*"([^"]+)"', body)
+    tmp = me + ".new"
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write(body)
+    os.chmod(tmp, 0o755)
+    os.replace(tmp, me)          # 先写临时文件再原子替换，中途断网也不会留个半截脚本
+    ok(f"脚本已更新：v{SCRIPT_VERSION} → v{m.group(1) if m else '?'}，用新版继续...")
+    return True
+
+
 def do_update():
-    """更新：拉最新镜像 + 按当前脚本重新生成配置。用户数据和密码都不动。"""
+    """更新：脚本自身 + 镜像 + 按新脚本重新生成配置。用户数据和密码都不动。"""
     d = ms_install_dir()
     if not is_installed(d):
         warn(f"还没安装（{d} 下没有 docker-compose.yml）。先选 1 安装。")
         return
+
+    if self_update():
+        me = os.path.realpath(__file__)
+        os.execv(sys.executable, [sys.executable, me, "update"])
+
     compose = os.path.join(d, "docker-compose.yml")
     env_file = os.path.join(d, ".env")
 
+    # 镜像拉不动就跳过，不再 return —— 跨境网络本来就时好时坏，
+    # 而下面重刷配置才是修 bug 的那一步，不该被一次拉取失败连坐掉。
     info("拉取最新镜像...")
     r = subprocess.run(f"docker compose -f {compose} --env-file {env_file} pull",
                        shell=True, timeout=1800)
     if r.returncode != 0:
-        err("拉取镜像失败，看上面的报错。")
-        return
-    info("用新镜像重启容器...")
-    r = subprocess.run(f"docker compose -f {compose} --env-file {env_file} up -d",
-                       shell=True, timeout=900)
-    if r.returncode != 0:
-        err("重启失败，看上面的报错。")
-        return
-    ok("镜像已更新")
-    sh("docker image prune -f", timeout=300)
+        warn("拉取镜像失败（网络问题居多），跳过换镜像，继续刷新配置。")
+    else:
+        info("用新镜像重启容器...")
+        r = subprocess.run(f"docker compose -f {compose} --env-file {env_file} up -d",
+                           shell=True, timeout=900)
+        if r.returncode != 0:
+            warn("用新镜像重启失败，看上面的报错；配置照常刷新。")
+        else:
+            ok("镜像已更新")
+            sh("docker image prune -f", timeout=300)
 
     # 再把脚本生成的那几份配置按当前版本重刷一遍。
     # 只重刷「纯脚本产物」：nginx 站点、Homepage 导航。
@@ -977,7 +1032,7 @@ def do_update():
         os.chmod(cred, 0o600)
 
     print()
-    ok("更新完成：镜像、nginx 站点、导航面板都已是当前版本")
+    ok(f"更新完成（脚本 v{SCRIPT_VERSION}）：镜像、nginx 站点、导航面板都已是当前版本")
     print(f"  {DIM}Emby API Key、网盘挂载路径、cron 这些你填的东西没有被动过。{RST}")
 
 

--- a/xy-installer.py
+++ b/xy-installer.py
@@ -3015,13 +3015,27 @@ def uninstall_all():
 
 # ============================================================================ 屏蔽中国域名/IP（独立文件）
 def ensure_remote_script(url, local):
-    """把仓库里的脚本拉到本地（每次尽量拉最新）；拉不到就用本地缓存。"""
+    """把仓库里的脚本拉到本地（每次尽量拉最新）；拉不到就用本地缓存。
+
+    两个坑都在这几行里踩过：
+      · 原来是 open(local,"w").write(fetch_url(url))，Python 会先把本地文件截成
+        0 字节再去发请求，网络一抖缓存就没了；而 os.path.exists 依然为真，于是
+        "成功"跑起一个空脚本，菜单点进去毫无反应。改成拉全、校验、再原子替换。
+      · URL 上带时间戳绕开 CDN 缓存：raw.githubusercontent 和 jsDelivr 都会缓存
+        几分钟到几小时，仓库明明改了、机器上拉到的还是旧版，修复就一直到不了。
+    """
     os.makedirs(BGP_DIR, exist_ok=True)
     try:
-        open(local, "w").write(fetch_url(url))
+        sep = "&" if "?" in url else "?"
+        body = fetch_url(f"{url}{sep}_t={int(time.time())}")
+        if body.strip():
+            tmp = local + ".new"
+            with open(tmp, "w") as f:
+                f.write(body)
+            os.replace(tmp, local)
     except Exception:
         pass
-    return os.path.exists(local)
+    return os.path.exists(local) and os.path.getsize(local) > 0
 
 def ensure_cn_block():
     return ensure_remote_script(CN_BLOCK_URL, CN_BLOCK_LOCAL)


### PR DESCRIPTION
## 问题

机器上的 `services.yaml` 里，Emby 的健康检查地址一直是 `http://emby:9000`。Emby 实际监听 8096，9000 是 MediaWarp，所以 Homepage 日志里刷的是：

```
error: <httpProxy> Error calling http://emby:9000/...
Error: connect ECONNREFUSED 172.18.0.4:9000
```

这处地址在仓库里已经改对两轮（#165、#166），机器上却一字未变。所以问题不在生成逻辑，在**更新链路**——修好的代码根本到不了机器上。

## 改了什么

- **`do_update()` 现在先更新脚本自己再干活。** 原来它只是按「这台机器上现有的那份脚本」重新生成一遍配置，脚本自身不更新，仓库里的修复就永远送不到。现在先拉最新版、原子替换、`os.execv` 原地重启。
- **`ensure_remote_script()` 会清空本地缓存。** 原来写作 `open(local,"w").write(fetch_url(url))`——Python 先求值 `open(local,"w")` 把文件截成 0 字节，再去发请求。网络一抖缓存就没了，而 `os.path.exists` 依然为真，于是「成功」跑起一个空脚本，菜单点进去毫无反应。改成拉全、校验非空、写临时文件再原子替换。
- **下载 URL 带时间戳绕开 CDN 缓存。** `raw.githubusercontent` 和 jsDelivr 镜像都会缓存几分钟到几小时，不绕开就会拉到刚推之前的旧版——仓库明明改了，机器上拉下来还是老的。
- **拉镜像失败不再连坐掉刷新配置。** 原来 `docker compose pull` 非零就 `return`，后面刷新 nginx 站点和 Homepage 配置的步骤全被跳过。跨境网络时好时坏，而刷配置才是修 bug 的那一步。现在拉不动只警告，配置照刷。
- **`media-stack update` 和菜单「4 更新」统一。** CLI 那条原来只做 `pull && up -d`，不刷配置，从这条路更新的人拿不到任何配置修复，只会觉得「更新过了还是老样子」。
- **`SCRIPT_VERSION` → 1.1.0。** 菜单标题会打印版本号，可以直接看出机器上跑的是不是最新那份。

## 与节点的边界

没有变化，AST 静态核对过全部写入点：仍然只**读** `state.json` / `nginx.conf`，只**写** `/etc/nginx/conf.d/media-stack.conf`、自己的安装目录、`/usr/local/bin/media-stack`。新增的写入目标是脚本文件自身（`/etc/bgpeer/media-stack.py`），本来就是 `xy-installer.py` 给它的缓存位置。`bgpeer.conf` / `bgpeer-stream.conf` / `nginx.conf` / `state.json` 一个都没碰。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_