### PR TITLE
fix: 列目录没有耗时阈值，47 秒也判绿还报「全部正常」

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2654,8 +2654,18 @@ def do_healthcheck():
                 _hc(f"列目录 {p}", "warn", f"{el:.1f} 秒  空目录")
                 todo.append((f"{p} 是空的", "路径写错了？或者网盘里这个目录本来就没东西"))
             else:
-                _hc(f"列目录 {p}", "ok", f"{el:.1f} 秒  {len(items)} 项")
+                # 列目录也要看耗时。以前只给「换直链」设了阈值,列目录无论多慢都判绿,
+                # 结果出现过「列目录 47.0 秒」和结论「全部正常」同屏 —— 那比不体检更误导。
+                # 而且这一项直接决定「生成媒体库」跑不跑得完:AutoFilm 每个目录都要列一次,
+                # 47 秒一个目录,几十个目录就必然半路超时(用户那些"扫到一半"就是这么来的)。
+                st = "ok" if el < 3 else ("warn" if el <= 15 else "bad")
+                extra = "" if st == "ok" else ("  偏慢" if st == "warn" else "  太慢（正常 < 3 秒）")
+                _hc(f"列目录 {p}", st, f"{el:.1f} 秒  {len(items)} 项{extra}")
                 listed_ok.append((p, items))
+                if st == "bad":
+                    todo.append((f"列 {p} 用了 {el:.0f} 秒，「生成媒体库」很可能扫到一半就超时",
+                                 "网盘接口到本机的线路问题。把扫描路径收窄到具体的媒体目录"
+                                 "（3 后补参数 → 4 扫描路径），目录少了成功率高很多"))
         except Exception as e:
             _hc(f"列目录 {p}", "bad", _short_err(e))
 


### PR DESCRIPTION
## 问题

真实输出：

```
    列目录 /quark       ✔  47.0 秒  22 项
    ...
  全部正常。播放仍然卡的话，多半是播放设备到网盘那条线，不在服务器这边。
```

**列 22 个文件用了 47 秒，而体检说全部正常。**

只给「换直链」设了阈值，列目录无论多慢都判绿。一个显示着 47 秒还说没问题的体检，比不体检更误导——它会把人往「问题不在服务器」的方向推，而这里明明有一个数量级的异常。

## 改法

补上阈值：`< 3 秒` 绿 / `3~15 秒` 黄 / `> 15 秒` 红。

## 为什么这一项重要

它直接决定「生成媒体库」跑不跑得完。AutoFilm **每个目录都要列一次**——47 秒一个目录、几十个目录就必然半路超时。

用户之前反复遇到的「扫到一半只出来几个文件」「跑一次少一点」，根因就在这，而当时体检完全看不出来（那时还没有体检，靠翻日志也只看到 `skipped_dir_count` 不为 0，不知道为什么）。

所以判红时的建议直接指向真正管用的那一步：

```
1. 列 /quark 用了 47 秒，「生成媒体库」很可能扫到一半就超时
   → 网盘接口到本机的线路问题。把扫描路径收窄到具体的媒体目录
     （3 后补参数 → 4 扫描路径），目录少了成功率高很多
```

## 验证

边界值逐个核对：2.9 → 绿，3.0 → 黄，15.0 → 黄，15.1 → 红，47.0 → 红。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_