### PR TITLE
堵住「Emby 刮不出海报」的三个坑

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -677,17 +677,20 @@ layout:
         siteMonitor: {monitor.get(container, f'http://{container}:{port}')}""")
     # 三块系统资源各自单独成组：Homepage 的 label 是「给这一组起名」，写在同一个
     # resources 块里只会出一个标题，所以拆成三块才能分别标上 CPU / 内存 / 硬盘。
-    # 核数只能写死在标题里 —— Homepage 的 CPU 格子只渲染百分比，没有核数这个字段。
-    # 数字是生成配置时从宿主机读的，换配置后跑一次「更新」就会重新写。
-    cores = os.cpu_count() or 1
-    # expanded 让内存/硬盘除了「剩余」再显示「已用 / 总量」，不然只有一个 Free 数字，
-    # 坏掉的时候（显示 -）根本看不出它本来该是什么。
+    #
+    # 标题里【不要】写核数、内存总量这类硬件数字。每台机器配置不一样，而写进
+    # widgets.yaml 的是生成那一刻的快照 —— 升配、换机之后不跑「更新」就一直是错的，
+    # 面板上摆一个错数字比不摆更糟。核数尤其没法做成实时的：Homepage 的
+    # /api/widgets/resources?type=cpu 只返回 usage 和 load，压根没有核数这个字段。
+    #
+    # expanded 让内存/硬盘除了「剩余」再显示「已用 / 总量」，CPU 多显示 load —— 这些
+    # 都是容器自己实时读的。硬盘那格万一又读不出来（显示 -），旁边还有总量兜底。
     #
     # 盯 /app/config 而不是 / ：容器里的 / 是 overlay，Homepage 官方文档写明要监控的
     # 盘必须挂进容器。/app/config 是 {安装目录}/homepage/config 的 bind mount，
     # df 出来是真实的块设备（/dev/vda1），读的就是宿主机根分区的容量。
-    widgets = f"""- resources:
-    label: CPU · {cores} 核
+    widgets = """- resources:
+    label: CPU
     expanded: true
     cpu: true
 - resources:

--- a/media-stack.py
+++ b/media-stack.py
@@ -675,10 +675,29 @@ layout:
         href: {url_for(sub, port)}
         description: {'影视播放' if container == 'emby' else '网盘挂载'}
         siteMonitor: {monitor.get(container, f'http://{container}:{port}')}""")
-    widgets = """- resources:
+    # 三块系统资源各自单独成组：Homepage 的 label 是「给这一组起名」，写在同一个
+    # resources 块里只会出一个标题，所以拆成三块才能分别标上 CPU / 内存 / 硬盘。
+    # 核数只能写死在标题里 —— Homepage 的 CPU 格子只渲染百分比，没有核数这个字段。
+    # 数字是生成配置时从宿主机读的，换配置后跑一次「更新」就会重新写。
+    cores = os.cpu_count() or 1
+    # expanded 让内存/硬盘除了「剩余」再显示「已用 / 总量」，不然只有一个 Free 数字，
+    # 坏掉的时候（显示 -）根本看不出它本来该是什么。
+    #
+    # 盯 /app/config 而不是 / ：容器里的 / 是 overlay，Homepage 官方文档写明要监控的
+    # 盘必须挂进容器。/app/config 是 {安装目录}/homepage/config 的 bind mount，
+    # df 出来是真实的块设备（/dev/vda1），读的就是宿主机根分区的容量。
+    widgets = f"""- resources:
+    label: CPU · {cores} 核
+    expanded: true
     cpu: true
+- resources:
+    label: 内存
+    expanded: true
     memory: true
-    disk: /
+- resources:
+    label: 硬盘
+    expanded: true
+    disk: /app/config
 - search:
     provider: duckduckgo
     target: _blank

--- a/media-stack.py
+++ b/media-stack.py
@@ -2129,8 +2129,13 @@ def do_strm():
     print(f"  {DIM}Emby → 设置 → 媒体库 → 添加媒体库 → 内容类型选「电影」→ 文件夹填上面这个{RST}")
     # 刮不出海报的两个高频原因,都在建库那一屏,建完再回头改很麻烦
     print(f"  {YELLOW}同一屏里还要改两处，不然刮不出海报：{RST}")
-    print(f"  {DIM}·{RST} 首选语言选{BOLD}中文{RST}、国家/地区选{BOLD}中国{RST}"
-          f"{DIM} —— 留空会按英文去 TMDb 搜，中文片名一条都搜不到{RST}")
+    # 这里【只是提示】,脚本不碰 Emby 的媒体库设置(体检那段也只读不写)。
+    # 语言不是硬规定:它决定刮回来的标题/简介用哪种语言显示,不限制能刮哪国的片子。
+    # 会出事的只有「文件名是中文 + 语言按英文搜」这一种组合。
+    print(f"  {DIM}·{RST} 首选语言{BOLD}别留空{RST}"
+          f"{DIM} —— 留空按服务器默认（通常英文）去 TMDb 搜，中文片名一条都搜不到。{RST}")
+    print(f"    {DIM}片名是中文就选中文/中国。这只影响标题简介显示成哪种语言，"
+          f"不限制能刮哪国的片子，随时能在 Emby 里改。{RST}")
     print(f"  {DIM}·{RST} 片子文件名要像 {BOLD}流浪地球 (2019).mkv{RST}"
           f"{DIM} —— 带发布组标记的（[BT]xxx.1080p.WEB-DL-YYY）Emby 解析不出片名{RST}")
 
@@ -2841,9 +2846,9 @@ def do_healthcheck():
                     if not (lb.get("LibraryOptions") or {}).get("PreferredMetadataLanguage")]
             if noln:
                 _hc("刮削语言", "warn", f"{'、'.join(noln)} 没设语言  {YELLOW}中文片名搜不到{RST}")
-                todo.append((f"媒体库「{noln[0]}」的元数据语言是空的，中文片名刮不出海报",
-                             "Emby → 设置 → 媒体库 → 点该库 → 首选语言选中文、地区选中国，"
-                             "再「扫描媒体库文件」"))
+                todo.append((f"媒体库「{noln[0]}」的元数据语言是空的，会按服务器默认（通常英文）搜",
+                             "Emby → 设置 → 媒体库 → 点该库 → 首选语言按片名的语种选"
+                             "（中文片名就选中文/中国），再「扫描媒体库文件」"))
             else:
                 _hc("刮削语言", "ok", "都设了")
         except Exception as e:

--- a/media-stack.py
+++ b/media-stack.py
@@ -2127,6 +2127,12 @@ def do_strm():
     print(f"  {BOLD}Emby 媒体库要指向的路径{RST}（容器内路径，不是宿主机路径）：")
     print(f"      {CYAN}{BOLD}{STRM_PATH}{RST}")
     print(f"  {DIM}Emby → 设置 → 媒体库 → 添加媒体库 → 内容类型选「电影」→ 文件夹填上面这个{RST}")
+    # 刮不出海报的两个高频原因,都在建库那一屏,建完再回头改很麻烦
+    print(f"  {YELLOW}同一屏里还要改两处，不然刮不出海报：{RST}")
+    print(f"  {DIM}·{RST} 首选语言选{BOLD}中文{RST}、国家/地区选{BOLD}中国{RST}"
+          f"{DIM} —— 留空会按英文去 TMDb 搜，中文片名一条都搜不到{RST}")
+    print(f"  {DIM}·{RST} 片子文件名要像 {BOLD}流浪地球 (2019).mkv{RST}"
+          f"{DIM} —— 带发布组标记的（[BT]xxx.1080p.WEB-DL-YYY）Emby 解析不出片名{RST}")
 
 
 def write_secret(path, key, value):
@@ -2367,8 +2373,9 @@ def set_scan_paths():
     else:
         print(f"  {DIM}OpenList 里还没挂任何网盘。{RST}")
     print()
-    print(f"  {DIM}填一条（/quark）、多条逗号隔开（/quark,/aliyun）、"
+    print(f"  {DIM}填一条（/quark/电影）、多条逗号隔开（/quark/电影,/quark/剧集）、"
           f"或 {RST}{BOLD}y{RST}{DIM} 自动跟随已挂载的存储。回车不改。{RST}")
+    print(f"  {YELLOW}填到影视目录那一层，别填网盘根目录{RST}{DIM} —— 原因见确认前的提示。{RST}")
     spec = parse_scan_spec(ask("扫描路径", ""))
     if not spec:
         print("没有改动。")
@@ -2387,6 +2394,21 @@ def set_scan_paths():
         if unknown:
             warn(f"这些路径不在已挂载的存储里：{'、'.join(unknown)}")
             print(f"  {DIM}拼错了或者还没在 OpenList 里挂上，扫的时候会被跳过。{RST}")
+
+    # 扫网盘根目录是个大坑,而且是「看起来成功了」的那种坑:
+    #   1. 整个盘都会被镜像成 strm —— 手机备份、微信截图、扫描件、壁纸全堆进媒体库,
+    #      Emby 把每个目录当成一部电影去 TMDb 搜,搜不到,于是"有条目没海报"
+    #   2. download.image 会把网盘里【所有】图片真的下载到 VPS 本地(不只是影视封面),
+    #      小盘 VPS 会被自己的相册备份撑爆
+    # 实测扫 /quark 生成 61 个 strm,其中只有 3 个跟影视沾边。
+    bare = [p for p in paths if p.strip("/").count("/") == 0]
+    if bare:
+        warn(f"{'、'.join(bare)} 是网盘根目录 —— 整个盘都会被扫进来")
+        print(f"  {DIM}手机备份、截图、扫描件都会变成 strm 堆在媒体库里，Emby 拿这些去")
+        print(f"  刮削当然搜不到，表现就是「有一堆条目、全都没有海报」。{RST}")
+        print(f"  {DIM}而且图片会{RST}真的下载到 VPS 本地{DIM}占硬盘，不只是影视封面。{RST}")
+        print(f"  {DIM}建议填到影视目录那一层，比如 {RST}{BOLD}{bare[0]}/电影{RST}")
+
     if not ask_yn("确认改成上面这些？", True):
         print("没有改动。")
         return
@@ -2811,6 +2833,19 @@ def do_healthcheck():
             if not hit:
                 todo.append((f"Emby 里没有指向 {STRM_PATH} 的媒体库",
                              f"Emby → 设置 → 媒体库 → 添加，路径填 {STRM_PATH}"))
+
+            # 元数据语言留空 = 跟服务器默认走(通常是 en)。中文片名拿去 TMDb 的英文
+            # 索引里搜是搜不到的,表现为「条目都在、一张海报都没有」,而且这个设置藏在
+            # 建库那一屏里,建完之后基本没人会回去看,所以单独拎出来报一条。
+            noln = [lb.get("Name") or "?" for lb in libs
+                    if not (lb.get("LibraryOptions") or {}).get("PreferredMetadataLanguage")]
+            if noln:
+                _hc("刮削语言", "warn", f"{'、'.join(noln)} 没设语言  {YELLOW}中文片名搜不到{RST}")
+                todo.append((f"媒体库「{noln[0]}」的元数据语言是空的，中文片名刮不出海报",
+                             "Emby → 设置 → 媒体库 → 点该库 → 首选语言选中文、地区选中国，"
+                             "再「扫描媒体库文件」"))
+            else:
+                _hc("刮削语言", "ok", "都设了")
         except Exception as e:
             _hc("Emby 媒体库", "warn", _short_err(e))
 

--- a/media-stack.py
+++ b/media-stack.py
@@ -667,7 +667,9 @@ layout:
     for sub, port, container, label in SUBDOMAINS:
         if sub == "home":
             continue
-        icon = {"emby": "emby.png", "openlist": "alist.png"}.get(container, "")
+        # 用 openlist.png 而不是 alist.png：跑的是 OpenList，挂 Alist 的旧标不对。
+        # 两个图标在 homarr-labs/dashboard-icons 里都在，确认过 HTTP 200。
+        icon = {"emby": "emby.png", "openlist": "openlist.png"}.get(container, "")
         services.append(f"""    - {label}:
         icon: {icon}
         href: {url_for(sub, port)}


### PR DESCRIPTION
实测一台机器：扫描路径填了网盘根目录 `/quark`，生成 61 个 strm，其中只有 3 个跟影视沾边，其余是手机备份、微信截图、扫描件、壁纸。Emby 库里当然没有电影，用户看到的现象是「Emby 自带的刮削器根本不出海报」—— 但刮削器本身是好的（`TheMovieDb` 勾着、TMDb 网络正常）。

## 改动

**1. 扫描路径填根目录时警告**

除了 strm 污染，更隐蔽的是 `download.image: true` 会把网盘里**所有**图片真的下载到 VPS 本地（不只是影视封面），小盘 VPS 会被自己的相册备份撑爆。输入提示里的例子也从 `/quark` 改成 `/quark/电影`。

**2.「生成媒体库」跑完的建库提示补两条**

- 首选语言别留空 —— 留空按服务器默认（通常英文）去 TMDb 搜，中文片名一条都搜不到
- 文件名要像 `流浪地球 (2019).mkv`，带发布组标记的 Emby 解析不出片名

这两项都在建库那一屏，建完再回头改很麻烦。

措辞上刻意避免写成硬规定：`PreferredMetadataLanguage` 决定的是刮回来的标题/简介用哪种语言**显示**，不限制能刮哪国的片子 —— 英文片名的片子设成中文照样精确匹配。真正会搜不到的只有「文件名是中文 + 按英文去搜」这一种组合。

**3. 链路体检加一项「刮削语言」**

任何一个库的 `PreferredMetadataLanguage` 为空就报 warn 并给出改法。这个设置藏在建库那一屏，建完基本没人会回去看。

## 边界

脚本**只读** Emby 的媒体库设置（`GET /Library/VirtualFolders`），从不写入。语言、内容类型这些仍然完全由用户在 Emby 界面里控制，随时可改。已在注释里写明。

## 验证

`python3 -m py_compile media-stack.py` 通过。诊断数据来自实际机器的 Emby API 与文件系统输出。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_