### PR TITLE
fix: media-stack strm 真正跑一次任务，而不是只重启容器

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -764,8 +764,49 @@ case "${1:-info}" in
     S=/etc/bgpeer/media-stack.py
     if [[ -f "$S" ]]; then python3 "$S" update; else dc pull && dc up -d; fi ;;
   strm)
+    # AutoFilm v2 没有手动触发的入口:./autofilm --help 只有 --config/--log/--timezone
+    # 这些开关,启动时也只注册 cron、不跑任务。所以这里临时把 cron 改成每分钟,
+    # 跑完一轮立刻还原 —— 不能让它一直每分钟去撸网盘,夸克那边风控很严。
+    CFG="${D}/autofilm/config/config.yaml"
+    [[ -f "$CFG" ]] || { echo "找不到 ${CFG}"; exit 1; }
+    BAK="${CFG}.strmbak.$$"
+    cp "$CFG" "$BAK" || exit 1
+    LP=""
+    restore() {
+      [[ -n "$LP" ]] && { kill "$LP" 2>/dev/null; wait "$LP" 2>/dev/null; }
+      # 还原是必须发生的,哪怕用户中途 Ctrl-C、哪怕 docker 命令失败
+      if [[ -f "$BAK" ]]; then
+        mv -f "$BAK" "$CFG"
+        docker restart autofilm >/dev/null 2>&1
+        echo; echo "${y}已还原原来的定时设置。${r}"
+      fi
+    }
+    # INT/TERM 只负责退出:bash 跑完信号处理函数后默认【继续往下执行】,
+    # 直接把 restore 挂在 INT 上的话,Ctrl-C 会还原配置然后接着轮询六分钟。
+    # 还原统一交给 EXIT,正常结束和被中断走同一条路。
+    trap 'exit 130' INT TERM
+    trap restore EXIT
+
+    sed -i 's|cron: ".*"|cron: "0 * * * * *"|' "$CFG"
+    TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     docker restart autofilm >/dev/null 2>&1 || { echo "autofilm 没在运行"; exit 1; }
-    echo "已触发 strm 生成，Ctrl-C 可退出日志跟踪:"; docker logs -f --tail 50 autofilm ;;
+    echo "${b}已临时改成每分钟跑一次,最多等 60 秒开始。跑完自动还原。${r}"
+    echo
+
+    docker logs -f --since "$TS" autofilm 2>&1 &
+    LP=$!
+    # 轮询完成标记而不是死等日志:任务跑完后日志就安静了,
+    # 只跟着 docker logs 的话会一直挂在那里,得靠人去按 Ctrl-C
+    for _ in $(seq 1 90); do            # 4s x 90 ≈ 6 分钟封顶
+      sleep 4
+      if docker logs --since "$TS" autofilm 2>&1 | grep -q "Alist2Strm 任务完成"; then
+        sleep 1; break
+      fi
+    done
+    echo
+    echo "${b}看上面那行「Alist2Strm 任务完成」里的 strm_created_count / strm_skipped_count。${r}"
+    echo "${y}skipped 不是失败,是文件已经在了。之后去 Emby 扫一次媒体库。${r}"
+    ;;
   302)
     echo "跟踪 MediaWarp 日志。现在去播放一集，看到 302 就说明直链生效:"
     docker logs -f --tail 20 mediawarp ;;


### PR DESCRIPTION
## 问题

`media-stack strm` 号称「立刻跑一次 strm 生成」，实际只做了 `docker restart autofilm`。但 **AutoFilm v2 启动时只注册 cron、不执行任务**：

```
INFO autofilm::schedule: 添加 Alist2Strm 定时任务 task_id=网盘 cron=0 0 5 * * *
INFO autofilm::schedule: 全部子任务调度完成 scheduled_count=1
INFO autofilm: AutoFilm 调度器启动完成 scheduled_count=1
```

日志到这里就没了。重启多少次都一样，真正跑要等到 cron 那个点（默认每天 05:00）。用户敲完命令看着日志刷了一堆启动信息，以为触发了，其实什么都没发生。

AutoFilm v2 也没有手动触发的入口：

```
$ ./autofilm --help
Usage: autofilm [OPTIONS]
Options:
      --debug / --config <PATH> / --log <PATH> / --timezone <TZ> / --colorful-log
```

没有 `run`、没有 `alist2strm`、没有 `--now`。

## 改法

临时把 cron 改成每分钟 → 重启 → 轮询日志等到「Alist2Strm 任务完成」→ 还原原来的 cron 并再重启一次。不能让它一直每分钟去撸网盘，夸克那边风控很严。

轮询完成标记而不是死等 `docker logs -f`：任务跑完日志就安静了，光跟着日志会一直挂在那儿等人按 Ctrl-C。

## 还原必须万无一失

还原挂在 `EXIT` trap 上，正常结束、Ctrl-C、`docker restart` 失败走的是同一条路。

`INT`/`TERM` 只负责 `exit 130`——**直接把还原函数挂在 `INT` 上是错的**：bash 跑完信号处理函数后默认继续往下执行，Ctrl-C 会还原配置然后接着轮询六分钟。这个在测试里实际复现了，才改成现在这样。

## 验证

四种情况实测（用假的 `docker` 命令注入场景）：

| 场景 | cron 还原 | 无 `.strmbak` 残留 |
|---|---|---|
| 正常跑完 | ✓ | ✓ |
| 中途 Ctrl-C | ✓（3 秒内退出） | ✓ |
| autofilm 没在跑（restart 失败） | ✓ | ✓ |
| 配置文件不存在 | 不动任何东西 | ✓ |

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_