### PR TITLE
115 扫码的「制作」改成循环检测：没有就直接做，有了先问

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2968,17 +2968,26 @@ def qr115_login():
             print()
             print(f"  {DIM}还没生成过令牌。{RST}")
         print()
-        print(f"  1. 重新制作二维码")
+        # 一个按钮按当前状态走两条路:没有就直接做,有了先问 —— 刷新会让旧令牌作废,
+        # 而用户很可能只是回来看一眼那串东西,不该顺手把它废掉
+        print(f"  1. 制作二维码" + (f"{DIM}（已有一个，会先问要不要刷新）{RST}" if uid else ""))
         print(f"  0. 返回")
         print("-" * 60)
         c = ask("请选择").strip()
         if c in ("0", ""):
             return
-        if c == "1":
-            _qr115_new()
-            ask("\n按回车继续...")
-        else:
+        if c != "1":
             print("无效选择。")
+            continue
+        if uid:
+            print()
+            warn("已经有一个令牌了，重新制作会让上面那串立刻作废。")
+            print(f"  {DIM}OpenList 里如果已经用它挂好了存储，那个存储不受影响"
+                  f"（它早换成 cookie 了）。{RST}")
+            if not ask_yn("确定要重新制作吗？", False):
+                continue
+        _qr115_new()
+        ask("\n按回车继续...")
 
 
 def toggle_metatube():


### PR DESCRIPTION
跟「3 直链方式」「5 MetaTube」一个手感：一个按钮按当前状态走两条路。

**没生成过：**

```
  还没生成过令牌。

  1. 制作二维码
  0. 返回
```

**已经有了：**

```
  当前令牌   a01ca4639a275d558fa9386dd5130183205c03c6   （8 分钟前生成）
  二维码     https://qrcodeapi.115.com/...
  [OpenList 各栏怎么填]

  1. 制作二维码（已有一个，会先问要不要刷新）
  0. 返回

→ 选 1 之后：
⚠ 已经有一个令牌了，重新制作会让上面那串立刻作废。
  OpenList 里如果已经用它挂好了存储，那个存储不受影响（它早换成 cookie 了）。
确定要重新制作吗？ [y/N]
```

## 为什么要先问

用户很可能只是回来看一眼那串令牌是什么（OpenList 那边填错了要重填），不该顺手把它废掉。#218 已经把「进来就自动申请」改掉了，这次把最后一步也补上。

顺带说清楚一件容易担心的事：重新制作**不影响已经挂好的存储** —— 那个存储在保存那一刻就把令牌换成 cookie 了，不再依赖这串 uid。

## 验证

`python3 -m py_compile` 通过；两种状态（无令牌 / 有令牌并选 1 后拒绝）都用桩渲染确认过。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_