### PR TITLE
片名改不过来：取单个条目用错了接口，而且失败被静默吞掉

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2479,7 +2479,7 @@ def apply_title_policy(d, key):
     uid = (users[0] or {}).get("Id", "") if users else ""
     if not uid:
         return 0
-    n = 0
+    n, seen, failed = 0, 0, []
     for lb in libs:
         pid = lb.get("ItemId")
         if not pid or not any(STRM_PATH in p or p in STRM_PATH
@@ -2495,9 +2495,15 @@ def apply_title_policy(d, key):
             if not path.endswith(".strm"):
                 continue
             iid = i.get("Id")
+            seen += 1
+            # 取单个条目必须走 /Users/{uid}/Items/{iid}。裸的 /Items/{iid} 在 Emby
+            # 上没有 GET 实现，会 404 —— 而这里原本 except 掉就 continue，于是每个
+            # 条目都被静默跳过，整个功能一声不吭地什么都不做。改片名【是】写操作，
+            # 失败必须看得见，不能和"本来就不用改"长得一样。
             try:
-                full = _emby(f"/Items/{iid}", key, timeout=30)
-            except Exception:
+                full = _emby(f"/Users/{uid}/Items/{iid}", key, timeout=30)
+            except Exception as e:
+                failed.append((str(i.get("Name") or "?")[:20], _short_err(e)))
                 continue
             locked = list(full.get("LockedFields") or [])
             stem = os.path.splitext(os.path.basename(path))[0]
@@ -2512,11 +2518,16 @@ def apply_title_policy(d, key):
                     continue
                 locked = [x for x in locked if x != "Name"]
             full["LockedFields"] = locked
+            # 更新走 POST /Items/{id}，这个是 Emby 网页端改元数据时用的那个
             try:
                 _emby(f"/Items/{iid}", key, method="POST", body=full, timeout=30)
                 n += 1
             except Exception as e:
-                warn(f"改「{(i.get('Name') or '?')[:20]}」的片名失败：{_short_err(e)}")
+                failed.append((str(i.get("Name") or "?")[:20], _short_err(e)))
+    if failed:
+        warn(f"{len(failed)} 个条目的片名没改成：")
+        for nm, why in failed[:5]:
+            print(f"  {DIM}·{RST} {nm}  {why}")
     if n:
         if want_filename:
             ok(f"{n} 个条目的片名已改成网盘文件名（并锁定，刮削不再覆盖）")
@@ -2524,6 +2535,10 @@ def apply_title_policy(d, key):
         else:
             ok(f"{n} 个条目的片名解锁，交回给刮削")
             print(f"  {DIM}标题会在下一次刮削时被覆盖回去。{RST}")
+    elif seen and not failed:
+        ok(f"{seen} 个条目的片名已经是想要的样子，没有需要改的")
+    elif not seen:
+        warn("没找到 strm 条目 —— Emby 媒体库可能还没建或还没扫。")
     return n
 
 


### PR DESCRIPTION
## 现象

用户设成「网盘文件名」，菜单显示 `当前：网盘文件名`，**Emby 里纹丝不动**。

## 两个错叠在一起

**1. 取单个条目用错了路径**

```python
_emby(f"/Items/{iid}", key)          # ✗ Emby 没有这个 GET，404
_emby(f"/Users/{uid}/Items/{iid}", key)   # ✓
```

同一个文件里 `heal_media_info` 用的就是正确那个，我写新函数时没照着来。

**2. 那句 `except` 直接 `continue`**

于是每个条目都被静默跳过，函数返回 0，**一行输出都没有**——和"本来就不用改"长得一模一样。用户只能看到设置生效了、结果没变，无从判断哪一步出的问题。

## 改动

改片名是**写操作**，失败必须看得见。收集失败原因并列出来，三种收场分开报：

```
✔ 2 个条目的片名已改成网盘文件名（并锁定，刮削不再覆盖）
✔ 3 个条目的片名已经是想要的样子，没有需要改的
⚠ 2 个条目的片名没改成：
  · 仙逆剧场版 弑仙之战  HTTP Error 404: Not Found
⚠ 没找到 strm 条目 —— Emby 媒体库可能还没建或还没扫。
```

更新那一侧的 `POST /Items/{id}` 是对的（Emby 网页端改元数据用的就是它），保持不变。

## 验证

| 场景 | 结果 |
|---|---|
| 正常 | GET 走 `/Users/u1/Items/165`，POST 走 `/Items/165`，改 2 个 |
| 取条目 404（旧代码的情形） | 返回 0，**并打印失败原因** |

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_