### PR TITLE
fix: 保活和列目录都在读缓存，没碰过网络 —— 保活等于空转

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -1016,10 +1016,15 @@ def do_keepalive():
                        timeout=30).get("data") or {}).get("token", "")
         if not tok:
             raise RuntimeError("登录失败")
-        # 只列第一条扫描路径就够:目的是让 token 和到网盘的连接活着,不是把库扫一遍
+        # refresh: true 是关键 —— 不加的话 OpenList 直接返回目录缓存、根本不联网,
+        # 保活就成了每 20 分钟读一次本地缓存的空转。实测过:那种保活记录的耗时是
+        # 0.0 秒,而下一次真正联网的调用照样要等三十几秒。
+        # 那三十几秒是跨境建连接的固定成本(体检里"谁先碰网络谁付这个钱"的现象),
+        # 只有真发一次网络请求才能把它提前付掉。
         p = (cfg["scan_paths"] or ["/"])[0]
         r = _ol_api("/api/fs/list", {"path": p, "password": "", "page": 1,
-                                     "per_page": 1}, tok, timeout=120)
+                                     "per_page": 1, "refresh": True},
+                    tok, timeout=180)
         if r.get("code") != 200:
             raise RuntimeError(r.get("message", "list 失败")[:60])
         rec["ok"] = True
@@ -2643,8 +2648,13 @@ def do_healthcheck():
             continue
         t0 = time.monotonic()
         try:
+            # refresh: true —— 不加的话 OpenList 直接返回目录缓存,这一行永远是 0.0 秒,
+            # 那个数字对判断链路好坏毫无意义。实测同一台机器三次体检:列目录
+            # 0.0 / 47.0 / 0.0 秒,而慢的那次恰好是缓存刚被清空 —— 说明快的两次
+            # 根本没联网。体检要量的是真实链路,不是缓存命中率。
             r = _ol_api("/api/fs/list", {"path": p, "password": "", "page": 1,
-                                         "per_page": 0}, token)
+                                         "per_page": 0, "refresh": True},
+                        token, timeout=180)
             el = time.monotonic() - t0
             items = (r.get("data") or {}).get("content")
             if r.get("code") != 200:


### PR DESCRIPTION
## 发现

同一台机器三次体检的数字暴露了这个：

| 时间 | 列目录 | 换直链 |
|---|---|---|
| 17:24 | 0.0 秒 | **36.2 秒** |
| 17:40 | **47.0 秒** | 0.9 秒 |
| 17:48 | 0.0 秒 | **35.4 秒** |

**总是有一个慢，而且总额差不多。** 17:40 那次是刚更新完、缓存被清空，列目录付了 47 秒，之后换直链就用上热连接只要 0.9 秒。

结论：那三十几秒是**跨境建连接的固定成本**，谁先真正碰网络谁付这个钱，不是某个接口特别慢。

## Bug

OpenList 的 `/api/fs/list` **默认读目录缓存**。于是：

- **保活用的就是 `fs/list`**——记录里「耗时 0.0 秒」就是没联网的铁证。每 20 分钟去读一次本地缓存，什么都没热到，**完全是空转**。上一版 PR 说「保活让连接是热的」，那个说法不成立。
- **体检的列目录同理**，`0.0 秒` 对判断链路好坏毫无意义，量的是缓存命中率而不是链路。

## 改法

两处都加 `refresh: true` 强制真发请求。

副作用是体检会先付一次冷启动成本——但这正是要量的东西。而且保活真正生效之后，连接平时就是热的，列目录不该再慢；如果还慢，那就是真的慢。

顺带把超时从 60 秒放宽到 180 秒：既然现在是真联网，得给冷启动留出余量，否则会把「慢」误报成「不通」。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_