### PR TITLE
fix: media-stack strm 明确提示别中途 Ctrl-C

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -797,7 +797,10 @@ case "${1:-info}" in
     sed -i 's|cron: ".*"|cron: "0 * * * * *"|' "$CFG"
     TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     docker restart autofilm >/dev/null 2>&1 || { echo "autofilm 没在运行"; exit 1; }
-    echo "${b}已临时改成每分钟跑一次,最多等 60 秒开始。跑完自动还原。${r}"
+    echo "${b}已临时改成每分钟跑一次,最多等 60 秒开始。${r}"
+    echo "${y}跑完会自己退出并还原定时设置 —— 中途别按 Ctrl-C,那会把任务掐断,"
+    echo "strm 只生成一半,Emby 里就会报「找不到目录」。${r}"
+    echo "${b}等到出现「Alist2Strm 任务完成」那一行为止,中间安静一阵是正常的。${r}"
     echo
 
     docker logs -f --since "$TS" autofilm 2>&1 &


### PR DESCRIPTION
## 问题

旧版 `media-stack strm` 是 `docker logs -f`，要靠人按 Ctrl-C 退出。新版（#170）跑完会自己退出，但提示语没说清楚，习惯没改过来就会在这一行掐掉：

```
15:50:00  开始扫描 AList 目录 task_id=网盘 source_dir=/quark^C
已还原原来的定时设置。
```

任务刚起步就被打断，56 个 strm 只落了 1 个，`电影/` 子目录压根没轮到。然后在 Emby 里添加媒体库就报：

```
找不到目录 "/data/strm/cloud/电影"
```

用户合理地怀疑是脚本屏蔽了什么文件，实际上只是任务没跑完。

## 改法

提示里写清三件事：

```
已临时改成每分钟跑一次,最多等 60 秒开始。
跑完会自己退出并还原定时设置 —— 中途别按 Ctrl-C,那会把任务掐断,
strm 只生成一半,Emby 里就会报「找不到目录」。
等到出现「Alist2Strm 任务完成」那一行为止,中间安静一阵是正常的。
```

「中间安静一阵是正常的」这句是必要的——等 cron 触发那 60 秒里日志确实没有任何输出，看起来很像卡住了。

## 验证

`bash -n` 通过；把这几行单独 `eval` 出来确认渲染正常。里面用的是全角「」而不是半角引号——半角双引号会把 `echo "..."` 的字符串提前截断。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_