### PR TITLE
改完续播门槛要回读确认，别拿 HTTP 200 当成功

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2357,6 +2357,21 @@ def tune_resume_thresholds(key):
         except Exception as e:
             warn(f"改「{lb.get('Name')}」的续播门槛失败：{_short_err(e)}")
             continue
+        # 【必须回读确认】这个接口对不认识的字段是静默忽略的：HTTP 200 不代表改进去了。
+        # 不回读的话，脚本会年复一年地打印"已改成 2 秒"，而 Emby 那边纹丝不动 ——
+        # 用户照着这行字排除掉"门槛"这个方向，真正的原因反而永远查不到。
+        try:
+            back = _emby("/Library/VirtualFolders", key)
+            now = next((x.get("LibraryOptions") or {} for x in back
+                        if x.get("ItemId") == lb.get("ItemId")), {})
+        except Exception:
+            now = {}
+        if now.get("MinResumeDurationSeconds") != RESUME_MIN_SECONDS:
+            warn(f"「{lb.get('Name')}」的续播门槛没改动成功"
+                 f"（回读还是 {now.get('MinResumeDurationSeconds')} 秒）")
+            print(f"  {DIM}Emby 收下了请求但没生效，这个版本的接口可能不吃这个字段。"
+                  f"短片子的进度条记忆会受影响。{RST}")
+            continue
         ok(f"媒体库「{lb.get('Name')}」续播门槛：{cur_s}秒/{cur_p}% → "
            f"{RESUME_MIN_SECONDS}秒/{RESUME_MIN_PCT}%")
         print(f"  {DIM}默认的 120 秒是按电影长度定的，短片子永远够不到，"


### PR DESCRIPTION
## 问题

Emby 的 `LibraryOptions` 接口对不认识的字段是**静默忽略**的：HTTP 200 只代表它收下了请求，不代表值真的写进去了。

之前不回读，脚本就会一遍遍打印「续播门槛：120秒/2% → 2秒/0%」，而 Emby 那边纹丝不动。

## 为什么这比不报更坏

用户照着这行绿勾把"门槛"这个方向**排除掉**，真正的原因反而永远查不到——而进度条记忆恰恰是这套东西里最难自查的毛病。

## 改动

POST 之后重新拉一次 `VirtualFolders` 核对。对不上就如实说，并且**不打**那行成功日志：

```
⚠ 「影视动漫」的续播门槛没改动成功（回读还是 120 秒）
  Emby 收下了请求但没生效，这个版本的接口可能不吃这个字段。短片子的进度条记忆会受影响。
```

## 验证

两种情况都断言过：

- 真的生效 → 打成功行，不打警告
- Emby 静默忽略 → 打警告，**不打**成功行

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_