### PR TITLE
fix: strm 智能保护阈值填反了，小媒体库会被整库误删

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -435,8 +435,14 @@ alist2strm_tasks:
       enabled: true         # 网盘删了文件，本地 strm 跟着删
       ignore:
       smart_protection:
-        enabled: true       # 防止网盘抽风返回空目录时把整个媒体库误删
-        threshold: 100
+        enabled: true
+        # threshold 是「待删除数量达到多少【才】启动保护」，不是「超过多少就不删」。
+        # 原来写 100 等于给小媒体库判了死刑：库里只有几十个 strm 时永远够不到阈值，
+        # 保护形同虚设 —— 夸克列目录超时一次(跨境线路上是家常便饭)，AutoFilm 就当
+        # 远端文件没了，把整库 strm 一次删光，Emby 里媒体库瞬间变空。实际就这么丢过。
+        # 填 1 表示「只要有文件要删就先进保护」，配合 grace_scans 连续确认 3 轮，
+        # 网络抖一两次不会误删，真在网盘里删掉的文件第 3 轮之后照样会清理。
+        threshold: 1
         grace_scans: 3
 """
 


### PR DESCRIPTION
## 问题

生成的 AutoFilm 配置里：

```yaml
    sync:
      enabled: true
      smart_protection:
        enabled: true       # 防止网盘抽风返回空目录时把整个媒体库误删
        threshold: 100
```

注释写的是「防止误删」，实际效果正相反。上游文档写得很清楚：

> `threshold: 100  # 触发保护的待删除 .strm 数量阈值`

`threshold` 是「待删除数量达到多少**才**启动保护」，不是「超过多少就不删」。填 100 等于给小媒体库判了死刑——库里只有几十个 strm 时永远够不到阈值，保护形同虚设。

## 实际后果

用户的库有 56 个 strm。夸克列目录超时一次（跨境线路上是家常便饭）：

```
skipped_dir_count=1  discovered_file_count=0  local_deleted_count=...
```

AutoFilm 认为远端文件没了 → 56 < 100 → 不进保护 → 一次删光。Emby 媒体库瞬间变空。

用户反复遇到「OpenList 里文件都在，Emby 里却是空的」，重建媒体库也没用——因为磁盘上的 strm 是真被删了，而且每天 05:00 的定时任务撞上一次网络抖动就再清空一次。

## 改法

```yaml
        threshold: 1
        grace_scans: 3
```

`threshold: 1` = 只要有文件要删就先进保护；`grace_scans: 3` = 连续三轮都确认该删才真删。网络抖一两次不会误删，真在网盘里删掉的文件第三轮之后照样清理。

对网盘这种「远端偶尔返回空目录」的数据源，这才是这两个参数该有的组合。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_