### PR TITLE
使用信息：堵住令牌泄漏，把诊断挪给体检，补上 MetaTube 用法

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2130,12 +2130,15 @@ def emby_scan_wait(key, timeout=600):
     return False
 
 
-def _emby(path, key, method="GET", timeout=60):
+def _emby(path, key, method="GET", timeout=60, body=None):
     u = f"http://127.0.0.1:8096{path}{'&' if '?' in path else '?'}api_key={key}"
-    with urllib.request.urlopen(
-            urllib.request.Request(u, method=method), timeout=timeout) as r:
-        body = r.read()
-    return json.loads(body) if body.strip() else {}
+    req = urllib.request.Request(
+        u, method=method,
+        data=json.dumps(body).encode() if body is not None else None,
+        headers={"Content-Type": "application/json"} if body is not None else {})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        out = r.read()
+    return json.loads(out) if out.strip() else {}
 
 
 def items_without_duration(key):
@@ -2174,6 +2177,51 @@ def items_without_duration(key):
     return out
 
 
+RESUME_MIN_SECONDS = 10     # 播够多少秒才值得记续播点
+RESUME_MIN_PCT     = 1      # 播到百分之几才值得记
+
+
+def tune_resume_thresholds(key):
+    """把媒体库的续播门槛调到对短片子也公平的值。
+
+    Emby 每个媒体库有三个续播参数,默认值是按"电影"设计的:
+        MinResumeDurationSeconds  120   播放位置不到 120 秒就不记
+        MinResumePct                2   不到总时长 2% 不记
+        MaxResumePct               90   超过 90% 判定看完,清掉续播点
+    网盘库里什么长度都有。一个 1 分多钟的片子,播放位置【永远】到不了 120 秒,
+    于是永远没有续播记忆 —— 用户看到的是"长的能记住、短的记不住",像是坏了,
+    其实是规则如此。而这三个值 Emby 的网页设置里不给改,只能走接口。
+
+    只动指向本脚本 strm 目录的媒体库:用户自己另外建的库(本地电影、音乐之类)
+    不该被这个脚本碰。MaxResumePct 也不动 —— 那条是按比例算的,长短本来就公平。
+    """
+    try:
+        libs = _emby("/Library/VirtualFolders", key)
+    except Exception:
+        return
+    for lb in libs:
+        if not any(STRM_PATH in p or p in STRM_PATH for p in (lb.get("Locations") or [])):
+            continue
+        o = lb.get("LibraryOptions") or {}
+        cur_s = o.get("MinResumeDurationSeconds")
+        cur_p = o.get("MinResumePct")
+        if cur_s == RESUME_MIN_SECONDS and cur_p == RESUME_MIN_PCT:
+            continue
+        o["MinResumeDurationSeconds"] = RESUME_MIN_SECONDS
+        o["MinResumePct"] = RESUME_MIN_PCT
+        try:
+            _emby("/Library/VirtualFolders/LibraryOptions",
+                  key, method="POST",
+                  body={"Id": lb.get("ItemId"), "LibraryOptions": o})
+        except Exception as e:
+            warn(f"改「{lb.get('Name')}」的续播门槛失败：{_short_err(e)}")
+            continue
+        ok(f"媒体库「{lb.get('Name')}」续播门槛：{cur_s}秒/{cur_p}% → "
+           f"{RESUME_MIN_SECONDS}秒/{RESUME_MIN_PCT}%")
+        print(f"  {DIM}默认的 120 秒是按电影长度定的，短片子永远够不到，"
+              f"表现为「长的记得住、短的记不住」。{RST}")
+
+
 def warm_media_info(d, key):
     """提前把每个新条目探测一遍，别等用户按下播放时才现探。
 
@@ -2182,7 +2230,7 @@ def warm_media_info(d, key):
         连接 0.11 / 2.5 / 32.4 秒，首字节 0.90 / 20.2 / 39.4 秒
     而 Emby 把它放在 PlaybackInfo 里做 —— 也就是【用户按下播放的那一刻】。
     浏览器等不到,38 秒就自己取消,日志里是
-        502 | 38.28s | POST /emby/Items/119/PlaybackInfo?...IsPlayback=true
+        502 | 38.28s | POST /emby/Items/<id>/PlaybackInfo?...IsPlayback=true
         http: proxy error: context canceled
     用户看到的是转圈或者「当前没有兼容的流」。
 
@@ -2427,6 +2475,7 @@ def do_strm():
             ok("Emby 已扫完")
         else:
             ok("已通知 Emby 扫描（后台进行，稍等片刻刷新 Emby 页面）")
+        tune_resume_thresholds(key)
         warm_media_info(d, key)
     else:
         warn("没有 Emby API Key，没法自动触发扫描。去 Emby 后台手动扫一次媒体库。")

--- a/media-stack.py
+++ b/media-stack.py
@@ -28,6 +28,7 @@ import subprocess
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 
 SCRIPT_VERSION = "1.1.0"
@@ -2880,14 +2881,45 @@ class _NoRedirect(urllib.request.HTTPRedirectHandler):
         return None
 
 
-def probe_302(key):
+def strm_target_path(content):
+    """从 strm 内容里还原出它在 OpenList 上的路径。两种形态都要认:
+
+      · 路径形式(旧)   /quark/电影/x.mp4
+      · URL 形式(新)   https://list.<域名>/d/quark/电影/x.mp4?sign=…
+
+    体检里有几项要按「挂载点」给文件分组,只认路径形式的话,升级之后会得出
+    「还没有 strm 文件」这种和上一行「strm 文件 3 个」直接打架的结论。
+    """
+    c = (content or "").strip()
+    if not c:
+        return ""
+    if c.startswith("/"):
+        return c
+    if not c.lower().startswith("http"):
+        return ""
+    try:
+        p = urllib.parse.unquote(urllib.parse.urlsplit(c).path)
+    except Exception:
+        return ""
+    # OpenList 的下载端点是 /d/<路径>，也见过带签名前缀的 /dav/ 形态
+    for pre in ("/d/", "/dav/"):
+        if p.startswith(pre):
+            return "/" + p[len(pre):]
+    return p or ""
+
+
+def probe_302(key, own_host=""):
     """真的发一次播放请求，看 MediaWarp 到底回不回 302、302 到哪。
 
     这是整套东西唯一的端到端证明。前面那些检查(存储 work、能换到直链)都只说明
     "零件是好的",而播放实际走哪条路要看这一下:
-      · 302 → 网盘 CDN     视频从网盘直达播放器,不经过本机 —— 这才是目的
-      · 302 → 内部地址     客户端根本连不上(raw_url: false 就是这个后果)
+      · 302 → 内部地址     客户端根本连不上
       · 200 不是 302       MediaWarp 没拦住,视频要经过本机中转,吃你的带宽
+
+    strm 改成 URL 形式之后这里【多了一跳】,只看第一跳会得出错误结论:
+    MediaWarp 现在 302 到的是 OpenList 的公网地址(own_host),播放器要再跟一次
+    才到网盘 CDN。所以拿到第一跳之后还要再跟一次,确认后半段也是通的 ——
+    否则「302 → 自己的域名」看起来像成功,实际上可能第二跳就死了。
 
     返回 (state, 说明)。
     """
@@ -2922,6 +2954,29 @@ def probe_302(key):
                     or _is_private_ip(bare))
         if internal:
             return "bad", f"302 → {host}  {RED}内部地址，客户端连不上{RST}"
+
+        # 第一跳落在自己的 OpenList 公网域名上 —— 这是 URL 形式 strm 的正常形态,
+        # 但还没到网盘。必须再跟一跳才知道后半段通不通:只看第一跳的话,
+        # 「302 → 自己的域名」看起来像成功,实际可能第二跳就死了。
+        if own_host and bare == own_host:
+            try:
+                with opener.open(loc, timeout=60) as r2:
+                    return "bad", (f"302 → {bare} 之后没有再跳转（HTTP {r2.status}）"
+                                   f"  {RED}视频会经过本机{RST}")
+            except urllib.error.HTTPError as e2:
+                if e2.code not in (301, 302, 303, 307, 308):
+                    return "bad", f"{bare} 返回 HTTP {e2.code}  {RED}换直链失败{RST}"
+                loc = e2.headers.get("Location", "")
+                host = loc.split("/")[2] if "://" in loc else loc[:40]
+                bare = host.split(":")[0]
+                if bare in ("openlist", "emby", "mediawarp", "localhost") or _is_private_ip(bare):
+                    return "bad", f"第二跳 → {host}  {RED}内部地址，客户端连不上{RST}"
+                two_hop = True
+            except Exception as ex:
+                return "bad", f"{bare} 那一跳失败：{_short_err(ex)}"
+        else:
+            two_hop = False
+
         # 判断实际拿到的是原画还是转码流。光看 .m3u8 会判错:夸克的转码流地址是
         # video-play-*.drive.quark.cn,并不一定以 m3u8 结尾,而原画是 dl-*。
         # 实际就出现过「302 那行说原画、直链方式那行说转码流」自相矛盾。
@@ -2932,8 +2987,9 @@ def probe_302(key):
             kind = "原画"
         else:
             kind = ""
-        tail = f"（{kind}，直连网盘、不经过本机）" if kind else "（直连网盘、不经过本机）"
-        return "ok", f"302 → {host}  {DIM}{tail}{RST}"
+        head = f"302 →{' ' + own_host + ' →' if two_hop else ''} {host}"
+        tail = (f"（{kind}，" if kind else "（") + "视频直达网盘，不经过本机）"
+        return "ok", f"{head}  {DIM}{tail}{RST}"
     except Exception as e:
         return "bad", _short_err(e)
 
@@ -3128,9 +3184,13 @@ def do_healthcheck():
             read_env(os.path.join(d, ".env"), "DATA_ROOT") or os.path.join(d, "media"),
             "strm", "**", "*.strm"), recursive=True)):
         try:
-            fp = open(f, encoding="utf-8").read().strip()
+            raw = open(f, encoding="utf-8").read()
         except OSError:
             continue
+        # strm 有两种形态(路径 / URL),统一还原成 OpenList 上的路径再分组。
+        # 只认路径形式的话,升级之后这里会空掉,体检就会打出「还没有 strm 文件」
+        # 而上一行明明写着「strm 文件 3 个」—— 自相矛盾比不检查更误导。
+        fp = strm_target_path(raw)
         if not fp.startswith("/"):
             continue
         mount = "/" + fp.lstrip("/").split("/")[0]      # /quark/电影/x.mp4 → /quark
@@ -3181,16 +3241,18 @@ def do_healthcheck():
         _hc("MediaWarp→Emby", "bad", _short_err(e))
         todo.append(("MediaWarp 打不通 Emby", "docker logs --tail 30 mediawarp"))
     # ---- 302 端到端 ----
-    st302, msg302 = probe_302(key)
+    own_host = urllib.parse.urlsplit(openlist_public_url(cfg)).hostname or ""
+    _hc_wait("302 直链", 90)
+    st302, msg302 = probe_302(key, own_host)
     _hc("302 直链", st302, msg302)
     if st302 == "bad":
         if "不是 302" in msg302:
             todo.append(("MediaWarp 没有拦截播放请求，视频会经过本机中转",
-                         "检查 mediawarp/config.yaml 的 alist_strm.prefix_list "
-                         f"是不是 {STRM_PATH}，以及 strm 内容是不是纯路径"))
+                         "检查 mediawarp/config.yaml 的 http_strm.enable 是不是 true、"
+                         f"prefix_list 是不是 {STRM_PATH}；「6 更新」会重新生成"))
         elif "内部地址" in msg302:
             todo.append(("302 指向了容器内部地址，播放器连不上",
-                         "mediawarp/config.yaml 里 raw_url 要是 true；"
+                         "autofilm 的 public_url 要填播放器能访问的地址；"
                          "「6 更新」会重新生成这份配置"))
         else:
             todo.append(("302 没生成", "多半是上一行的换直链失败，等线路恢复再试"))

--- a/media-stack.py
+++ b/media-stack.py
@@ -2840,7 +2840,18 @@ def params_menu():
 def _hc(label, state, detail=""):
     icon = {"ok": f"{GREEN}✔{RST}", "warn": f"{YELLOW}⚠{RST}",
             "bad": f"{RED}✖{RST}", "skip": f"{DIM}—{RST}"}[state]
-    print(f"    {pad(label, 20)}{icon}  {detail}")
+    print(f"\r\x1b[2K    {pad(label, 20)}{icon}  {detail}")
+
+
+def _hc_wait(label, secs):
+    """慢检查开始前先把行占上，让人看得见它在等什么、要等多久。
+
+    体检恰恰是「东西已经坏了」的时候才会跑的：网盘接口不通时，列目录会一直等到
+    超时，屏幕上却停在上一行不动。用户看到的是「体检自己卡死了」——最需要它说话
+    的时刻，它反而一声不吭。
+    这里先打一行不换行的占位，_hc 用 \\r + 清行覆盖掉它。
+    """
+    print(f"    {pad(label, 20)}{DIM}测试中…最多 {secs} 秒{RST}", end="", flush=True)
 
 
 def _short_err(s):
@@ -3055,6 +3066,7 @@ def do_healthcheck():
         if not token:
             _hc(f"列目录 {p}", "skip", "OpenList 没登上")
             continue
+        _hc_wait(f"列目录 {p}", 120)
         t0 = time.monotonic()
         try:
             # refresh: true —— 不加的话 OpenList 直接返回目录缓存,这一行永远是 0.0 秒,
@@ -3063,7 +3075,10 @@ def do_healthcheck():
             # 根本没联网。体检要量的是真实链路,不是缓存命中率。
             r = _ol_api("/api/fs/list", {"path": p, "password": "", "page": 1,
                                          "per_page": 0, "refresh": True},
-                        token, timeout=180)
+                        # 120 秒封顶,不是 180:体检本来就是"东西坏了"才跑的,
+                        # 网盘不通时每条路径干等 3 分钟,人只会以为体检自己死了。
+                        # 实测最慢的一次真实列目录是 119.8 秒,120 刚好盖住。
+                        token, timeout=120)
             el = time.monotonic() - t0
             items = (r.get("data") or {}).get("content")
             if r.get("code") != 200:
@@ -3126,9 +3141,10 @@ def do_healthcheck():
         _hc("换直链", "skip", "还没有 strm 文件，无从测起")
     for mount, fp in list(by_mount.items())[:3]:       # 封顶 3 个,每个最坏要等半分钟
         label = "换直链" if len(by_mount) == 1 else f"换直链 {mount}"
+        _hc_wait(label, 60)
         t0 = time.monotonic()
         try:
-            r = _ol_api("/api/fs/get", {"path": fp, "password": ""}, token)
+            r = _ol_api("/api/fs/get", {"path": fp, "password": ""}, token, timeout=60)
             el = time.monotonic() - t0
             raw = (r.get("data") or {}).get("raw_url", "")
             if not raw:

--- a/media-stack.py
+++ b/media-stack.py
@@ -738,31 +738,27 @@ layout:
         href: {url_for(sub, port)}
         description: {'影视播放' if container == 'emby' else '网盘挂载'}
         siteMonitor: {monitor.get(container, f'http://{container}:{port}')}""")
-    # 三块系统资源各自单独成组：Homepage 的 label 是「给这一组起名」，写在同一个
-    # resources 块里只会出一个标题，所以拆成三块才能分别标上 CPU / 内存 / 硬盘。
+    # ⚠ 三样资源必须写在【同一个】 resources 块里，不要为了分别加中文标题拆开。
+    # 试过拆成三块（label 是「给这一组起名」，一块只能有一个标题），结果是
+    # 只有一块能拿到数据，另外两块常驻「-」，被挪走的那块还会显示「API 错误」——
+    # 接口本身是好的（直接 curl /api/widgets/resources?type=memory 数据齐全），
+    # 纯粹是多块并存渲染不出来。拿标题换掉数据，是笔亏本买卖。
     #
-    # 标题里【不要】写核数、内存总量这类硬件数字。每台机器配置不一样，而写进
+    # 标题里也【不要】写核数、内存总量这类硬件数字。每台机器配置不一样，而写进
     # widgets.yaml 的是生成那一刻的快照 —— 升配、换机之后不跑「更新」就一直是错的，
     # 面板上摆一个错数字比不摆更糟。核数尤其没法做成实时的：Homepage 的
     # /api/widgets/resources?type=cpu 只返回 usage 和 load，压根没有核数这个字段。
     #
-    # expanded 让内存/硬盘除了「剩余」再显示「已用 / 总量」，CPU 多显示 load —— 这些
-    # 都是容器自己实时读的。硬盘那格万一又读不出来（显示 -），旁边还有总量兜底。
+    # expanded 让内存/硬盘除了「剩余」再显示「总量」，CPU 多显示 load。
     #
     # 盯 /app/config 而不是 / ：容器里的 / 是 overlay，Homepage 官方文档写明要监控的
     # 盘必须挂进容器。/app/config 是 {安装目录}/homepage/config 的 bind mount，
     # df 出来是真实的块设备（/dev/vda1），读的就是宿主机根分区的容量。
     widgets = """- resources:
-    label: CPU
+    label: 系统
     expanded: true
     cpu: true
-- resources:
-    label: 内存
-    expanded: true
     memory: true
-- resources:
-    label: 硬盘
-    expanded: true
     disk: /app/config
 - search:
     provider: duckduckgo

--- a/media-stack.py
+++ b/media-stack.py
@@ -1319,22 +1319,21 @@ def show_info():
     if os.path.exists(NGX_SITE):
         print(f"      nginx 站点 {NGX_SITE}")
 
+    # 这一屏是「地址 / 账号密码 / 怎么用」，不是诊断屏。所以这里只列【挂了哪些盘】,
+    # 状态细节和修法全部交给「5 链路体检」——
+    #   · status 字段装的是整条 Go 错误，里面带着 access_token。原样打印等于把网盘
+    #     令牌摆在屏幕上，而这一屏恰恰是最常被截图发出去的
+    #   · 而且它是【存储初始化那一刻】写进去的，之后恢复了也不会改回 work，
+    #     拿它当实时状态用会把陈年记录报成当前故障
     stores = openlist_storages(d)
     if stores:
         print(f"\n  {BOLD}▸ 网盘挂载{RST}")
         for mp, drv, status, root in stores:
-            col = GREEN if status == "work" else YELLOW
-            print(f"      {pad(mp, 14)}{pad(drv, 12)}{col}{status}{RST}"
-                  + (f"   {DIM}根文件夹ID={root}{RST}" if root else ""))
-        # 夸克要的是「文件夹 ID」，根目录是 0。填成 / 这种路径写法，夸克会回
-        # "必传参数不能为空"——表现极具迷惑性：存储状态是 work、二维码也扫过了，
-        # 但点进去目录是空的，AutoFilm 每晚跑完 strm_created_count 都是 0。
-        for mp, drv, _status, root in stores:
-            if drv.lower().startswith("quark") and (not root or "/" in root):
-                print()
-                warn(f"{mp} 的根文件夹ID 是 {root or '<空>'}，夸克认的是文件夹 ID 不是路径。")
-                warn("根目录要填 0，否则目录挂得上但是空的，strm 一个也不会生成。")
-                warn("改：OpenList 管理 → 存储 → 编辑 → 根文件夹ID 填 0 → 全部重新加载。")
+            print(f"      {pad(mp, 14)}{pad(drv, 12)}"
+                  + (f"{DIM}根文件夹ID={root}{RST}" if root else ""))
+        if any(s != "work" for _m, _d, s, _r in stores):
+            print(f"      {YELLOW}有存储上次初始化时报过错{RST}"
+                  f"{DIM} —— 跑「5 链路体检」看现在通不通、怎么修{RST}")
 
     # strm 数量是判断「Emby 里为什么是空的」最直接的指标，放在容器状态前面
     n = strm_count(d)
@@ -1353,12 +1352,35 @@ def show_info():
         print(f"        2. 回本菜单点 {GREEN}{BOLD}4 生成媒体库{RST}")
         print(f"      {DIM}生成完再去 Emby 添加媒体库，路径填 {STRM_PATH}{RST}")
 
-    print(f"\n  {BOLD}▸ 容器状态{RST}")
-    r = sh(f"docker compose -f {os.path.join(d, 'docker-compose.yml')} "
-           f"--env-file {env_file} ps", timeout=60)
-    out = (r.stdout or "").strip()
-    print("\n".join("      " + ln for ln in out.splitlines()) if out
-          else f"      {YELLOW}容器没在跑，用「3 更新」或 media-stack start 拉起来。{RST}")
+    if metatube_on(d):
+        print(f"\n  {BOLD}▸ MetaTube 番号刮削{RST}")
+        print(f"      服务端地址 {CYAN}{BOLD}http://metatube:{METATUBE_PORT}{RST}"
+              f"   {DIM}(容器内地址，填进 Emby 插件设置){RST}")
+        print(f"      {DIM}用法：{RST}")
+        print(f"        1. Emby → 设置 → 插件 → MetaTube → 服务器地址填上面那个")
+        print(f"        2. 要用它的媒体库 → 编辑 → 刮削器勾上 {BOLD}MetaTube{RST} → 再扫一次")
+        print(f"      {DIM}只对文件名是番号（ABC-123 这种）的片子有效；")
+        print(f"      普通电影电视剧交给 Emby 自带的 TMDb，别在同一个库里混着开。{RST}")
+        print(f"      {DIM}装/卸：3 后补参数 → 5{RST}")
+
+    # 容器只报「几个在跑」。以前这里直接贴 docker compose ps 的原始输出,在手机上
+    # 每行都折成三四行,IMAGE/COMMAND/PORTS 糊成一片,而真正要看的只有"跑没跑"。
+    # 详细状态在「5 链路体检」里。
+    print(f"\n  {BOLD}▸ 容器{RST}")
+    want = ["emby", "openlist", "autofilm", "mediawarp"]
+    if os.path.isdir(os.path.join(d, "homepage")):
+        want.append("homepage")
+    if metatube_on(d):
+        want.append("metatube")
+    r = sh("docker ps --format '{{.Names}}'", timeout=60)
+    live = set((r.stdout or "").split())
+    down = [n for n in want if n not in live]
+    if not down:
+        print(f"      {GREEN}{len(want)}/{len(want)} 在跑{RST}")
+    else:
+        print(f"      {YELLOW}{len(want) - len(down)}/{len(want)} 在跑"
+              f"   没起来：{'、'.join(down)}{RST}")
+        print(f"      {DIM}拉起来：media-stack start{RST}")
 
     # API Key 是空的话 302 根本不生效，这是最容易被忽略的一步，单独提醒
     try:

--- a/media-stack.py
+++ b/media-stack.py
@@ -30,6 +30,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import zipfile
 
 SCRIPT_VERSION = "1.1.0"
 
@@ -423,6 +424,28 @@ def gen_compose(cfg):
       - {d}/homepage/config:/app/config
     ports:
       - "{bind}3000:3000"
+    networks: [mediastack]
+""")
+
+    if cfg.get("metatube"):
+        # 【不映射端口】：只有同一个 docker 网络里的 Emby 需要访问它，nginx 也不
+        # 给它建站点。所以不设 -token —— 在这个拓扑下加了也拦不住任何人，代价却是
+        # 用户要把一串随机字符抄进 Emby 的插件设置页。真要对外开放时再补。
+        #
+        # -dsn 要的是【纯文件路径】，不是 URL。实测：
+        #   /data/metatube.db            ✔ 建表成功
+        #   sqlite:///data/metatube.db   ✖ unable to open database file
+        # 不带 -dsn 也能跑，但数据不落盘，重启后缓存全丢、每次都要重新抓站。
+        parts.append(f"""  metatube:
+    image: {METATUBE_IMAGE}
+    container_name: metatube
+    restart: unless-stopped
+    environment:
+      - TZ=${{TZ}}
+    volumes:
+      - {d}/metatube:/data
+    command: ["-port", "{METATUBE_PORT}", "-bind", "0.0.0.0",
+              "-dsn", "/data/metatube.db", "-db-auto-migrate"]
     networks: [mediastack]
 """)
 
@@ -1400,6 +1423,9 @@ def rebuild_cfg_from_disk(d):
         "ba_pass":  read_env(sec_file, "BA_PASS", fallback=env_file),
         # 装了 Homepage 就有这个目录；容器可能被手动停掉，用目录判断更稳
         "homepage": os.path.isdir(os.path.join(d, "homepage", "config")),
+        # MetaTube 用 compose 里有没有这个服务来判断，不看目录:关掉之后数据目录
+        # 是留着的(里面是刮好的元数据缓存,再打开能直接接着用),看目录会误判成"装着"
+        "metatube": metatube_on(d),
         "host_ip":  "",     # 只有无域名模式才用得上，下面按需取
     }
     # 这三个是装的时候用户填的，脚本没有别的地方存 —— 从上次生成的配置里读回来，
@@ -2587,6 +2613,42 @@ def set_web_credentials():
           f"或清一下该站点的登录状态。{RST}")
 
 
+# ============================================================================ MetaTube
+# 按番号刮削的 Emby 插件。跟这套网盘直链没有任何关系，纯粹是「Emby 拿到文件之后
+# 怎么刮信息」那一层的补充，默认不装。
+#
+# 它是【两件东西】,少一件就是"装了但不工作":
+#   · MetaTube Server —— 独立后端,插件自己不抓站,所有请求都转给它
+#   · Emby 插件本体   —— 放进 Emby 的 plugins 目录
+METATUBE_IMAGE = "ghcr.io/metatube-community/metatube-server:latest"
+METATUBE_PORT  = 8080
+METATUBE_API   = ("https://api.github.com/repos/metatube-community"
+                  "/jellyfin-plugin-metatube/releases/latest")
+# 下载地址在运行时查 Releases,不写死:写死的话人家发新版就断了。
+# 同一个 release 里 Emby 和 Jellyfin 各一个包,按前缀挑 —— 实测资产名形如
+#   Emby.MetaTube@v2025.1102.2200.0.zip
+#   Jellyfin.MetaTube@v2025.1102.2200.0.zip
+METATUBE_ASSET_PREFIX = "Emby."
+
+
+def metatube_dir(d):
+    return os.path.join(d, "metatube")
+
+
+def emby_plugin_dir(d):
+    """Emby 容器里的 /config/plugins 对应的宿主机目录。"""
+    return os.path.join(d, "emby", "config", "plugins")
+
+
+def metatube_on(d):
+    """compose 里有没有 metatube 这个服务。"""
+    try:
+        with open(os.path.join(d, "docker-compose.yml"), encoding="utf-8") as f:
+            return "container_name: metatube" in f.read()
+    except OSError:
+        return False
+
+
 LINK_METHODS = {
     "download":  ("原画直链", "画质最好（网盘里是什么就播什么），但码率高；"
                             "跨境线路上 4K 原盘经常拉不动"),
@@ -2620,6 +2682,139 @@ def link_method_storages(d):
         if "link_method" in a:
             out.append((sid, mp, drv, str(a.get("link_method") or "")))
     return out
+
+
+def _compose_up(d):
+    compose = os.path.join(d, "docker-compose.yml")
+    env_file = os.path.join(d, ".env")
+    return subprocess.run(
+        f"docker compose -f {compose} --env-file {env_file} up -d --remove-orphans",
+        shell=True, timeout=900).returncode == 0
+
+
+def _metatube_fetch_plugin(d):
+    """下载并解压 Emby 版插件，返回落地的文件名列表。"""
+    req = urllib.request.Request(
+        METATUBE_API,
+        headers={"Accept": "application/vnd.github+json",
+                 # GitHub 的 API 不带 UA 会直接 403
+                 "User-Agent": "media-stack"})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        rel = json.load(r)
+    asset = next((a for a in rel.get("assets") or []
+                  if str(a.get("name", "")).startswith(METATUBE_ASSET_PREFIX)
+                  and str(a.get("name", "")).endswith(".zip")), None)
+    if not asset:
+        names = "、".join(a.get("name", "?") for a in (rel.get("assets") or [])) or "（空）"
+        raise RuntimeError(f"这个 release 里没有 Emby 版插件包。现有：{names}")
+    info(f"下载 {asset['name']}（{rel.get('tag_name', '')}）...")
+    dst = emby_plugin_dir(d)
+    os.makedirs(dst, exist_ok=True)
+    tmp = os.path.join(dst, ".metatube.zip.part")
+    req = urllib.request.Request(asset["browser_download_url"],
+                                 headers={"User-Agent": "media-stack"})
+    with urllib.request.urlopen(req, timeout=300) as r, open(tmp, "wb") as f:
+        shutil.copyfileobj(r, f)
+    written = []
+    try:
+        with zipfile.ZipFile(tmp) as z:
+            for n in z.namelist():
+                # 只取压缩包根部的普通文件,挡掉 ../ 之类的路径穿越
+                base = os.path.basename(n)
+                if not base or n.endswith("/"):
+                    continue
+                with z.open(n) as src, open(os.path.join(dst, base), "wb") as out:
+                    shutil.copyfileobj(src, out)
+                written.append(base)
+    finally:
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
+    if not written:
+        raise RuntimeError("压缩包里没有文件")
+    return written
+
+
+def toggle_metatube():
+    """装 / 卸 MetaTube（服务端容器 + Emby 插件），一个按钮来回切。
+
+    两件东西必须一起动:只装插件不装服务端的话,插件什么都刮不出来,而界面上
+    看起来"装好了" —— 那种状态最难排查。
+    """
+    d = ms_install_dir()
+    if not is_installed(d):
+        warn(f"还没安装（{d} 下没有 docker-compose.yml）。先选 1 安装。")
+        return
+    on = metatube_on(d)
+    files = ms_state().get("metatube_files") or []
+
+    print()
+    print(f"  {BOLD}MetaTube{RST} {DIM}—— 按番号刮削的 Emby 插件{RST}")
+    print(f"  {DIM}给文件名是番号（ABC-123 这种）的片子刮标题、封面、演员。")
+    print(f"  普通电影电视剧用不上它 —— 那些 Emby 自带的 TMDb 就够了。{RST}")
+    print(f"  {DIM}要求 Emby 4.9 及以上。{RST}")
+    print()
+    print(f"  当前：{(GREEN + BOLD + '已安装' + RST) if on else (DIM + '未安装' + RST)}")
+    print()
+
+    if on:
+        print(f"  {DIM}卸载会：删掉 metatube 容器、删掉插件文件、重启 Emby。{RST}")
+        print(f"  {DIM}已经刮好的元数据缓存（{metatube_dir(d)}）留着不删，")
+        print(f"  以后再装回来能直接接着用。{RST}")
+        if not ask_yn("现在卸载吗？", False):
+            print("没有改动。")
+            return
+        for n in files:
+            try:
+                os.remove(os.path.join(emby_plugin_dir(d), n))
+            except OSError:
+                pass
+        cfg = rebuild_cfg_from_disk(d)
+        cfg["metatube"] = False
+        with open(os.path.join(d, "docker-compose.yml"), "w") as f:
+            f.write(gen_compose(cfg))
+        subprocess.run(["docker", "rm", "-f", "metatube"], capture_output=True)
+        _compose_up(d)
+        subprocess.run(["docker", "restart", "emby"], capture_output=True)
+        save_ms_state(metatube_files=[])
+        ok("已卸载（元数据缓存保留）")
+        return
+
+    print(f"  {DIM}安装会新增一个容器（几十 MB），并下载插件到 Emby 的插件目录。{RST}")
+    print(f"  {DIM}服务端不映射端口，只有同网络的 Emby 连得到。{RST}")
+    if not ask_yn("现在安装吗？", False):
+        print("没有改动。")
+        return
+
+    try:
+        files = _metatube_fetch_plugin(d)
+    except Exception as e:
+        err(f"插件下载失败：{_short_err(e)}")
+        print(f"  {DIM}容器还没动，什么都没改。网络好了再试一次。{RST}")
+        return
+    ok(f"插件已就位：{'、'.join(files)}")
+
+    cfg = rebuild_cfg_from_disk(d)
+    cfg["metatube"] = True
+    os.makedirs(metatube_dir(d), exist_ok=True)
+    with open(os.path.join(d, "docker-compose.yml"), "w") as f:
+        f.write(gen_compose(cfg))
+    info("启动 MetaTube 服务端...")
+    if not _compose_up(d):
+        err("容器启动失败，看上面的报错。")
+        return
+    subprocess.run(["docker", "restart", "emby"], capture_output=True)
+    save_ms_state(metatube_files=files)
+    ok("装好了")
+    print()
+    print(f"  {YELLOW}还有两步要你在 Emby 里手动做{RST}{DIM}（脚本代劳不了，"
+          f"那是插件自己的设置页）：{RST}")
+    print(f"  {DIM}1.{RST} Emby → 设置 → 插件 → MetaTube → 服务器地址填 "
+          f"{CYAN}{BOLD}http://metatube:{METATUBE_PORT}{RST}")
+    print(f"  {DIM}2.{RST} 要用它的那个媒体库 → 编辑 → 刮削器里勾上 "
+          f"{BOLD}MetaTube{RST}，再扫一次")
+    print(f"  {DIM}插件没出现的话，Emby 可能还没加载完，等一会儿刷新设置页。{RST}")
 
 
 def set_link_method():
@@ -2814,6 +3009,9 @@ def params_menu():
             sp_state = f"{DIM}未安装{RST}"
         print(f"  4. 扫描路径（加网盘 / 换目录）")
         print(f"     {DIM}当前：{sp_state}{RST}")
+        mt_state = ((f"{GREEN}已安装{RST}" if metatube_on(d) else f"{DIM}未安装{RST}")
+                    if is_installed(d) else f"{DIM}未安装{RST}")
+        print(f"  5. MetaTube 刮削插件（番号识别）  当前：{mt_state}")
         print("  0. 返回")
         print("-" * 60)
         c = ask("请选择").strip()
@@ -2827,6 +3025,8 @@ def params_menu():
             set_link_method()
         elif c == "4":
             set_scan_paths()
+        elif c == "5":
+            toggle_metatube()
         else:
             print("无效选择。")
             continue

--- a/xy-installer.py
+++ b/xy-installer.py
@@ -1930,7 +1930,7 @@ def _self_ip():
     return _SELF_IP_CACHE
 
 def _root_domain(host):
-    """收敛到可注册域：dmcn2.679588.xyz → 679588.xyz。
+    """收敛到可注册域：node2.example.com → example.com。
 
        多机聚合时同一个注册域下会冒出一堆子域（各节点域名、订阅域名、AdGuard DoT 的
        <ClientID>.域名…），逐条写进规则里又长又重复，还全是同一个域。收敛成一条就够。


### PR DESCRIPTION
## 令牌泄漏

「2 使用信息」把 OpenList 存储的 `status` 字段原样打印了，而它装的是整条 Go 错误，URL 的 query 里带着夸克的 `access_token`：

```
/quark  QuarkTV  Get "https://open-api-drive.quark.cn/user?access_token=eyJhbGci…
```

这一屏恰恰是**最常被截图发出去的**。体检里同样的坑早先修过（`_short_err`），这里漏了。

## 顺带回答「这些不该在体检里吗」

该。这一屏的定位是「地址 / 账号密码 / 怎么用」，不是诊断屏。

**1. 网盘挂载** —— 只列挂了哪些盘和根文件夹 ID。有存储报过错就一句话指向「5 链路体检」。

除了泄漏，原来那个 `status` 还是**初始化那一刻**写进去的，之后恢复了也不会改回 `work`，拿它当实时状态会把陈年记录报成当前故障 —— 体检里已经按「上次初始化时」处理过这个语义，不该在两个地方各讲一套。夸克根文件夹 ID 的长篇告警也删掉，体检里有同样的检查和改法。

**2. 容器状态** —— 原来直接贴 `docker compose ps` 的原始输出，手机上每行折成三四行，IMAGE/COMMAND/PORTS 糊成一片，而真正要看的只有「跑没跑」。改成 `N/N 在跑`，没起来的列出名字。

**3. 新增 MetaTube 段**（装了才显示）：服务端地址、两步用法、适用范围提醒、在哪装卸。

## 验证

`python3 -m py_compile` 通过。用一条**带 token 的假 status** 渲染整屏确认：输出里不再出现 token，MetaTube 段正常显示，容器行按「N/N 在跑」呈现。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_