### PR TITLE
fix: 更新完立刻热一次网盘链路，别让人更新完就撞上转圈

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -1528,6 +1528,18 @@ def do_update():
             f.write(build_summary(cfg, colored=False) + "\n")
         os.chmod(cred, 0o600)
 
+    # 更新过程重启了容器，连接池被清空，这一刻链路是【冷的】——
+    # 不补这一下的话，更新完马上去播，第一部片八成要转圈几十秒，
+    # 而用户会以为是这次更新弄坏了什么。顺便也立刻验证网盘还通不通。
+    info("热一下网盘链路...")
+    do_keepalive()
+    ka = keepalive_state(d)
+    if ka.get("ok"):
+        ok(f"网盘链路已热好（{ka.get('elapsed', 0)}s），现在去播不会卡在开头")
+    elif ka:
+        warn(f"网盘暂时不通：{ka.get('error', '')}")
+        print(f"  {DIM}和这次更新无关，是线路问题。保活每 {KEEPALIVE_MIN} 分钟会自己重试。{RST}")
+
     print()
     ok(f"更新完成（脚本 v{SCRIPT_VERSION}）：镜像、nginx 站点、导航面板都已是当前版本")
     print(f"  {DIM}Emby API Key、网盘挂载路径、cron 这些你填的东西没有被动过。{RST}")


### PR DESCRIPTION
## 问题

用户问「点更新之后是不是会自动唤醒一次」。查了流程，答案是**不会，而且恰恰相反**。

`do_update()` 会重启容器（`docker compose up -d` + `docker restart mediawarp/autofilm`），OpenList 到网盘的连接池被清空——**更新完那一刻链路是最冷的**。这时候去播第一部片八成要转圈几十秒。

而用户很自然会把这个归因到「刚更新完就坏了」。这个误导比问题本身更麻烦。

## 改法

在容器重启完、打印总结之前补一次保活：

```
>>> 热一下网盘链路...
✔ 网盘链路已热好（0.4s），现在去播不会卡在开头
```

顺带立刻验证网盘还通不通。不通时明说：

```
⚠ 网盘暂时不通：网盘接口超时
  和这次更新无关，是线路问题。保活每 20 分钟会自己重试。
```

**最后那句是专门加的**——更新后紧接着出问题最容易被归因到更新头上，这句话挡的就是这个。

## 验证

静态核对 `do_update` 里的顺序：重启容器 → 热链路 → 打印总结，三者位置递增。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_