### PR TITLE
补时长的成功判据也改看源：别把刮削回填的片长当成探测成功

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2893,9 +2893,17 @@ def heal_media_info(d, key):
                       key, method="POST", timeout=200)
             except Exception:
                 pass          # 探测本身超时也要走到 finally 把文件还原
+            # 【核对源的时长，不是条目的】条目的 RunTimeTicks 可能是刮削回填的
+            # （TMDb 给的片长）。拿它当探测结果的话，探测明明失败了也会报"✔ 18 分钟"
+            # —— 谎报成功比报失败坏得多：这个条目从此被当成已修好，再也不会重试，
+            # 而进度条依然是坏的。判据必须和 items_without_duration 保持一致。
             try:
-                mins = (_emby(f"/Users/{uid}/Items/{iid}", key,
-                              timeout=30).get("RunTimeTicks") or 0) / 6e8
+                got = _emby(f"/Users/{uid}/Items/{iid}?Fields=MediaSources",
+                            key, timeout=30)
+                srcs = got.get("MediaSources") or []
+                ticks = (min((s.get("RunTimeTicks") or 0) for s in srcs) if srcs
+                         else (got.get("RunTimeTicks") or 0))
+                mins = ticks / 6e8
             except Exception:
                 mins = 0
         finally:


### PR DESCRIPTION
## 漏修了一半

上一个提交把 `items_without_duration` 的判据改成看 `MediaSource`，但 `heal_media_info` 自己核对探测结果时**还在读条目的 `RunTimeTicks`**——同一个坑只修了一边。

## 后果比漏报严重

探测明明失败了，条目却因为 TMDb 刮到片长而显示非 0，于是 heal 打出：

```
✔ 仙逆剧场版 弑仙之战  18 分钟
```

这个条目从此被当成已修好。而两边判据一致之后，它**再也不会被重试**——进度条依然是坏的，但没有任何地方还会去碰它。

**谎报成功比报失败坏得多。**

## 改动

取 `MediaSources` 里**最小**的那个时长：任何一个源没探到，这一轮就算没成——因为播放时用到哪个源不由脚本决定。没有源时才退回看条目。

## 验证

| 情况 | 结果 |
|---|---|
| 源探到了 | ✔ 报成功（17.7 分） |
| 源是 0 但条目有刮削片长 | · 报没探到 |
| 多个源有一个是 0 | · 报没探到 |
| 没有源 | ✔ 退回看条目 |

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_