### PR TITLE
体检的「条目时长」报片名，不要只报个数

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -4235,8 +4235,15 @@ def do_healthcheck():
 
             nodur = items_without_duration(key)
             if nodur:
+                # 必须把片名列出来。只报个数字的话，用户看到"某个媒体库没有进度条
+                # 记忆"会以为是那个库的设置没生效 —— 而实际上门槛早就调好了，
+                # 缺的只是【某一部片子】的时长。一个是库的问题，一个是条目的问题，
+                # 排查方向完全相反，光给数字分不出来。
+                names = "、".join(n for _u, _i, n in nodur[:3])
+                if len(nodur) > 3:
+                    names += f" 等 {len(nodur)} 个"
                 _hc("条目时长", "bad",
-                    f"{len(nodur)} 个没有时长  {YELLOW}这些片子不会有进度条记忆{RST}")
+                    f"{names}  {YELLOW}没有时长，不会有进度条记忆{RST}")
                 todo.append((f"{len(nodur)} 个条目没探到时长，"
                              f"它们看到一半退出会被当成看完、下次从头开始",
                              "点「4 生成媒体库」会挨个补探一遍；"


### PR DESCRIPTION
## 问题

> 一个媒体库美女动作片有进度条记忆，还有一个媒体库叫影视动漫没有进度条记忆，按道理说只要我新加的都应该追加这个功能啊

这个反应完全合理，但结论是错的——而**错在我的输出方式**。

实际情况：两个库的续播门槛都调好了（上一轮输出里两行都打了勾）。缺的只是「影视动漫」里**那一部片子**的时长没探到，而那个库正好只有一部片。

## 为什么只给数字不够

这两件事的排查方向完全相反：

| 现象 | 真实原因 | 该看哪里 |
|---|---|---|
| 整个库都没记忆 | 库的续播门槛没跟上 | 续播门槛那行 |
| 某几部没记忆 | 那几部没探到时长 | 条目时长那行 |

而「3 个没有时长」这种只给数字的报法，把这两者混成了一个样子——用户没有任何线索能分辨自己撞上的是哪一种。

## 改后

```
✖ 条目时长    仙逆剧场版 弑仙之战  没有时长，不会有进度条记忆
✖ 条目时长    仙逆剧场版 弑仙之战、宝贝有戏之小仙女  没有时长，不会有进度条记忆
✖ 条目时长    片子0、片子1、片子2 等 5 个  没有时长，不会有进度条记忆
```

最多列 3 个，多了缀「等 N 个」。用户一眼就能对上是哪一部，不会再往"库没生效"上想。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_