### PR TITLE
生成媒体库后预探测，别把跨境拉文件头塞进播放的关键路径

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2117,6 +2117,105 @@ def emby_scan_wait(key, timeout=600):
     return False
 
 
+def _emby(path, key, method="GET", timeout=60):
+    u = f"http://127.0.0.1:8096{path}{'&' if '?' in path else '?'}api_key={key}"
+    with urllib.request.urlopen(
+            urllib.request.Request(u, method=method), timeout=timeout) as r:
+        body = r.read()
+    return json.loads(body) if body.strip() else {}
+
+
+def items_without_duration(key):
+    """Emby 里还没探测出时长的影视条目 [(id, 名字), ...]。
+
+    枚举方式是照抄 Emby 网页端自己发的请求:ParentId 填【媒体库条目 id】
+    (VirtualFolders 里的 ItemId)、带 Recursive 和 IncludeItemTypes。
+    少了 IncludeItemTypes 的话 Emby 会把媒体库节点本身当结果返回,看起来就像
+    "库里只有一个条目",排查时会被带到沟里去。
+    """
+    out = []
+    try:
+        libs = _emby("/Library/VirtualFolders", key)
+    except Exception:
+        return out
+    uid = ""
+    try:
+        users = _emby("/Users", key)
+        uid = (users[0] or {}).get("Id", "") if users else ""
+    except Exception:
+        pass
+    if not uid:
+        return out
+    for lb in libs:
+        pid = lb.get("ItemId")
+        if not pid:
+            continue
+        try:
+            d = _emby(f"/Users/{uid}/Items?ParentId={pid}&Recursive=true"
+                      f"&IncludeItemTypes=Movie,Episode,Video&Fields=Path", key)
+        except Exception:
+            continue
+        for i in d.get("Items") or []:
+            if not (i.get("RunTimeTicks") or 0):
+                out.append((uid, i.get("Id"), i.get("Name") or "?"))
+    return out
+
+
+def warm_media_info(d, key):
+    """提前把每个新条目探测一遍，别等用户按下播放时才现探。
+
+    这是 URL 形式 strm 的代价:Emby 要真的去网盘 CDN 拉一段文件头,才知道时长和
+    编码。同一台机器实测这一步的耗时(三个文件):
+        连接 0.11 / 2.5 / 32.4 秒，首字节 0.90 / 20.2 / 39.4 秒
+    而 Emby 把它放在 PlaybackInfo 里做 —— 也就是【用户按下播放的那一刻】。
+    浏览器等不到,38 秒就自己取消,日志里是
+        502 | 38.28s | POST /emby/Items/119/PlaybackInfo?...IsPlayback=true
+        http: proxy error: context canceled
+    用户看到的是转圈或者「当前没有兼容的流」。
+
+    路径形式的 strm 没有这个问题,因为 Emby 压根不碰网盘 —— 所以这是换成 URL
+    形式之后【新增】的失败模式,必须一起解决,不能只改一半。
+
+    好在这个代价只付一次:探测成功后媒体信息就存库了。所以挪到这里来做,
+    生成媒体库之后、没人等着看片的时候。
+    """
+    pend = items_without_duration(key)
+    if not pend:
+        return
+    print()
+    info(f"给 {len(pend)} 个条目预探测媒体信息（时长、编码）...")
+    print(f"  {DIM}不做这一步的话，第一次点播放要等 Emby 现去网盘拉文件头，")
+    print(f"  跨境线路上实测能到 40 秒，播放器等不了那么久会直接报错。{RST}")
+    print(f"  {DIM}每个最多等 3 分钟，慢是正常的，做完一次以后就都是现成的。{RST}")
+    done = 0
+    for uid, iid, name in pend:
+        try:
+            _emby(f"/Items/{iid}/PlaybackInfo?UserId={uid}&IsPlayback=true"
+                  f"&AutoOpenLiveStream=true&MediaSourceId=mediasource_{iid}"
+                  f"&StartTimeTicks=0&MaxStreamingBitrate=200000000",
+                  key, method="POST", timeout=200)
+        except Exception as e:
+            print(f"  {DIM}·{RST} {name[:28]}  {YELLOW}{_short_err(e)}{RST}")
+            continue
+        # 拿回来确认一下,PlaybackInfo 返回 200 不代表探测成功
+        try:
+            it = _emby(f"/Users/{uid}/Items/{iid}", key, timeout=30)
+            mins = (it.get("RunTimeTicks") or 0) / 6e8
+        except Exception:
+            mins = 0
+        if mins:
+            done += 1
+            print(f"  {GREEN}✔{RST} {name[:28]}  {mins:.0f} 分钟")
+        else:
+            print(f"  {DIM}·{RST} {name[:28]}  {YELLOW}没探到，第一次播放时会再试{RST}")
+    if done == len(pend):
+        ok(f"{done} 个条目全部探测完成，进度条和续播现在可用")
+    else:
+        warn(f"{done}/{len(pend)} 个探测成功")
+        print(f"  {DIM}没成功的多半是当时网盘那条线在抖。再点一次「4 生成媒体库」")
+        print(f"  会只补没探到的那些，已经好的不会重来。{RST}")
+
+
 def migrate_strm_format(d):
     """把老的路径形式 strm 迁移成 URL 形式。返回是否需要在之后重新生成。
 
@@ -2311,9 +2410,11 @@ def do_strm():
     key = read_yaml_scalar(os.path.join(d, "mediawarp", "config", "config.yaml"), "auth")
     if key:
         info("通知 Emby 扫描媒体库...")
-        sh(f"curl -sS -m 30 -X POST 'http://127.0.0.1:8096/Library/Refresh?api_key={key}'",
-           timeout=60)
-        ok("已通知 Emby 扫描（后台进行，稍等片刻刷新 Emby 页面）")
+        if emby_scan_wait(key, timeout=900):
+            ok("Emby 已扫完")
+        else:
+            ok("已通知 Emby 扫描（后台进行，稍等片刻刷新 Emby 页面）")
+        warm_media_info(d, key)
     else:
         warn("没有 Emby API Key，没法自动触发扫描。去 Emby 后台手动扫一次媒体库。")
         print(f"  {DIM}填 API Key：「3 后补参数 → 添加 API 密钥」{RST}")

--- a/media-stack.py
+++ b/media-stack.py
@@ -2078,6 +2078,21 @@ def emby_scan_wait(key, timeout=600):
     """
     if not key:
         return False
+
+    def scan_task():
+        try:
+            with urllib.request.urlopen(
+                    f"http://127.0.0.1:8096/ScheduledTasks?api_key={key}", timeout=30) as r:
+                return next((x for x in json.load(r)
+                             if x.get("Key") == "RefreshLibrary"), None)
+        except Exception:
+            return None
+
+    # 先记下上一次执行的结束时间。只靠「State 从 Running 变回 Idle」是不够的:
+    # 小媒体库一两秒就扫完了,轮询第一次去看时任务早就 Idle,于是永远等不到那个
+    # 状态跳变,只能干等到超时(实测 60 个文件的库就这样卡满 10 分钟)。
+    # 结束时间变了同样说明这一轮跑完了,两个条件哪个先成立都算数。
+    before = ((scan_task() or {}).get("LastExecutionResult") or {}).get("EndTimeUtc", "")
     try:
         urllib.request.urlopen(
             urllib.request.Request(
@@ -2085,23 +2100,19 @@ def emby_scan_wait(key, timeout=600):
             timeout=30).close()
     except Exception:
         return False
+
     deadline = time.time() + timeout
     seen_running = False
     while time.time() < deadline:
-        time.sleep(4)
-        try:
-            with urllib.request.urlopen(
-                    f"http://127.0.0.1:8096/ScheduledTasks?api_key={key}", timeout=30) as r:
-                tasks = json.load(r)
-        except Exception:
+        time.sleep(3)
+        t = scan_task()
+        if t is None:
             continue
-        t = next((x for x in tasks if x.get("Key") == "RefreshLibrary"), None)
-        if not t:
-            time.sleep(20)          # 找不到任务就退回固定等待，总比不等强
-            return False
-        if t.get("State") == "Running":
+        if t.get("State") != "Idle":
             seen_running = True
-        elif seen_running:
+            continue
+        end = (t.get("LastExecutionResult") or {}).get("EndTimeUtc", "")
+        if seen_running or (end and end != before):
             return True
     return False
 

--- a/media-stack.py
+++ b/media-stack.py
@@ -654,10 +654,14 @@ http_strm:
   prefix_list:
     - {STRM_PATH}
 
-# alist_strm 保持开启，只为兼容【升级前生成的、路径形式的老 strm】。
-# 两个处理器按 strm 内容各管各的，互不干扰。老 strm 能播，但没有时长。
+# alist_strm 必须关掉，不能和 http_strm 并存。
+# 试过留着它「兼容老 strm」，结果老 strm 直接播不了了，报「当前没有兼容的流」：
+# MediaWarp 是按【路径前缀】选处理器的，而两者的 prefix_list 只能是同一个
+# {STRM_PATH}（strm 全在这一个目录下）。http_strm 抢先接管整个前缀，然后把老
+# strm 里的 /quark/电影/x.mp4 当成 URL 去重定向 —— 那不是合法 URL，于是失败。
+# 所以老格式的 strm 必须迁移掉（见 migrate_strm_format），没有共存这条路。
 alist_strm:
-  enable: true
+  enable: false
   proxy: true
   # 必须是 true。false 的话 MediaWarp 会拿下面的 addr 拼重定向地址，把播放器
   # 302 到 http://openlist:5244/d/... —— 那是容器内部地址，手机/电视根本连不上。
@@ -1608,14 +1612,31 @@ def do_update():
             f.write(build_summary(cfg, colored=False) + "\n")
         os.chmod(cred, 0o600)
 
-    # 更新过程重启了容器，连接池被清空，这一刻链路是【冷的】——
-    # 不补这一下的话，更新完马上去播，第一部片八成要转圈几十秒，
-    # 而用户会以为是这次更新弄坏了什么。顺便也立刻验证网盘还通不通。
-    info("热一下网盘链路...")
+    # 新版把播放交给 http_strm，而它和 alist_strm 不能共存（同一个路径前缀，
+    # 见 gen_mediawarp_conf）。所以更新之后，旧格式的 strm 会【立刻播不了】，
+    # 点开报「当前没有兼容的流」。不能让用户停在这个状态上自己去发现 ——
+    # 更新的最后一步必须把它挑明，并且当场给出出口。
+    old = old_format_strm(d)
+    if old:
+        print()
+        warn(f"有 {len(old)} 个旧格式 strm —— 这些片子现在{BOLD}暂时播不了{RST}")
+        print(f"  {DIM}新版本改由 http_strm 处理播放，它只认 URL 形式的 strm；")
+        print(f"  旧的是网盘路径形式，点开会报「当前没有兼容的流」。{RST}")
+        print(f"  {DIM}重新生成一次就恢复，而且顺带拿到时长（进度条、续播才能用）。{RST}")
+        if ask_yn("现在就重新生成媒体库吗？", True):
+            do_strm()
+        else:
+            print(f"  {YELLOW}在你点「4 生成媒体库」之前，那些片子一直播不了。{RST}")
+
+    # 更新过程重启了所有容器，这一步顺便验证网盘还通不通 —— 更新完立刻发现
+    # 网盘挂了，总比晚上想看片时才发现强。
+    # 注意：这【不是】"把链路热好"。实测耗时和空闲时间不相关（见 do_keepalive
+    # 的文档字符串），所以别在这里承诺"现在去播不会卡"。
+    info("顺便测一下网盘链路...")
     do_keepalive()
     ka = keepalive_state(d)
     if ka.get("ok"):
-        ok(f"网盘链路已热好（{ka.get('elapsed', 0)}s），现在去播不会卡在开头")
+        ok(f"网盘链路正常（列目录 {ka.get('elapsed', 0)}s）")
     elif ka:
         warn(f"网盘暂时不通：{ka.get('error', '')}")
         print(f"  {DIM}和这次更新无关，是线路问题。保活每 {KEEPALIVE_MIN} 分钟会自己重试。{RST}")


### PR DESCRIPTION
#199 把 strm 改成 URL 形式修好了进度条和续播，但引入了一个没预见到的副作用：片子点开播不了，报「当前没有兼容的流」或者一直转圈。

## 结构性变化

```
改之前：strm 里是路径
        Emby 全程不碰网盘
        播放 = MediaWarp 问 OpenList 要直链（0.2 秒）→ 302 → 手机自己下载

改之后：strm 里是 URL
        Emby 必须自己去网盘 CDN 拉一段文件头才知道时长和编码
        而它把这件事放在 PlaybackInfo 里做 —— 也就是用户按下播放的那一刻
```

同一台机器实测这一步的耗时（三个文件）：

| 文件 | 连接 | 首字节 | 2MB 速度 |
|---|---|---|---|
| A | 2.5s | 20.2s | 510 KB/s |
| B | **32.4s** | **39.4s** | 1.26 MB/s |
| C | 0.11s | 0.90s | 230 KB/s |

浏览器等不到，38 秒就自己取消：

```
502 | 38.28s | POST /emby/Items/119/PlaybackInfo?...IsPlayback=true
http: proxy error: context canceled
```

（`context canceled` 是**客户端**取消的，不是服务端超时，所以调大 nginx / MediaWarp 的超时没用。）

## 做法

这个代价只付一次 —— 探测成功后媒体信息就存库了。所以挪到生成媒体库之后、没人等着看片的时候做。

- `items_without_duration()` 枚举还没有 `RunTimeTicks` 的条目。枚举方式照抄 Emby 网页端自己发的请求：`ParentId` 填**媒体库条目 id**（`VirtualFolders` 的 `ItemId`）、带 `Recursive` 和 `IncludeItemTypes`。少了 `IncludeItemTypes` 的话 Emby 会把媒体库节点本身当结果返回，看起来像「库里只有一个条目」—— 排查时被这个带到沟里去过好几轮
- `warm_media_info()` 对每个条目发一次 `IsPlayback=true` 的 PlaybackInfo，超时给到 200 秒，发完**再读回来确认** `RunTimeTicks` 真的有了（返回 200 不等于探测成功）
- 挂在 `do_strm()` 末尾，并把那里的扫描改成等扫完再探，否则条目还没建出来

没探到的条目下次再点「4 生成媒体库」会只补没探到的，已经好的不重来。

## 验证

`python3 -m py_compile` 通过，新函数可导入。失败现场（502 / `context canceled` / CDN 耗时表）全部来自真实机器。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_