### PR TITLE
fix: 直链缓存 10m 太短，一部电影要重换九次，每次都可能卡 30 秒

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -479,7 +479,14 @@ log:
 cache:
   enable: true
   http_strm_ttl: 1m
-  alist_api_ttl: 10m
+  # 默认 10m 太短。每次缓存过期,MediaWarp 就要让 OpenList 重新去网盘换一次直链;
+  # 跨境线路上这个调用实测 0.3 秒到 44 秒不等,还经常直接超时 —— 日志里表现为
+  #   404 | 30.3s | GET /emby/Videos/11/stream
+  # 播放器等不到地址,画面就停在那儿。一部 93 分钟的电影按 10m 算要换约 9 次,
+  # 等于把 9 次赌博串进一次观影。
+  # 夸克直链的 auth_key 实测有效期约 30 小时,缓存 2 小时安全余量很足,
+  # 一部片子只需要成功换一次。
+  alist_api_ttl: 2h
   image_ttl: 10m
   subtitle_ttl: 2h
 


### PR DESCRIPTION
## 证据

MediaWarp 日志里播放期间的真实表现：

```
13:13:13 | 404 | 30.336688152s | GET /emby/Videos/11/stream
13:13:44 | 404 | 30.331373760s | GET /emby/Videos/11/stream.strm
13:14:15 | 404 | 30.427849374s | GET /emby/Videos/11/stream.strm
13:14:47 | 302 | 14.686443959s | GET ...stream.strm     ← 成功，但等了 14.7 秒
13:14:51 | 302 | 10.204118240s | GET ...stream          ← 10.2 秒
```

每次缓存过期，MediaWarp 就要让 OpenList 重新去网盘换一次直链。这个调用在跨境线路上实测 **0.3 秒到 44 秒不等，还经常直接超时变成 404**（对应 OpenList 日志里那些 `open-api-drive.quark.cn ... i/o timeout`）。播放器等不到地址，画面就停在那儿。

用户描述的「过两秒卡一下、网速只有几百 KB」就是这么来的——不是带宽不够（实测手机 78 Mbps、VPS 到夸克 3.4 MB/s），是在等地址。

## 改法

`alist_api_ttl` 从 `10m` 改成 `2h`。

一部 93 分钟的电影按 10 分钟算要重换约 9 次直链，等于把 9 次赌博串进一次观影。而夸克直链的 `auth_key` 实测有效期约 **30 小时**（`auth_key=1786822629-...` 换算），缓存 10 分钟纯属浪费。

2 小时的安全余量仍然很足，一部片子只需要成功换一次。

## 说明

这不能解决根本问题——从这台 VPS 访问夸克 API 本身就不稳定，那是跨境线路的事，服务端改不了。但它把「每部电影暴露 9 次」压到「1 次」，是这一层能做的最大改善。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_