### PR TITLE
fix: Homepage 上 OpenList 的图标挂的是 Alist 的旧标

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -667,7 +667,9 @@ layout:
     for sub, port, container, label in SUBDOMAINS:
         if sub == "home":
             continue
-        icon = {"emby": "emby.png", "openlist": "alist.png"}.get(container, "")
+        # 用 openlist.png 而不是 alist.png：跑的是 OpenList，挂 Alist 的旧标不对。
+        # 两个图标在 homarr-labs/dashboard-icons 里都在，确认过 HTTP 200。
+        icon = {"emby": "emby.png", "openlist": "openlist.png"}.get(container, "")
         services.append(f"""    - {label}:
         icon: {icon}
         href: {url_for(sub, port)}


### PR DESCRIPTION
跑的是 OpenList，导航面板的卡片上却是 Alist 的标——用户一眼就看出来了。

```diff
- icon = {"emby": "emby.png", "openlist": "alist.png"}.get(container, "")
+ icon = {"emby": "emby.png", "openlist": "openlist.png"}.get(container, "")
```

## 验证

图标库 `homarr-labs/dashboard-icons` 里确实有 `openlist.png`：

```
HTTP 200   png/openlist.png
HTTP 200   png/alist.png
```

`tree.json` 里 `openlist` 的 png / svg / webp 三种格式都在，不会换成空白。生成的 `services.yaml` 断言只含 `openlist.png`、不含 `alist.png`。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_