### PR TITLE
fix: strm 触发改成单次，不再让多轮任务并发互删

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -772,8 +772,8 @@ case "${1:-info}" in
     if [[ -f "$S" ]]; then python3 "$S" update; else dc pull && dc up -d; fi ;;
   strm)
     # AutoFilm v2 没有手动触发的入口:./autofilm --help 只有 --config/--log/--timezone
-    # 这些开关,启动时也只注册 cron、不跑任务。所以这里临时把 cron 改成每分钟,
-    # 跑完一轮立刻还原 —— 不能让它一直每分钟去撸网盘,夸克那边风控很严。
+    # 这些开关,启动时也只注册 cron、不跑任务。所以这里临时把 cron 改成
+    # "两分钟后的那一分钟"、只触发一次,跑完立刻还原成用户原来的定时设置。
     CFG="${D}/autofilm/config/config.yaml"
     [[ -f "$CFG" ]] || { echo "找不到 ${CFG}"; exit 1; }
     BAK="${CFG}.strmbak.$$"
@@ -794,10 +794,25 @@ case "${1:-info}" in
     trap 'exit 130' INT TERM
     trap restore EXIT
 
-    sed -i 's|cron: ".*"|cron: "0 * * * * *"|' "$CFG"
+    # 定成"每分钟"是错的:一轮跑不完下一轮就压上来,几轮任务并发扫同一个目录、
+    # 互相删对方刚写出去的 strm(实测跨境网络慢时一轮要 121 秒,同时跑了三轮,
+    # 最后 io error: No such file or directory)。改成【指定时刻只触发一次】。
+    # 时刻要按 autofilm 容器自己的时区算 —— 调度器用的是容器里的本地时间,
+    # 拿宿主机的时间去填,时区一差就永远等不到。
+    CT="$(docker exec autofilm date +'%H %M' 2>/dev/null)"
+    if [[ -z "$CT" ]]; then CT="$(date +'%H %M')"; fi
+    read -r CH CM <<<"$CT"
+    T=$(( (10#$CH * 60 + 10#$CM + 2) % 1440 ))     # +2 分钟,留足重启和对齐的余量
+    FH="$(printf '%02d' $((T / 60)))"; FM="$(printf '%02d' $((T % 60)))"
+    # 引号用变量带进去。这整段是 Python 的三引号字符串,在里面用反斜杠转义双引号
+    # 会被 Python 自己吃掉,落到 bash 里就是引号错乱的一行,sed 静默不替换 ——
+    # 而且不报错,只是 cron 没改成,人会以为是网盘慢。用变量就完全绕开这个坑。
+    q='"'
+    sed -i "s|cron: ${q}.*${q}|cron: ${q}0 $FM $FH * * *${q}|" "$CFG"
+
     TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     docker restart autofilm >/dev/null 2>&1 || { echo "autofilm 没在运行"; exit 1; }
-    echo "${b}已临时改成每分钟跑一次,最多等 60 秒开始。${r}"
+    echo "${b}已安排在 ${FH}:${FM}(容器时间)触发一次,最多等 2 分钟开始。${r}"
     echo "${y}跑完会自己退出并还原定时设置 —— 中途别按 Ctrl-C,那会把任务掐断,"
     echo "strm 只生成一半,Emby 里就会报「找不到目录」。${r}"
     echo "${b}等到出现「Alist2Strm 任务完成」那一行为止,中间安静一阵是正常的。${r}"
@@ -806,8 +821,10 @@ case "${1:-info}" in
     docker logs -f --since "$TS" autofilm 2>&1 &
     LP=$!
     # 轮询完成标记而不是死等日志:任务跑完后日志就安静了,
-    # 只跟着 docker logs 的话会一直挂在那里,得靠人去按 Ctrl-C
-    for _ in $(seq 1 90); do            # 4s x 90 ≈ 6 分钟封顶
+    # 只跟着 docker logs 的话会一直挂在那里,得靠人去按 Ctrl-C。
+    # 封顶给到 15 分钟:网盘慢的时候一轮真的能跑十几分钟,提前收工会让人
+    # 以为"又失败了",其实还在跑。
+    for _ in $(seq 1 225); do           # 4s x 225 = 15 分钟封顶
       sleep 4
       if docker logs --since "$TS" autofilm 2>&1 | grep -q "Alist2Strm 任务完成"; then
         sleep 1; break


### PR DESCRIPTION
## 问题

`media-stack strm` 把 cron 临时设成「每分钟」，这个设计假设了一轮十几秒能跑完。跨境网络慢的时候一轮要 121 秒，于是第 2、3 轮压了上来：

```
16:07:00  开始扫描 AList 目录 source_dir=/quark
16:08:00  开始扫描 AList 目录 source_dir=/quark     ← 上一轮还在跑
16:09:00  开始扫描 AList 目录 source_dir=/quark     ← 又一轮
16:09:01  任务完成 duration=121.148s scanned_dir_count=0 local_deleted_count=1
16:09:01  ERROR Alist2Strm 任务失败 error=io error: No such file or directory (os error 2)
```

几轮任务并发扫同一个目录，`sync.enabled: true` 让它们互相删对方刚写出去的 strm。表现是目录一会儿多一个、一会儿又没了，看着像随机不稳定。

## 改法

cron 设成「**两分钟后的那一分钟**」，只触发一次，从根上不可能重叠。

时刻按 **autofilm 容器自己的时区**算——调度器用的是容器里的本地时间，拿宿主机时间去填，时区一差就永远等不到那个点。`docker exec autofilm date` 拿不到时回落到宿主机时间。

轮询封顶从 6 分钟放宽到 15 分钟：网盘慢的时候一轮真能跑十几分钟，提前收工会让人以为又失败了。

## 顺带修一个静默失效的坑

sed 那行原本写成：

```python
sed -i "s|cron: \".*\"|cron: \"0 $FM $FH * * *\"|" "$CFG"
```

`CLI_TEMPLATE` 是 Python 的 `'''...'''` 字符串，里面的 `\"` 会被 **Python 自己**解析成 `"`。落到 bash 里变成：

```bash
sed -i "s|cron: ".*"|cron: "0 $FM $FH * * *"|" "$CFG"
```

引号错乱，sed **不报错也不替换**——cron 根本没改成，人只会以为是网盘慢。改成用变量 `q='"'` 带引号，完全绕开这一类坑。

这个是测试里发现的：断言「运行期间 cron 应该变成单次触发的时刻」时看到它还是原值。

## 验证

| 用例 | 运行期间 cron | 还原后 | 残留 |
|---|---|---|---|
| 容器时间 16:09 | `0 11 16 * * *` | `0 0 5 * * *` | 无 |
| 跨天 23:59 | `0 01 00 * * *` | `0 0 5 * * *` | 无 |
| `docker exec` 失败 | 回落宿主机时间 | `0 0 5 * * *` | 无 |
| 中途 Ctrl-C | — | `0 0 5 * * *` | 无 |

时刻计算另测了前导零（`09 08` → 09:10，`10#` 前缀避开八进制解析）和整点跨越。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_