### PR TITLE
Homepage 资源面板：三块分组 + 硬盘改盯 bind mount

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -677,17 +677,20 @@ layout:
         siteMonitor: {monitor.get(container, f'http://{container}:{port}')}""")
     # 三块系统资源各自单独成组：Homepage 的 label 是「给这一组起名」，写在同一个
     # resources 块里只会出一个标题，所以拆成三块才能分别标上 CPU / 内存 / 硬盘。
-    # 核数只能写死在标题里 —— Homepage 的 CPU 格子只渲染百分比，没有核数这个字段。
-    # 数字是生成配置时从宿主机读的，换配置后跑一次「更新」就会重新写。
-    cores = os.cpu_count() or 1
-    # expanded 让内存/硬盘除了「剩余」再显示「已用 / 总量」，不然只有一个 Free 数字，
-    # 坏掉的时候（显示 -）根本看不出它本来该是什么。
+    #
+    # 标题里【不要】写核数、内存总量这类硬件数字。每台机器配置不一样，而写进
+    # widgets.yaml 的是生成那一刻的快照 —— 升配、换机之后不跑「更新」就一直是错的，
+    # 面板上摆一个错数字比不摆更糟。核数尤其没法做成实时的：Homepage 的
+    # /api/widgets/resources?type=cpu 只返回 usage 和 load，压根没有核数这个字段。
+    #
+    # expanded 让内存/硬盘除了「剩余」再显示「已用 / 总量」，CPU 多显示 load —— 这些
+    # 都是容器自己实时读的。硬盘那格万一又读不出来（显示 -），旁边还有总量兜底。
     #
     # 盯 /app/config 而不是 / ：容器里的 / 是 overlay，Homepage 官方文档写明要监控的
     # 盘必须挂进容器。/app/config 是 {安装目录}/homepage/config 的 bind mount，
     # df 出来是真实的块设备（/dev/vda1），读的就是宿主机根分区的容量。
-    widgets = f"""- resources:
-    label: CPU · {cores} 核
+    widgets = """- resources:
+    label: CPU
     expanded: true
     cpu: true
 - resources:

--- a/media-stack.py
+++ b/media-stack.py
@@ -675,10 +675,29 @@ layout:
         href: {url_for(sub, port)}
         description: {'影视播放' if container == 'emby' else '网盘挂载'}
         siteMonitor: {monitor.get(container, f'http://{container}:{port}')}""")
-    widgets = """- resources:
+    # 三块系统资源各自单独成组：Homepage 的 label 是「给这一组起名」，写在同一个
+    # resources 块里只会出一个标题，所以拆成三块才能分别标上 CPU / 内存 / 硬盘。
+    # 核数只能写死在标题里 —— Homepage 的 CPU 格子只渲染百分比，没有核数这个字段。
+    # 数字是生成配置时从宿主机读的，换配置后跑一次「更新」就会重新写。
+    cores = os.cpu_count() or 1
+    # expanded 让内存/硬盘除了「剩余」再显示「已用 / 总量」，不然只有一个 Free 数字，
+    # 坏掉的时候（显示 -）根本看不出它本来该是什么。
+    #
+    # 盯 /app/config 而不是 / ：容器里的 / 是 overlay，Homepage 官方文档写明要监控的
+    # 盘必须挂进容器。/app/config 是 {安装目录}/homepage/config 的 bind mount，
+    # df 出来是真实的块设备（/dev/vda1），读的就是宿主机根分区的容量。
+    widgets = f"""- resources:
+    label: CPU · {cores} 核
+    expanded: true
     cpu: true
+- resources:
+    label: 内存
+    expanded: true
     memory: true
-    disk: /
+- resources:
+    label: 硬盘
+    expanded: true
+    disk: /app/config
 - search:
     provider: duckduckgo
     target: _blank

--- a/media-stack.py
+++ b/media-stack.py
@@ -667,7 +667,9 @@ layout:
     for sub, port, container, label in SUBDOMAINS:
         if sub == "home":
             continue
-        icon = {"emby": "emby.png", "openlist": "alist.png"}.get(container, "")
+        # 用 openlist.png 而不是 alist.png：跑的是 OpenList，挂 Alist 的旧标不对。
+        # 两个图标在 homarr-labs/dashboard-icons 里都在，确认过 HTTP 200。
+        icon = {"emby": "emby.png", "openlist": "openlist.png"}.get(container, "")
         services.append(f"""    - {label}:
         icon: {icon}
         href: {url_for(sub, port)}


### PR DESCRIPTION
面板上一格 CPU、一格「-  Free」，看不出谁是谁；硬盘那格读不出来的时候更是完全不知道本来该显示什么。

## 改动

- **拆成三个 `resources` 块**，分别标上 `CPU` / `内存` / `硬盘`。Homepage 的 `label` 是「给这一组起名」，三个资源写在同一个块里只会出一个标题，必须拆开
- **`expanded: true`**：内存和硬盘除了「剩余」再显示「已用 / 总量」，CPU 多显示 load。硬盘那格万一又读不出来，旁边还有总量兜底
- **监控目标 `/` → `/app/config`**。容器里的 `/` 是 overlay；`/app/config` 是 `{安装目录}/homepage/config` 的 bind mount，`df` 出来是真实块设备。Homepage 文档也写明要监控的盘必须挂进容器

## 标题里不写硬件数字

中途试过把 `os.cpu_count()` 拼进 CPU 的 label，已经撤掉：那是生成配置那一刻的快照，每台机器配置不一样，升配或换机之后不跑「更新」就一直是错的。

核数也做不成实时的 —— 核对过 Homepage 的 `src/pages/api/widgets/resources.js`，`type=cpu` 只返回 `usage` 和 `load`，没有核数字段。所以标题只留名字，数字全部交给 `expanded` 实时读。

## 验证

- `python3 -m py_compile media-stack.py` 通过
- 直接调 `gen_homepage_conf()` 渲染出的 `widgets.yaml` 内容已确认
- 目标机器上 `docker exec homepage df -Pk /app/config` 返回 `/dev/vda1 ... 23980836 available`，与宿主机根分区一致

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_