### PR TITLE
补时长的判据改看 MediaSource：刮削回填的片长会把探测失败盖住

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2316,6 +2316,17 @@ def items_without_duration(key):
     (VirtualFolders 里的 ItemId)、带 Recursive 和 IncludeItemTypes。
     少了 IncludeItemTypes 的话 Emby 会把媒体库节点本身当结果返回,看起来就像
     "库里只有一个条目",排查时会被带到沟里去。
+
+    【判据看 MediaSource，不看条目】条目的 RunTimeTicks 有两个来源：文件探测，
+    以及刮削（TMDb 给的片长）。刮削那份是【元数据】不是【探测结果】—— 探测失败
+    的条目照样能从 TMDb 拿到一个片长填在条目上,而 MediaSource 那边还是 0。
+
+    后果是这个函数会认为它"已经有时长了"而跳过，补时长那步【永远不会再试它】,
+    这条修复路径就此断掉。用户看到的是"明明显示 17 分钟,进度条还是记不住",
+    而体检也跟着报「条目时长 都有」—— 两边一起把人往错的方向带。
+
+    实例：仙逆那部探测失败(日志里明写"没探到"),但 TMDb 匹配上一部同名剧场版、
+    回填了 17.7 分钟,于是它从待补列表里消失了。
     """
     out = []
     try:
@@ -2336,11 +2347,16 @@ def items_without_duration(key):
             continue
         try:
             d = _emby(f"/Users/{uid}/Items?ParentId={pid}&Recursive=true"
-                      f"&IncludeItemTypes=Movie,Episode,Video&Fields=Path", key)
+                      f"&IncludeItemTypes=Movie,Episode,Video"
+                      f"&Fields=Path,MediaSources", key)
         except Exception:
             continue
         for i in d.get("Items") or []:
-            if not (i.get("RunTimeTicks") or 0):
+            srcs = i.get("MediaSources") or []
+            # 有源就以源为准（源才是文件的真实探测结果）；一个源都没有时退回看条目
+            need = (any(not (s.get("RunTimeTicks") or 0) for s in srcs) if srcs
+                    else not (i.get("RunTimeTicks") or 0))
+            if need:
                 out.append((uid, i.get("Id"), i.get("Name") or "?"))
     return out
 


### PR DESCRIPTION
## 问题

条目的 `RunTimeTicks` 有**两个来源**：文件探测，以及刮削（TMDb 给的片长）。这两个在接口上长得一模一样，但意义完全不同——后者是元数据，跟这个文件能不能播、能不能拖进度条毫无关系。

用户的实际数据：

```
仙逆剧场版 弑仙之战
  条目 RunTimeTicks = 17.7 分      ← TMDb 刮削回填
  MediaSource       = 0            ← 探测失败（heal 日志里明写"没探到"）
```

`items_without_duration` 只看条目的 `RunTimeTicks`，于是认为它"已经有时长了"而跳过——**补时长那步永远不会再试它**，修复路径就此断掉。

## 为什么这个 bug 特别难查

体检用的是同一个判据，跟着报「条目时长 都有」。

**两边一起把人往错的方向带**：用户看到的是"明明显示 17 分钟，进度条还是记不住"，然后开始怀疑续播门槛、怀疑已播放标记、怀疑媒体库设置——全查完也查不到，因为真正坏掉的那个数字根本没被看过。

## 改动

有 `MediaSources` 就以源为准（源才是文件的真实探测结果），一个源都没有时才退回看条目。

## 验证

照用户实际数据造：

```
待补时长: ['仙逆剧场版 弑仙之战', '没源也没时长']
旧判据只会挑出: ['没源也没时长']  ← 仙逆被漏掉，永远不会重试
```

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_