### PR TITLE
说清楚「被并成版本」这条路：它会顺带把进度条弄坏

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2548,14 +2548,18 @@ def report_not_in_emby(d, key):
     if not missing:
         return 0
     print()
-    warn(f"有 {len(missing)} 个 strm 生成了，但 Emby 没把它收进媒体库：")
+    warn(f"有 {len(missing)} 个 strm 生成了，但 Emby 里没有对应的独立条目：")
     for p in missing[:8]:
         print(f"  {DIM}·{RST} {p}")
     if len(missing) > 8:
         print(f"  {DIM}...另外 {len(missing) - 8} 个{RST}")
     print(f"  {DIM}文件和 strm 都没问题，是 Emby 的电影库布局规则把它吃掉了：{RST}")
-    print(f"  {DIM}同一个文件夹里放了多部片子时，Emby 可能只认其中一部"
-          f"（另一部当成「版本」或者直接忽略）。{RST}")
+    print(f"  {DIM}同一个文件夹里放了多部片子时，Emby 可能只认其中一部，"
+          f"另一部要么被忽略，要么被并成前一部的一个「版本」。{RST}")
+    # 并成"版本"比直接忽略更难查，而且会顺带把进度条弄坏：合并后的条目挂着两个源，
+    # 其中探测失败的那个时长是 0，Emby 一按它算续播百分比就判定"看完了"
+    print(f"  {YELLOW}被并成「版本」的话还会连累进度条 —— 那个条目会同时挂着两个源，"
+          f"探测失败的那个时长是 0，续播点就存不下来。{RST}")
     print(f"  {YELLOW}改法：只把上面这几个挪进各自的单独文件夹，别的不用动。{RST}")
     print(f"  {DIM}  /quark/电影/仙逆/A [4K].mp4      ← 名字相近，被当成同一部{RST}")
     print(f"  {DIM}  /quark/电影/仙逆/A 剧场版.mp4{RST}")


### PR DESCRIPTION
## 实测确认了合并的后果

`/Items/165/PlaybackInfo` 拿到**两个源**：

```
源时长 = 17.67 分   容器 = hls
源时长 =  0.00 分   容器 = strm
```

两个文件被并成一个条目，其中探测失败的那个源时长是 0。Emby 按时长算续播百分比时用到它，分母为 0 那套逻辑就失效——一停播就判定"看完了"，续播点存不下来。

用户看到的是「这个库里的片子永远没有进度条记忆」，而条目上明明写着 17 分钟（那 17 分钟是 TMDb 刮来的，见上一个提交）。

## 两处措辞修正

**1. 「没收录」不准确** —— 文件其实在 Emby 里，只是没有独立条目。改成「Emby 里没有对应的独立条目」。

**2. 补一句被并成版本会连累进度条**

这条比"直接被忽略"隐蔽得多：片子看得见、点得开、能播，**只有进度条不对**，很难联想到是合并造成的。我自己也是绕了好几轮才定位到。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_