### PR TITLE
对账要连 MediaSources 一起看：否则照建议摆片子的人全被误报

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2456,13 +2456,20 @@ def strm_not_in_emby(d, key):
                               for p in (lb.get("Locations") or [])):
             continue
         try:
-            r = _emby(f"/Users/{uid}/Items?ParentId={pid}&Recursive=true&Fields=Path", key)
+            r = _emby(f"/Users/{uid}/Items?ParentId={pid}&Recursive=true"
+                      f"&Fields=Path,MediaSources", key)
         except Exception:
             return []                  # 有一个库问不到就整个放弃，别报假阳性
         for i in r.get("Items") or []:
-            p = str(i.get("Path") or "")
-            if p.endswith(".strm"):
-                known.add(p)
+            # 条目自己的 Path 【不一定】是那个 strm。片子单独放一个文件夹时，
+            # Emby 把整个文件夹当成这部电影，条目的 Path 是【文件夹】，真正的
+            # 文件在 MediaSources 里。只看 Path 的话，凡是按"一部片一个文件夹"
+            # 摆的片子会全部被误报成"没收录" —— 而那个摆法恰恰是本脚本推荐的，
+            # 等于谁照着建议做谁中招。两处都收。
+            for p in [str(i.get("Path") or "")] + \
+                     [str(s.get("Path") or "") for s in (i.get("MediaSources") or [])]:
+                if p.endswith(".strm"):
+                    known.add(p)
     if not known:
         return []                      # 一个都没有多半是库还没建，那是另一回事
     missing = []


### PR DESCRIPTION
## Bug

上一版判断「Emby 收没收录」**只看条目自己的 `Path`**。

但片子单独放一个文件夹时，Emby 把整个文件夹当成这部电影：

```
条目 Path        = /data/strm/cloud/仙逆/弑仙之战          ← 文件夹
MediaSources[0]  = /data/strm/cloud/仙逆/弑仙之战/弑仙之战.strm   ← 真正的文件
```

于是凡是按「一部片一个文件夹」摆的片子会**全部被误报成"没收录"**。

## 为什么这个 bug 特别糟

**那个摆法恰恰是这个功能自己给出的建议。**

用户看到"这几个没被收录，改法：挪进各自的单独文件夹" → 照做 → 下次跑，全部还报没收录，而且还是同一句建议。等于谁照着建议做谁中招，还会被反复劝去做已经做过的事。

## 改动

条目 `Path` 和 `MediaSources` 里的路径都收进已知集合。

## 验证

两种摆法各测一次：

| 摆法 | 结果 |
|---|---|
| 一部片一个文件夹（Path 是目录，strm 在 MediaSources） | 误报 **0** |
| 平铺且真的少一个 | 准确检出那一个 |

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_