### PR TITLE
生成媒体库不用再守着：配置提前还原，随时能 Ctrl-C 走人

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2339,6 +2339,167 @@ def normalize_strm_files(d):
     return n
 
 
+def strm_inventory(d):
+    """本地每个 strm 和它在 OpenList 上的目标路径 [(本地文件, 网盘路径), ...]。"""
+    out = []
+    for dirpath, _dirnames, files in os.walk(strm_root(d)):
+        for fn in files:
+            if not fn.endswith(".strm"):
+                continue
+            p = os.path.join(dirpath, fn)
+            try:
+                tgt = strm_target_path(open(p, encoding="utf-8").read())
+            except OSError:
+                continue
+            if tgt.startswith("/"):
+                out.append((p, tgt))
+    return out
+
+
+def _strm_sidecars(strm_path):
+    """跟这个 strm 同名的附属文件（nfo / 海报 / 字幕）。
+
+    必须带上那个点再比前缀：拿 `第01集` 直接比的话，`第01集完整版.nfo` 也会中枪。
+    另一个 .strm 无论如何不碰 —— 那是另一部片子，它的死活单独判断。
+    """
+    dirn, fn = os.path.split(strm_path)
+    stem = fn[:-len(".strm")] + "."
+    out = []
+    try:
+        for f in os.listdir(dirn):
+            if f == fn or not f.startswith(stem) or f.endswith(".strm"):
+                continue
+            out.append(os.path.join(dirn, f))
+    except OSError:
+        pass
+    return out
+
+
+def _ol_exists(path, token):
+    """网盘上还有这个文件吗。True 有 / False 确认没有 / None 问不出来。
+
+    三态是这个函数的全部意义。AutoFilm 自带的同步删除是两态的（不在扫描结果里
+    就算删了），跨境线路上列目录超时是常态，于是"没扫到"被当成"已删除"，整个
+    目录的 strm 被清掉 —— 所以那个开关在 gen_autofilm_conf 里是【关】的。
+
+    这里换成逐个文件问 OpenList，并且只认它明确回答的那一句。除此之外的一切
+    —— 超时、报错、连不上 —— 都归到 None，宁可留一堆废文件也不误删一个。
+    """
+    try:
+        r = _ol_api("/api/fs/get", {"path": path, "password": ""}, token, timeout=30)
+    except Exception:
+        return None
+    if r.get("code") == 200:
+        return True
+    msg = (r.get("message") or "").lower()
+    # 只认 object not found。"storage not found" 是【存储没挂上/掉线】，那一刻
+    # 这个挂载点下面每个文件都会这么回答 —— 认成"已删除"就是清空整个媒体库
+    if "object not found" in msg and "storage not found" not in msg:
+        return False
+    return None
+
+
+def prune_dead_strm(d):
+    """删掉网盘上【确认已经不存在】的 strm。返回删了几个。
+
+    为什么需要：用户在网盘里整理片子（新建文件夹、分类、改名）之后，AutoFilm
+    会在新路径下生成一批新的 strm，但旧路径那批不会消失 —— 同步删除是关着的。
+    表现就是 Emby 里同一部片子出现两次，一个能放、一个点开报错，而且整理得越
+    勤长得越多。这是"生成"这条路本身补不上的缺口，得单独有人来收尾。
+
+    删除前逐个问 OpenList，只删它明确回答"对象不存在"的。判断依据见 _ol_exists。
+    """
+    inv = strm_inventory(d)
+    if not inv:
+        return 0
+    pw = read_env(os.path.join(d, ".secrets"), "OPENLIST_PASS",
+                  fallback=os.path.join(d, ".env"))
+    try:
+        token = (_ol_api("/api/auth/login", {"username": "admin", "password": pw},
+                         timeout=30).get("data") or {}).get("token", "")
+    except Exception:
+        token = ""
+    if not token:
+        warn("OpenList 登不上，跳过失效 strm 清理（不影响已生成的片子）。")
+        return 0
+
+    print()
+    info(f"核对 {len(inv)} 个 strm 在网盘上还在不在...")
+    print(f"  {DIM}只删网盘明确回答「对象不存在」的。超时、报错、存储掉线一律"
+          f"当成还在 —— 宁可留废文件，不能误删。{RST}")
+
+    dead, unknown = [], 0
+    for i, (local, tgt) in enumerate(inv):
+        v = _ol_exists(tgt, token)
+        if v is False:
+            dead.append((local, tgt))
+        elif v is None:
+            unknown += 1
+        if (i + 1) % 25 == 0 and i + 1 < len(inv):
+            print(f"  {DIM}...已核对 {i + 1}/{len(inv)}{RST}")
+
+    if not dead:
+        if unknown:
+            warn(f"{unknown} 个没问出结果（超时或报错），这轮不动它们。")
+        else:
+            ok("没有失效的 strm，本地和网盘对得上。")
+        return 0
+
+    def mount_of(p):
+        return "/" + p.lstrip("/").split("/")[0]
+
+    print()
+    warn(f"有 {len(dead)} 个 strm 指向的文件在网盘上已经没有了：")
+    # 按挂载点摆出「死了几个 / 一共几个」：整个盘都判死通常是存储出了问题，
+    # 而不是用户真把片子删光了，这个比例必须让人一眼看见再决定
+    counts = {}
+    for _l, t in dead:
+        counts[mount_of(t)] = counts.get(mount_of(t), 0) + 1
+    for m, n in sorted(counts.items()):
+        tot = sum(1 for _l, t in inv if mount_of(t) == m)
+        flag = (f"   {YELLOW}← 这个挂载点下面全没了，先去 OpenList 确认盘还正常{RST}"
+                if n == tot and tot > 1 else "")
+        print(f"  {DIM}·{RST} {m}  {n}/{tot} 个{flag}")
+    print()
+    for _l, t in dead[:10]:
+        print(f"    {DIM}{t}{RST}")
+    if len(dead) > 10:
+        print(f"    {DIM}...另外 {len(dead) - 10} 个{RST}")
+    if unknown:
+        print(f"  {DIM}另有 {unknown} 个没问出结果，不在删除范围内。{RST}")
+
+    print()
+    print(f"  {DIM}删掉之后 Emby 里那些点不开的条目会在下一次扫描时消失。{RST}")
+    print(f"  {DIM}注意：在网盘里移动或改名过的片子，Emby 会当成一部新片 ——"
+          f"观看进度和已看标记不会跟过去。{RST}")
+    print(f"  {DIM}Emby 是按文件路径认片子的，路径变了就是新条目，这条脚本改不了。{RST}")
+    if not ask_yn("删掉这些失效 strm（连同同名的 nfo / 海报 / 字幕）？", False):
+        print(f"  {DIM}没删。留着不影响新片子，只是 Emby 里会多出一批点不开的条目。{RST}")
+        return 0
+
+    n = 0
+    for local, _t in dead:
+        for f in [local] + _strm_sidecars(local):
+            try:
+                os.remove(f)
+            except OSError:
+                pass
+        n += 1
+    # 顺手收掉空目录：整理之后旧的目录层级会整层空下来，留着 Emby 里就是一排空文件夹。
+    # 深的先删，这样父目录轮到自己时看到的已经是子目录删完之后的状态
+    root = strm_root(d)
+    for dirpath, _dn, _f in sorted(os.walk(root), key=lambda x: -len(x[0])):
+        if os.path.abspath(dirpath) == os.path.abspath(root):
+            continue
+        try:
+            if not os.listdir(dirpath):
+                os.rmdir(dirpath)
+        except OSError:
+            pass
+    ok(f"删掉 {n} 个失效 strm")
+    return n
+
+
 def heal_media_info(d, key):
     """给没有时长的条目补上媒体信息。进度条、续播、已看标记全靠这一步。
 
@@ -2600,6 +2761,11 @@ def do_strm():
         print(f"  {DIM}·{RST} AutoFilm 扫的是 {BOLD}{read_yaml_scalar(cfg_path, 'source_dir', '/')}{RST}，"
               f"这个路径在 OpenList 里点得开吗")
         return
+
+    # 生成只会【加】不会【减】。用户在网盘里整理过片子的话，旧路径那批 strm
+    # 还留在本地，Emby 里就是同一部片子两个条目、一个点不开。放在扫描之前收尾，
+    # 让 Emby 这一趟同时看到"新的多了"和"旧的没了"。
+    prune_dead_strm(d)
 
     # 生成完顺手让 Emby 扫一遍，省得用户还要再进 Emby 后台找「扫描媒体库」
     key = read_yaml_scalar(os.path.join(d, "mediawarp", "config", "config.yaml"), "auth")
@@ -3905,7 +4071,7 @@ def main_menu():
         print("  3. 后补参数（Emby API Key 等装完才拿得到的东西）")
         # 装完网盘还没挂，所以这一步只能等用户在 OpenList 里挂好之后自己点。
         # 没有这个按钮的话，不敲命令的人就卡在「OpenList 里有文件、Emby 里空的」
-        print("  4. 生成媒体库（网盘挂好后点这个，Emby 才看得到片子）")
+        print("  4. 生成媒体库（网盘挂好、或在网盘里整理过片子之后点这个）")
         print("  5. 链路体检（卡住 / 不出片子时先跑这个）")
         print("  6. 更新（拉最新镜像 + 按新版本刷新配置）")
         print("  7. 卸载")

--- a/media-stack.py
+++ b/media-stack.py
@@ -2657,8 +2657,17 @@ def do_strm():
 
     触发方式和 CLI 那条一致：AutoFilm v2 没有手动执行的入口(--help 里只有
     --config/--log/--timezone 这类开关)，启动时也只注册 cron、不跑任务。所以临时把
-    cron 改成两分钟后只触发一次，跑完立刻还原。不用「每分钟」是因为网盘慢的时候一轮
-    要一两分钟，几轮压在一起会并发扫同一个目录、互相删对方刚写出的 strm。
+    cron 改成两分钟后只触发一次。不用「每分钟」是因为网盘慢的时候一轮要一两分钟，
+    几轮压在一起会并发扫同一个目录、互相删对方刚写出的 strm。
+
+    【为什么还原不等到最后】AutoFilm 是启动时把 config.yaml 读进内存注册 cron 的，
+    之后再改磁盘上那份不影响已经排好的这一轮。所以容器一起来就立刻还原，从那一秒起
+    脚本对磁盘不欠任何东西 —— 用户可以随时 Ctrl-C 走人，不会留下临时定时值，也不用
+    在末尾再重启一次容器（那次重启才是"必须干等到底"的真正原因）。
+
+    代价是那条临时 cron 以每天一次的形式留在内存里，直到容器下次重启。无害：
+    overwrite 是 false、同步删除是关的，重复跑一轮只是白扫一遍。而且本函数开头就会
+    重启容器，之前积下的那条随之清掉 —— 任何时刻最多只存在一条。
     """
     d = ms_install_dir()
     if not is_installed(d):
@@ -2690,10 +2699,23 @@ def do_strm():
     patched = re.sub(r'(?m)^(\s*cron:\s*)".*"$', lambda m: f'{m.group(1)}"{fire}"',
                      original, count=1)
     if patched == original:
-        # 还没动过文件就退出，别进 try —— 否则 finally 会白重启一次容器
+        # 还没动过文件就退出，别进 try —— 否则 finally 会白写一次文件
         err("没能改写 cron 那一行，为安全起见没有继续。")
         return
 
+    def autofilm_log(since):
+        r"""合并 stdout 和 stderr 并剥掉颜色码。
+
+        两路都要读：不同版本的 AutoFilm/Docker 日志落在哪一路并不一致，只读 stdout
+        会漏掉统计数字（表现是最后那行全是问号）。
+        颜色码必须先剥：AutoFilm 默认 --colorful-log，日志里的字段名被转义序列包着
+        (strm_created_count 前后各有一段 \x1b[..m)，直接拿正则找 xxx_count=数字
+        一个都匹配不到。这个坑很隐蔽 —— 粘进聊天框时终端把颜色码剥掉了，看着很干净。
+        """
+        r = sh(f"docker logs --since {since} autofilm", timeout=60)
+        return ANSI_RE.sub("", (r.stdout or "") + (r.stderr or ""))
+
+    done = ""
     try:
         with open(cfg_path, "w", encoding="utf-8") as f:
             f.write(patched)
@@ -2702,34 +2724,66 @@ def do_strm():
                           capture_output=True).returncode != 0:
             err("重启 AutoFilm 失败，它可能没在跑。")
             return
-        info(f"已安排在 {fire.split()[2]}:{fire.split()[1]}（容器时间）触发一次，最多等 2 分钟开始。")
-        print(f"  {DIM}扫描期间日志会安静一阵，正常。整个过程最长 15 分钟。{RST}")
 
-        done = ""
+        # 等它把配置读进内存（启动会打印 scheduled_count），然后【立刻】还原磁盘。
+        # 见函数开头的说明：还原之后这一轮照跑，而脚本从此可以随时被打断。
+        for _ in range(20):
+            if "scheduled_count" in autofilm_log(since):
+                break
+            time.sleep(1)
+        with open(cfg_path, "w", encoding="utf-8") as f:
+            f.write(original)
+        base_lines = len(autofilm_log(since).splitlines())
+
+        info(f"已安排在 {fire.split()[2]}:{fire.split()[1]}（容器时间）触发，最多等 2 分钟开始。")
+        print(f"  {GREEN}这一步不用守着{RST}{DIM}：定时设置已经还原，扫描在容器里跑。"
+              f"按 Ctrl-C 随时可以走人，不会打断它。{RST}")
+        print(f"  {DIM}整个过程最长 15 分钟。等在这儿的好处是跑完会接着补时长、"
+              f"清失效条目、通知 Emby 扫描 —— 走人的话这三步要下次再点。{RST}")
+
+        started, last = False, ""
         for i in range(225):                       # 4s x 225 = 15 分钟封顶
-            # 合并 stdout 和 stderr：不同版本的 AutoFilm/Docker 日志落在哪一路
-            # 并不一致，只读 stdout 会漏掉统计数字（表现是最后那行全是问号）
-            r = sh(f"docker logs --since {since} autofilm", timeout=60)
-            # 先剥掉 ANSI 颜色码：AutoFilm 默认 --colorful-log，日志里的字段名被
-            # 转义序列包着(strm_created_count 前后各有一段 \x1b[..m)，直接拿正则
-            # 找 xxx_count=数字 一个都匹配不到，最后只能打出一排问号。
-            # 这个坑很隐蔽：粘贴到聊天/文档里时终端把颜色码剥掉了，看起来完全干净。
-            out = ANSI_RE.sub("", (r.stdout or "") + (r.stderr or ""))
-            for ln in out.splitlines():
+            out = autofilm_log(since)
+            lines = out.splitlines()
+            for ln in lines:
                 if "Alist2Strm 任务完成" in ln:
                     done = ln                      # 不 break：取最后一条，也就是最新那轮
             if done:
                 break
+            # 日志行数超过"刚启动"那一刻，就说明任务真的动起来了。用行数而不是认
+            # 某句中文：AutoFilm 各版本的措辞不一样，认死了会一直显示"还没开始"
+            if len(lines) > base_lines:
+                started = True
+                for ln in reversed(lines):
+                    if ln.strip():
+                        last = ln.strip()
+                        break
             time.sleep(4)
-            if i % 15 == 14:
-                print(f"  {DIM}...已等待 {(i + 1) * 4 // 60} 分钟{RST}")
+            if i % 8 == 7:                         # 每 32 秒报一次，别让人以为卡死了
+                el = (i + 1) * 4
+                phase = "正在扫描网盘" if started else "等 AutoFilm 到点触发"
+                print(f"  {DIM}...{phase}，已等 {el // 60} 分 {el % 60} 秒{RST}")
+                if last:
+                    print(f"  {DIM}   {last[-88:]}{RST}")
         if not done:
             warn("15 分钟内没等到「任务完成」。网盘可能一直超时，稍后再试一次。")
+    except KeyboardInterrupt:
+        print()
+        warn("不等了 —— 扫描在容器里继续跑，strm 会照常生成。")
+        print(f"  {DIM}没跑的是后面三步：补时长（进度条要靠它）、清失效条目、"
+              f"通知 Emby 扫描。{RST}")
+        print(f"  {DIM}过十来分钟再点一次「4 生成媒体库」：那一次文件已经在了，"
+              f"生成会秒过，这三步在那次补上。{RST}")
+        return
     finally:
-        # 还原是必须发生的：中途报错、Ctrl-C 都不能把用户的定时设置留在临时值上
-        with open(cfg_path, "w", encoding="utf-8") as f:
-            f.write(original)
-        subprocess.run(["docker", "restart", "autofilm"], capture_output=True)
+        # 兜底：中途报错也不能把临时定时值留在用户的配置里。正常路径上面已经还原过，
+        # 这里读一眼、不一样才写，省掉一次无谓的磁盘写入
+        try:
+            if open(cfg_path, encoding="utf-8").read() != original:
+                with open(cfg_path, "w", encoding="utf-8") as f:
+                    f.write(original)
+        except OSError:
+            pass
 
     after = strm_count(d)
     print()


### PR DESCRIPTION
## 问题

「4 生成媒体库」那 15 分钟必须干等到底，用户看到的是四行 `...已等待 N 分钟`，不知道是在跑还是卡死了。

根因不是网盘慢，是**末尾那次 `docker restart autofilm`**：临时 cron 写进了 `config.yaml`，只能等任务跑完才敢还原并重启，于是人被钉在终端前。

## 改法

AutoFilm 是**启动时**把 config.yaml 读进内存注册 cron 的，之后改磁盘不影响已经排好的这一轮。

所以改成容器一起来（日志出现 `scheduled_count`）就**立刻还原**，从那一秒起脚本对磁盘不欠任何东西，末尾那次重启整个去掉。`Ctrl-C` 现在是安全的。

### 代价

那条临时 cron 以每天一次的形式留在内存里，直到容器下次重启。无害：`overwrite: false`、同步删除是关的，重复跑一轮只是白扫一遍。而且**本函数开头就会重启容器**，之前积下的那条随之清掉 —— 任何时刻最多存在一条，不会累积。

## 顺带：等待期从没有信息变成有信息

- 报出当前阶段：「等 AutoFilm 到点触发」还是「正在扫描网盘」
  - 判据用**日志行数超过刚启动那一刻**，不认某句中文 —— 各版本措辞不一样，认死了会一直显示"还没开始"
- 每 32 秒（原 60 秒）报一次，并附上 AutoFilm 最新那行日志
- 明说等在这儿的好处：跑完接着补时长 / 清失效 / 通知 Emby 扫描；走人则这三步下次补

`Ctrl-C` 的提示直接给出下一步：过十来分钟再点一次 4，那次文件已在、生成秒过，三步在那次补上。

## 其它

`docker logs` 的读取 + 剥 ANSI 色码抽成 `autofilm_log()`，两处共用。

## 验证

- `py_compile` 通过
- AST 断言：`do_strm` 里 `docker restart autofilm` 只剩 1 次（原 2 次），`except KeyboardInterrupt` 分支存在
- 演练还原时序：patched 写入 → 早还原 → `finally` 读到内容一致、跳过重复写入

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_