### PR TITLE
后补参数加 MetaTube 开关（番号刮削，默认不装）

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2130,12 +2130,15 @@ def emby_scan_wait(key, timeout=600):
     return False
 
 
-def _emby(path, key, method="GET", timeout=60):
+def _emby(path, key, method="GET", timeout=60, body=None):
     u = f"http://127.0.0.1:8096{path}{'&' if '?' in path else '?'}api_key={key}"
-    with urllib.request.urlopen(
-            urllib.request.Request(u, method=method), timeout=timeout) as r:
-        body = r.read()
-    return json.loads(body) if body.strip() else {}
+    req = urllib.request.Request(
+        u, method=method,
+        data=json.dumps(body).encode() if body is not None else None,
+        headers={"Content-Type": "application/json"} if body is not None else {})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        out = r.read()
+    return json.loads(out) if out.strip() else {}
 
 
 def items_without_duration(key):
@@ -2174,6 +2177,51 @@ def items_without_duration(key):
     return out
 
 
+RESUME_MIN_SECONDS = 10     # 播够多少秒才值得记续播点
+RESUME_MIN_PCT     = 1      # 播到百分之几才值得记
+
+
+def tune_resume_thresholds(key):
+    """把媒体库的续播门槛调到对短片子也公平的值。
+
+    Emby 每个媒体库有三个续播参数,默认值是按"电影"设计的:
+        MinResumeDurationSeconds  120   播放位置不到 120 秒就不记
+        MinResumePct                2   不到总时长 2% 不记
+        MaxResumePct               90   超过 90% 判定看完,清掉续播点
+    网盘库里什么长度都有。一个 1 分多钟的片子,播放位置【永远】到不了 120 秒,
+    于是永远没有续播记忆 —— 用户看到的是"长的能记住、短的记不住",像是坏了,
+    其实是规则如此。而这三个值 Emby 的网页设置里不给改,只能走接口。
+
+    只动指向本脚本 strm 目录的媒体库:用户自己另外建的库(本地电影、音乐之类)
+    不该被这个脚本碰。MaxResumePct 也不动 —— 那条是按比例算的,长短本来就公平。
+    """
+    try:
+        libs = _emby("/Library/VirtualFolders", key)
+    except Exception:
+        return
+    for lb in libs:
+        if not any(STRM_PATH in p or p in STRM_PATH for p in (lb.get("Locations") or [])):
+            continue
+        o = lb.get("LibraryOptions") or {}
+        cur_s = o.get("MinResumeDurationSeconds")
+        cur_p = o.get("MinResumePct")
+        if cur_s == RESUME_MIN_SECONDS and cur_p == RESUME_MIN_PCT:
+            continue
+        o["MinResumeDurationSeconds"] = RESUME_MIN_SECONDS
+        o["MinResumePct"] = RESUME_MIN_PCT
+        try:
+            _emby("/Library/VirtualFolders/LibraryOptions",
+                  key, method="POST",
+                  body={"Id": lb.get("ItemId"), "LibraryOptions": o})
+        except Exception as e:
+            warn(f"改「{lb.get('Name')}」的续播门槛失败：{_short_err(e)}")
+            continue
+        ok(f"媒体库「{lb.get('Name')}」续播门槛：{cur_s}秒/{cur_p}% → "
+           f"{RESUME_MIN_SECONDS}秒/{RESUME_MIN_PCT}%")
+        print(f"  {DIM}默认的 120 秒是按电影长度定的，短片子永远够不到，"
+              f"表现为「长的记得住、短的记不住」。{RST}")
+
+
 def warm_media_info(d, key):
     """提前把每个新条目探测一遍，别等用户按下播放时才现探。
 
@@ -2182,7 +2230,7 @@ def warm_media_info(d, key):
         连接 0.11 / 2.5 / 32.4 秒，首字节 0.90 / 20.2 / 39.4 秒
     而 Emby 把它放在 PlaybackInfo 里做 —— 也就是【用户按下播放的那一刻】。
     浏览器等不到,38 秒就自己取消,日志里是
-        502 | 38.28s | POST /emby/Items/119/PlaybackInfo?...IsPlayback=true
+        502 | 38.28s | POST /emby/Items/<id>/PlaybackInfo?...IsPlayback=true
         http: proxy error: context canceled
     用户看到的是转圈或者「当前没有兼容的流」。
 
@@ -2427,6 +2475,7 @@ def do_strm():
             ok("Emby 已扫完")
         else:
             ok("已通知 Emby 扫描（后台进行，稍等片刻刷新 Emby 页面）")
+        tune_resume_thresholds(key)
         warm_media_info(d, key)
     else:
         warn("没有 Emby API Key，没法自动触发扫描。去 Emby 后台手动扫一次媒体库。")

--- a/media-stack.py
+++ b/media-stack.py
@@ -28,6 +28,7 @@ import subprocess
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 
 SCRIPT_VERSION = "1.1.0"
@@ -2880,14 +2881,45 @@ class _NoRedirect(urllib.request.HTTPRedirectHandler):
         return None
 
 
-def probe_302(key):
+def strm_target_path(content):
+    """从 strm 内容里还原出它在 OpenList 上的路径。两种形态都要认:
+
+      · 路径形式(旧)   /quark/电影/x.mp4
+      · URL 形式(新)   https://list.<域名>/d/quark/电影/x.mp4?sign=…
+
+    体检里有几项要按「挂载点」给文件分组,只认路径形式的话,升级之后会得出
+    「还没有 strm 文件」这种和上一行「strm 文件 3 个」直接打架的结论。
+    """
+    c = (content or "").strip()
+    if not c:
+        return ""
+    if c.startswith("/"):
+        return c
+    if not c.lower().startswith("http"):
+        return ""
+    try:
+        p = urllib.parse.unquote(urllib.parse.urlsplit(c).path)
+    except Exception:
+        return ""
+    # OpenList 的下载端点是 /d/<路径>，也见过带签名前缀的 /dav/ 形态
+    for pre in ("/d/", "/dav/"):
+        if p.startswith(pre):
+            return "/" + p[len(pre):]
+    return p or ""
+
+
+def probe_302(key, own_host=""):
     """真的发一次播放请求，看 MediaWarp 到底回不回 302、302 到哪。
 
     这是整套东西唯一的端到端证明。前面那些检查(存储 work、能换到直链)都只说明
     "零件是好的",而播放实际走哪条路要看这一下:
-      · 302 → 网盘 CDN     视频从网盘直达播放器,不经过本机 —— 这才是目的
-      · 302 → 内部地址     客户端根本连不上(raw_url: false 就是这个后果)
+      · 302 → 内部地址     客户端根本连不上
       · 200 不是 302       MediaWarp 没拦住,视频要经过本机中转,吃你的带宽
+
+    strm 改成 URL 形式之后这里【多了一跳】,只看第一跳会得出错误结论:
+    MediaWarp 现在 302 到的是 OpenList 的公网地址(own_host),播放器要再跟一次
+    才到网盘 CDN。所以拿到第一跳之后还要再跟一次,确认后半段也是通的 ——
+    否则「302 → 自己的域名」看起来像成功,实际上可能第二跳就死了。
 
     返回 (state, 说明)。
     """
@@ -2922,6 +2954,29 @@ def probe_302(key):
                     or _is_private_ip(bare))
         if internal:
             return "bad", f"302 → {host}  {RED}内部地址，客户端连不上{RST}"
+
+        # 第一跳落在自己的 OpenList 公网域名上 —— 这是 URL 形式 strm 的正常形态,
+        # 但还没到网盘。必须再跟一跳才知道后半段通不通:只看第一跳的话,
+        # 「302 → 自己的域名」看起来像成功,实际可能第二跳就死了。
+        if own_host and bare == own_host:
+            try:
+                with opener.open(loc, timeout=60) as r2:
+                    return "bad", (f"302 → {bare} 之后没有再跳转（HTTP {r2.status}）"
+                                   f"  {RED}视频会经过本机{RST}")
+            except urllib.error.HTTPError as e2:
+                if e2.code not in (301, 302, 303, 307, 308):
+                    return "bad", f"{bare} 返回 HTTP {e2.code}  {RED}换直链失败{RST}"
+                loc = e2.headers.get("Location", "")
+                host = loc.split("/")[2] if "://" in loc else loc[:40]
+                bare = host.split(":")[0]
+                if bare in ("openlist", "emby", "mediawarp", "localhost") or _is_private_ip(bare):
+                    return "bad", f"第二跳 → {host}  {RED}内部地址，客户端连不上{RST}"
+                two_hop = True
+            except Exception as ex:
+                return "bad", f"{bare} 那一跳失败：{_short_err(ex)}"
+        else:
+            two_hop = False
+
         # 判断实际拿到的是原画还是转码流。光看 .m3u8 会判错:夸克的转码流地址是
         # video-play-*.drive.quark.cn,并不一定以 m3u8 结尾,而原画是 dl-*。
         # 实际就出现过「302 那行说原画、直链方式那行说转码流」自相矛盾。
@@ -2932,8 +2987,9 @@ def probe_302(key):
             kind = "原画"
         else:
             kind = ""
-        tail = f"（{kind}，直连网盘、不经过本机）" if kind else "（直连网盘、不经过本机）"
-        return "ok", f"302 → {host}  {DIM}{tail}{RST}"
+        head = f"302 →{' ' + own_host + ' →' if two_hop else ''} {host}"
+        tail = (f"（{kind}，" if kind else "（") + "视频直达网盘，不经过本机）"
+        return "ok", f"{head}  {DIM}{tail}{RST}"
     except Exception as e:
         return "bad", _short_err(e)
 
@@ -3128,9 +3184,13 @@ def do_healthcheck():
             read_env(os.path.join(d, ".env"), "DATA_ROOT") or os.path.join(d, "media"),
             "strm", "**", "*.strm"), recursive=True)):
         try:
-            fp = open(f, encoding="utf-8").read().strip()
+            raw = open(f, encoding="utf-8").read()
         except OSError:
             continue
+        # strm 有两种形态(路径 / URL),统一还原成 OpenList 上的路径再分组。
+        # 只认路径形式的话,升级之后这里会空掉,体检就会打出「还没有 strm 文件」
+        # 而上一行明明写着「strm 文件 3 个」—— 自相矛盾比不检查更误导。
+        fp = strm_target_path(raw)
         if not fp.startswith("/"):
             continue
         mount = "/" + fp.lstrip("/").split("/")[0]      # /quark/电影/x.mp4 → /quark
@@ -3181,16 +3241,18 @@ def do_healthcheck():
         _hc("MediaWarp→Emby", "bad", _short_err(e))
         todo.append(("MediaWarp 打不通 Emby", "docker logs --tail 30 mediawarp"))
     # ---- 302 端到端 ----
-    st302, msg302 = probe_302(key)
+    own_host = urllib.parse.urlsplit(openlist_public_url(cfg)).hostname or ""
+    _hc_wait("302 直链", 90)
+    st302, msg302 = probe_302(key, own_host)
     _hc("302 直链", st302, msg302)
     if st302 == "bad":
         if "不是 302" in msg302:
             todo.append(("MediaWarp 没有拦截播放请求，视频会经过本机中转",
-                         "检查 mediawarp/config.yaml 的 alist_strm.prefix_list "
-                         f"是不是 {STRM_PATH}，以及 strm 内容是不是纯路径"))
+                         "检查 mediawarp/config.yaml 的 http_strm.enable 是不是 true、"
+                         f"prefix_list 是不是 {STRM_PATH}；「6 更新」会重新生成"))
         elif "内部地址" in msg302:
             todo.append(("302 指向了容器内部地址，播放器连不上",
-                         "mediawarp/config.yaml 里 raw_url 要是 true；"
+                         "autofilm 的 public_url 要填播放器能访问的地址；"
                          "「6 更新」会重新生成这份配置"))
         else:
             todo.append(("302 没生成", "多半是上一行的换直链失败，等线路恢复再试"))

--- a/media-stack.py
+++ b/media-stack.py
@@ -2840,7 +2840,18 @@ def params_menu():
 def _hc(label, state, detail=""):
     icon = {"ok": f"{GREEN}✔{RST}", "warn": f"{YELLOW}⚠{RST}",
             "bad": f"{RED}✖{RST}", "skip": f"{DIM}—{RST}"}[state]
-    print(f"    {pad(label, 20)}{icon}  {detail}")
+    print(f"\r\x1b[2K    {pad(label, 20)}{icon}  {detail}")
+
+
+def _hc_wait(label, secs):
+    """慢检查开始前先把行占上，让人看得见它在等什么、要等多久。
+
+    体检恰恰是「东西已经坏了」的时候才会跑的：网盘接口不通时，列目录会一直等到
+    超时，屏幕上却停在上一行不动。用户看到的是「体检自己卡死了」——最需要它说话
+    的时刻，它反而一声不吭。
+    这里先打一行不换行的占位，_hc 用 \\r + 清行覆盖掉它。
+    """
+    print(f"    {pad(label, 20)}{DIM}测试中…最多 {secs} 秒{RST}", end="", flush=True)
 
 
 def _short_err(s):
@@ -3055,6 +3066,7 @@ def do_healthcheck():
         if not token:
             _hc(f"列目录 {p}", "skip", "OpenList 没登上")
             continue
+        _hc_wait(f"列目录 {p}", 120)
         t0 = time.monotonic()
         try:
             # refresh: true —— 不加的话 OpenList 直接返回目录缓存,这一行永远是 0.0 秒,
@@ -3063,7 +3075,10 @@ def do_healthcheck():
             # 根本没联网。体检要量的是真实链路,不是缓存命中率。
             r = _ol_api("/api/fs/list", {"path": p, "password": "", "page": 1,
                                          "per_page": 0, "refresh": True},
-                        token, timeout=180)
+                        # 120 秒封顶,不是 180:体检本来就是"东西坏了"才跑的,
+                        # 网盘不通时每条路径干等 3 分钟,人只会以为体检自己死了。
+                        # 实测最慢的一次真实列目录是 119.8 秒,120 刚好盖住。
+                        token, timeout=120)
             el = time.monotonic() - t0
             items = (r.get("data") or {}).get("content")
             if r.get("code") != 200:
@@ -3126,9 +3141,10 @@ def do_healthcheck():
         _hc("换直链", "skip", "还没有 strm 文件，无从测起")
     for mount, fp in list(by_mount.items())[:3]:       # 封顶 3 个,每个最坏要等半分钟
         label = "换直链" if len(by_mount) == 1 else f"换直链 {mount}"
+        _hc_wait(label, 60)
         t0 = time.monotonic()
         try:
-            r = _ol_api("/api/fs/get", {"path": fp, "password": ""}, token)
+            r = _ol_api("/api/fs/get", {"path": fp, "password": ""}, token, timeout=60)
             el = time.monotonic() - t0
             raw = (r.get("data") or {}).get("raw_url", "")
             if not raw:

--- a/media-stack.py
+++ b/media-stack.py
@@ -738,31 +738,27 @@ layout:
         href: {url_for(sub, port)}
         description: {'影视播放' if container == 'emby' else '网盘挂载'}
         siteMonitor: {monitor.get(container, f'http://{container}:{port}')}""")
-    # 三块系统资源各自单独成组：Homepage 的 label 是「给这一组起名」，写在同一个
-    # resources 块里只会出一个标题，所以拆成三块才能分别标上 CPU / 内存 / 硬盘。
+    # ⚠ 三样资源必须写在【同一个】 resources 块里，不要为了分别加中文标题拆开。
+    # 试过拆成三块（label 是「给这一组起名」，一块只能有一个标题），结果是
+    # 只有一块能拿到数据，另外两块常驻「-」，被挪走的那块还会显示「API 错误」——
+    # 接口本身是好的（直接 curl /api/widgets/resources?type=memory 数据齐全），
+    # 纯粹是多块并存渲染不出来。拿标题换掉数据，是笔亏本买卖。
     #
-    # 标题里【不要】写核数、内存总量这类硬件数字。每台机器配置不一样，而写进
+    # 标题里也【不要】写核数、内存总量这类硬件数字。每台机器配置不一样，而写进
     # widgets.yaml 的是生成那一刻的快照 —— 升配、换机之后不跑「更新」就一直是错的，
     # 面板上摆一个错数字比不摆更糟。核数尤其没法做成实时的：Homepage 的
     # /api/widgets/resources?type=cpu 只返回 usage 和 load，压根没有核数这个字段。
     #
-    # expanded 让内存/硬盘除了「剩余」再显示「已用 / 总量」，CPU 多显示 load —— 这些
-    # 都是容器自己实时读的。硬盘那格万一又读不出来（显示 -），旁边还有总量兜底。
+    # expanded 让内存/硬盘除了「剩余」再显示「总量」，CPU 多显示 load。
     #
     # 盯 /app/config 而不是 / ：容器里的 / 是 overlay，Homepage 官方文档写明要监控的
     # 盘必须挂进容器。/app/config 是 {安装目录}/homepage/config 的 bind mount，
     # df 出来是真实的块设备（/dev/vda1），读的就是宿主机根分区的容量。
     widgets = """- resources:
-    label: CPU
+    label: 系统
     expanded: true
     cpu: true
-- resources:
-    label: 内存
-    expanded: true
     memory: true
-- resources:
-    label: 硬盘
-    expanded: true
     disk: /app/config
 - search:
     provider: duckduckgo

--- a/media-stack.py
+++ b/media-stack.py
@@ -30,6 +30,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import zipfile
 
 SCRIPT_VERSION = "1.1.0"
 
@@ -423,6 +424,28 @@ def gen_compose(cfg):
       - {d}/homepage/config:/app/config
     ports:
       - "{bind}3000:3000"
+    networks: [mediastack]
+""")
+
+    if cfg.get("metatube"):
+        # 【不映射端口】：只有同一个 docker 网络里的 Emby 需要访问它，nginx 也不
+        # 给它建站点。所以不设 -token —— 在这个拓扑下加了也拦不住任何人，代价却是
+        # 用户要把一串随机字符抄进 Emby 的插件设置页。真要对外开放时再补。
+        #
+        # -dsn 要的是【纯文件路径】，不是 URL。实测：
+        #   /data/metatube.db            ✔ 建表成功
+        #   sqlite:///data/metatube.db   ✖ unable to open database file
+        # 不带 -dsn 也能跑，但数据不落盘，重启后缓存全丢、每次都要重新抓站。
+        parts.append(f"""  metatube:
+    image: {METATUBE_IMAGE}
+    container_name: metatube
+    restart: unless-stopped
+    environment:
+      - TZ=${{TZ}}
+    volumes:
+      - {d}/metatube:/data
+    command: ["-port", "{METATUBE_PORT}", "-bind", "0.0.0.0",
+              "-dsn", "/data/metatube.db", "-db-auto-migrate"]
     networks: [mediastack]
 """)
 
@@ -1400,6 +1423,9 @@ def rebuild_cfg_from_disk(d):
         "ba_pass":  read_env(sec_file, "BA_PASS", fallback=env_file),
         # 装了 Homepage 就有这个目录；容器可能被手动停掉，用目录判断更稳
         "homepage": os.path.isdir(os.path.join(d, "homepage", "config")),
+        # MetaTube 用 compose 里有没有这个服务来判断，不看目录:关掉之后数据目录
+        # 是留着的(里面是刮好的元数据缓存,再打开能直接接着用),看目录会误判成"装着"
+        "metatube": metatube_on(d),
         "host_ip":  "",     # 只有无域名模式才用得上，下面按需取
     }
     # 这三个是装的时候用户填的，脚本没有别的地方存 —— 从上次生成的配置里读回来，
@@ -2587,6 +2613,42 @@ def set_web_credentials():
           f"或清一下该站点的登录状态。{RST}")
 
 
+# ============================================================================ MetaTube
+# 按番号刮削的 Emby 插件。跟这套网盘直链没有任何关系，纯粹是「Emby 拿到文件之后
+# 怎么刮信息」那一层的补充，默认不装。
+#
+# 它是【两件东西】,少一件就是"装了但不工作":
+#   · MetaTube Server —— 独立后端,插件自己不抓站,所有请求都转给它
+#   · Emby 插件本体   —— 放进 Emby 的 plugins 目录
+METATUBE_IMAGE = "ghcr.io/metatube-community/metatube-server:latest"
+METATUBE_PORT  = 8080
+METATUBE_API   = ("https://api.github.com/repos/metatube-community"
+                  "/jellyfin-plugin-metatube/releases/latest")
+# 下载地址在运行时查 Releases,不写死:写死的话人家发新版就断了。
+# 同一个 release 里 Emby 和 Jellyfin 各一个包,按前缀挑 —— 实测资产名形如
+#   Emby.MetaTube@v2025.1102.2200.0.zip
+#   Jellyfin.MetaTube@v2025.1102.2200.0.zip
+METATUBE_ASSET_PREFIX = "Emby."
+
+
+def metatube_dir(d):
+    return os.path.join(d, "metatube")
+
+
+def emby_plugin_dir(d):
+    """Emby 容器里的 /config/plugins 对应的宿主机目录。"""
+    return os.path.join(d, "emby", "config", "plugins")
+
+
+def metatube_on(d):
+    """compose 里有没有 metatube 这个服务。"""
+    try:
+        with open(os.path.join(d, "docker-compose.yml"), encoding="utf-8") as f:
+            return "container_name: metatube" in f.read()
+    except OSError:
+        return False
+
+
 LINK_METHODS = {
     "download":  ("原画直链", "画质最好（网盘里是什么就播什么），但码率高；"
                             "跨境线路上 4K 原盘经常拉不动"),
@@ -2620,6 +2682,139 @@ def link_method_storages(d):
         if "link_method" in a:
             out.append((sid, mp, drv, str(a.get("link_method") or "")))
     return out
+
+
+def _compose_up(d):
+    compose = os.path.join(d, "docker-compose.yml")
+    env_file = os.path.join(d, ".env")
+    return subprocess.run(
+        f"docker compose -f {compose} --env-file {env_file} up -d --remove-orphans",
+        shell=True, timeout=900).returncode == 0
+
+
+def _metatube_fetch_plugin(d):
+    """下载并解压 Emby 版插件，返回落地的文件名列表。"""
+    req = urllib.request.Request(
+        METATUBE_API,
+        headers={"Accept": "application/vnd.github+json",
+                 # GitHub 的 API 不带 UA 会直接 403
+                 "User-Agent": "media-stack"})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        rel = json.load(r)
+    asset = next((a for a in rel.get("assets") or []
+                  if str(a.get("name", "")).startswith(METATUBE_ASSET_PREFIX)
+                  and str(a.get("name", "")).endswith(".zip")), None)
+    if not asset:
+        names = "、".join(a.get("name", "?") for a in (rel.get("assets") or [])) or "（空）"
+        raise RuntimeError(f"这个 release 里没有 Emby 版插件包。现有：{names}")
+    info(f"下载 {asset['name']}（{rel.get('tag_name', '')}）...")
+    dst = emby_plugin_dir(d)
+    os.makedirs(dst, exist_ok=True)
+    tmp = os.path.join(dst, ".metatube.zip.part")
+    req = urllib.request.Request(asset["browser_download_url"],
+                                 headers={"User-Agent": "media-stack"})
+    with urllib.request.urlopen(req, timeout=300) as r, open(tmp, "wb") as f:
+        shutil.copyfileobj(r, f)
+    written = []
+    try:
+        with zipfile.ZipFile(tmp) as z:
+            for n in z.namelist():
+                # 只取压缩包根部的普通文件,挡掉 ../ 之类的路径穿越
+                base = os.path.basename(n)
+                if not base or n.endswith("/"):
+                    continue
+                with z.open(n) as src, open(os.path.join(dst, base), "wb") as out:
+                    shutil.copyfileobj(src, out)
+                written.append(base)
+    finally:
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+    if not written:
+        raise RuntimeError("压缩包里没有文件")
+    return written
+
+
+def toggle_metatube():
+    """装 / 卸 MetaTube（服务端容器 + Emby 插件），一个按钮来回切。
+
+    两件东西必须一起动:只装插件不装服务端的话,插件什么都刮不出来,而界面上
+    看起来"装好了" —— 那种状态最难排查。
+    """
+    d = ms_install_dir()
+    if not is_installed(d):
+        warn(f"还没安装（{d} 下没有 docker-compose.yml）。先选 1 安装。")
+        return
+    on = metatube_on(d)
+    files = ms_state().get("metatube_files") or []
+
+    print()
+    print(f"  {BOLD}MetaTube{RST} {DIM}—— 按番号刮削的 Emby 插件{RST}")
+    print(f"  {DIM}给文件名是番号（ABC-123 这种）的片子刮标题、封面、演员。")
+    print(f"  普通电影电视剧用不上它 —— 那些 Emby 自带的 TMDb 就够了。{RST}")
+    print(f"  {DIM}要求 Emby 4.9 及以上。{RST}")
+    print()
+    print(f"  当前：{(GREEN + BOLD + '已安装' + RST) if on else (DIM + '未安装' + RST)}")
+    print()
+
+    if on:
+        print(f"  {DIM}卸载会：删掉 metatube 容器、删掉插件文件、重启 Emby。{RST}")
+        print(f"  {DIM}已经刮好的元数据缓存（{metatube_dir(d)}）留着不删，")
+        print(f"  以后再装回来能直接接着用。{RST}")
+        if not ask_yn("现在卸载吗？", False):
+            print("没有改动。")
+            return
+        for n in files:
+            try:
+                os.remove(os.path.join(emby_plugin_dir(d), n))
+            except OSError:
+                pass
+        cfg = rebuild_cfg_from_disk(d)
+        cfg["metatube"] = False
+        with open(os.path.join(d, "docker-compose.yml"), "w") as f:
+            f.write(gen_compose(cfg))
+        subprocess.run(["docker", "rm", "-f", "metatube"], capture_output=True)
+        _compose_up(d)
+        subprocess.run(["docker", "restart", "emby"], capture_output=True)
+        save_ms_state(metatube_files=[])
+        ok("已卸载（元数据缓存保留）")
+        return
+
+    print(f"  {DIM}安装会新增一个容器（几十 MB），并下载插件到 Emby 的插件目录。{RST}")
+    print(f"  {DIM}服务端不映射端口，只有同网络的 Emby 连得到。{RST}")
+    if not ask_yn("现在安装吗？", False):
+        print("没有改动。")
+        return
+
+    try:
+        files = _metatube_fetch_plugin(d)
+    except Exception as e:
+        err(f"插件下载失败：{_short_err(e)}")
+        print(f"  {DIM}容器还没动，什么都没改。网络好了再试一次。{RST}")
+        return
+    ok(f"插件已就位：{'、'.join(files)}")
+
+    cfg = rebuild_cfg_from_disk(d)
+    cfg["metatube"] = True
+    os.makedirs(metatube_dir(d), exist_ok=True)
+    with open(os.path.join(d, "docker-compose.yml"), "w") as f:
+        f.write(gen_compose(cfg))
+    info("启动 MetaTube 服务端...")
+    if not _compose_up(d):
+        err("容器启动失败，看上面的报错。")
+        return
+    subprocess.run(["docker", "restart", "emby"], capture_output=True)
+    save_ms_state(metatube_files=files)
+    ok("装好了")
+    print()
+    print(f"  {YELLOW}还有两步要你在 Emby 里手动做{RST}{DIM}（脚本代劳不了，"
+          f"那是插件自己的设置页）：{RST}")
+    print(f"  {DIM}1.{RST} Emby → 设置 → 插件 → MetaTube → 服务器地址填 "
+          f"{CYAN}{BOLD}http://metatube:{METATUBE_PORT}{RST}")
+    print(f"  {DIM}2.{RST} 要用它的那个媒体库 → 编辑 → 刮削器里勾上 "
+          f"{BOLD}MetaTube{RST}，再扫一次")
+    print(f"  {DIM}插件没出现的话，Emby 可能还没加载完，等一会儿刷新设置页。{RST}")
 
 
 def set_link_method():
@@ -2814,6 +3009,9 @@ def params_menu():
             sp_state = f"{DIM}未安装{RST}"
         print(f"  4. 扫描路径（加网盘 / 换目录）")
         print(f"     {DIM}当前：{sp_state}{RST}")
+        mt_state = ((f"{GREEN}已安装{RST}" if metatube_on(d) else f"{DIM}未安装{RST}")
+                    if is_installed(d) else f"{DIM}未安装{RST}")
+        print(f"  5. MetaTube 刮削插件（番号识别）  当前：{mt_state}")
         print("  0. 返回")
         print("-" * 60)
         c = ask("请选择").strip()
@@ -2827,6 +3025,8 @@ def params_menu():
             set_link_method()
         elif c == "4":
             set_scan_paths()
+        elif c == "5":
+            toggle_metatube()
         else:
             print("无效选择。")
             continue

--- a/xy-installer.py
+++ b/xy-installer.py
@@ -1930,7 +1930,7 @@ def _self_ip():
     return _SELF_IP_CACHE
 
 def _root_domain(host):
-    """收敛到可注册域：dmcn2.679588.xyz → 679588.xyz。
+    """收敛到可注册域：node2.example.com → example.com。
 
        多机聚合时同一个注册域下会冒出一堆子域（各节点域名、订阅域名、AdGuard DoT 的
        <ClientID>.域名…），逐条写进规则里又长又重复，还全是同一个域。收敛成一条就够。


### PR DESCRIPTION
Emby 自带的 TMDb 刮不到按番号命名的片子。MetaTube 补这一层。

但它不是「一个插件」那么简单 —— 是**两件东西**，少一件就是「装了、界面上看着正常、什么都刮不出来」，那种状态最难排查：

- **MetaTube Server 容器**：插件自己不抓站，所有请求都转给它
- **Emby 插件本体**：放进 `emby/config/plugins/`

所以做成一个开关，两件一起装、一起卸，跟「3 直链方式」一个手感：点进去先显示当前状态，`y` 确认，`n` 返回。

## 实测确定的值（跑出来的，不是照文档抄的）

| | |
|---|---|
| 镜像 | `ghcr.io/metatube-community/metatube-server:latest` |
| 参数 | `-port` / `-bind` / `-dsn` / `-token` / `-db-auto-migrate` |
| 插件包 | 按 `Emby.` 前缀挑（同一 release 里还有 `Jellyfin.` 那个） |

`-dsn` 要的是**纯文件路径**：

```
/data/metatube.db            ✔ 建表成功，落地 28 KB 的 db
sqlite:///data/metatube.db   ✖ unable to open database file
不带 -dsn                     ✔ 能跑，但数据不落盘，重启后缓存全丢
```

## 设计决定

- **下载地址运行时查 GitHub Releases**，不写死版本号 —— 上游发新版不会断
- **不设 `-token`**：服务端不映射端口、nginx 也不给它建站点，只有 `mediastack` 网络内的容器碰得到。在这个拓扑下 token 拦不住任何人，代价却是要把一串随机字符抄进 Emby 的插件设置页。将来真要对外开放再补
- **卸载保留 `metatube/` 数据目录**（里面是刮好的元数据缓存），再装回来能接着用。因此「装没装」的判据是 compose 里有没有这个服务，不是看目录
- **解压只取压缩包根部的普通文件并走 `basename`**，挡掉 `../` 路径穿越
- **插件下载失败就原样返回，不碰容器** —— 不留半装状态

装完还需要用户在 Emby 里填服务端地址（`http://metatube:8080`）和勾上刮削器，这两步脚本代劳不了，安装成功后直接打印出来。

## 验证

- `python3 -m py_compile` 通过
- `gen_compose` 在 `metatube` 开 / 关两种 cfg 下的输出已确认
- 下载解压逻辑用假 release + 假 zip 离线跑通：正确挑中 `Emby.` 那个包、跳过 `Jellyfin.`；`nested/../evil.txt` 被 `basename` 压平，写不出插件目录

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_