### PR TITLE
fix: 默认关掉同步删除，别让失败的扫描把已生成的媒体库越删越少

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -33,6 +33,10 @@ SCRIPT_VERSION = "1.1.0"
 # 本脚本在仓库里的地址，「更新」时用它把自己换成最新版
 SELF_URL = "https://raw.githubusercontent.com/bgpeer/nodekit/main/media-stack.py"
 
+# 容器日志里的 ANSI 颜色码。解析日志前必须剥掉，否则字段名被转义序列包着，
+# 正则一个都匹配不到（而粘贴出来的文本又是干净的，极难察觉）
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
 # ---- 节点（xy-installer.py）的落盘状态，只读 ----
 BGP_DIR    = "/etc/bgpeer"
 STATE_FILE = BGP_DIR + "/state.json"        # 含 domain / sni_split 等
@@ -432,16 +436,23 @@ alist2strm_tasks:
       other_ext: []
       concurrency: 5
     sync:
-      enabled: true         # 网盘删了文件，本地 strm 跟着删
+      # 默认【关】。同步删除的前提是"扫描结果可信"，而网盘扫描根本不满足这个前提：
+      # 跨境线路上列目录超时是常态，AutoFilm 跳过该目录照样报"任务完成"，于是那
+      # 一整个目录的文件就被判定为"远端已删除"，本地 strm 跟着清掉。
+      # 实际后果：第一轮扫出 387 个文件、生成 56 个 strm；之后每轮只扫到一两个，
+      # 每轮都删掉一批 —— 跑得越多剩得越少，用户看到的是"越搞越拉垮"。
+      #
+      # 先前试过 smart_protection.threshold 从 100 改成 1 来堵，堵不住：
+      # 只要扫描本身不可靠，同步删除就是个错误的默认值。
+      # 权衡很清楚 —— 网盘里删掉的文件在本地留个失效 strm，点开报错而已；
+      # 而整库被清空是灾难，而且现象诡异到根本查不出原因。
+      # 真要开就把 enabled 改成 true，下面的保护参数已经调好了。
+      enabled: false
       ignore:
       smart_protection:
         enabled: true
         # threshold 是「待删除数量达到多少【才】启动保护」，不是「超过多少就不删」。
-        # 原来写 100 等于给小媒体库判了死刑：库里只有几十个 strm 时永远够不到阈值，
-        # 保护形同虚设 —— 夸克列目录超时一次(跨境线路上是家常便饭)，AutoFilm 就当
-        # 远端文件没了，把整库 strm 一次删光，Emby 里媒体库瞬间变空。实际就这么丢过。
-        # 填 1 表示「只要有文件要删就先进保护」，配合 grace_scans 连续确认 3 轮，
-        # 网络抖一两次不会误删，真在网盘里删掉的文件第 3 轮之后照样会清理。
+        # 填 1 表示「只要有文件要删就先进保护」，配合 grace_scans 连续确认 3 轮。
         threshold: 1
         grace_scans: 3
 """
@@ -1691,7 +1702,11 @@ def do_strm():
             # 合并 stdout 和 stderr：不同版本的 AutoFilm/Docker 日志落在哪一路
             # 并不一致，只读 stdout 会漏掉统计数字（表现是最后那行全是问号）
             r = sh(f"docker logs --since {since} autofilm", timeout=60)
-            out = (r.stdout or "") + (r.stderr or "")
+            # 先剥掉 ANSI 颜色码：AutoFilm 默认 --colorful-log，日志里的字段名被
+            # 转义序列包着(strm_created_count 前后各有一段 \x1b[..m)，直接拿正则
+            # 找 xxx_count=数字 一个都匹配不到，最后只能打出一排问号。
+            # 这个坑很隐蔽：粘贴到聊天/文档里时终端把颜色码剥掉了，看起来完全干净。
+            out = ANSI_RE.sub("", (r.stdout or "") + (r.stderr or ""))
             for ln in out.splitlines():
                 if "Alist2Strm 任务完成" in ln:
                     done = ln                      # 不 break：取最后一条，也就是最新那轮


### PR DESCRIPTION
## 问题

用户的原话是「第一次都扫出来了，后面就越搞越拉垮」。不是错觉，机制很确定：

```
第一轮    discovered_file_count=387   strm_created_count=56
之后每轮  只扫到一两个（跨境线路列目录超时）   local_deleted_count=1..N
```

AutoFilm 跳过列不出来的目录之后**照样报「任务完成」**，于是那一整个目录的文件被判定成「远端已删除」，本地 strm 跟着清掉。跑得越多剩得越少。最后 56 个 strm 只剩 1 个。

## 改法

**`sync.enabled` 默认改成 `false`。**

同步删除的前提是「扫描结果可信」，而网盘扫描根本不满足这个前提。之前把 `smart_protection.threshold` 从 100 改成 1 想堵这个洞（#175），堵不住——只要扫描本身不可靠，同步删除就是个错误的默认值。

权衡也很清楚：

| | 后果 |
|---|---|
| 关掉同步 | 网盘里删掉的文件在本地留个失效 strm，点开报错而已 |
| 开着同步 | 整库被清空，而且现象诡异到根本查不出原因 |

保护参数保留在配置里，想开的人把 `enabled` 改成 `true` 就行。

## 顺带修一个隐蔽的解析 bug

上一个 PR（#178）加的统计输出仍然打出一排问号：

```
✔ 生成完成，AutoFilm 的统计行：
  bdmv_selected_count=0 strm_created_count=0 ...
```

原因是 AutoFilm 默认 `--colorful-log`，日志里字段名被 ANSI 转义序列包着——`strm_created_count` 前后各有一段 `\x1b[..m`，正则 `([a-z_]+_count)=(\d+)` 一个都匹配不到。

这个坑很隐蔽：**粘贴到聊天或文档里时终端把颜色码剥掉了，看起来完全干净**，所以对着日志文本怎么看都觉得正则没问题。解析前统一剥离。

## 验证

用带 ANSI 的真实格式复现：剥离前解析结果为空（正是那排问号），剥离后七个计数全部取到；纯文本不受影响。`gen_autofilm_conf` 断言 `sync.enabled: false`。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_