### PR TITLE
再选一次同一项要重新套用：那是用户唯一的重试入口

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -939,7 +939,7 @@ def issue_cert(domain, crt, key, cf_token):
 
 
 # ============================================================================ 管理命令
-CLI_TEMPLATE = '''#!/usr/bin/env bash
+CLI_TEMPLATE = r'''#!/usr/bin/env bash
 # media-stack 管理命令（由 media-stack.py 生成）
 set -uo pipefail
 D="${MEDIA_STACK_DIR:-__DIR__}"
@@ -3955,11 +3955,18 @@ def set_title_policy():
     print("-" * 60)
     c = ask("选 1 或 2（回车不改）").strip()
     want = {"1": "scrape", "2": "filename"}.get(c)
-    if not want or want == cur:
+    if not want:
         print("没有改动。")
         return
-    save_ms_state(title_policy=want)
-    ok(f"已改成：{'网盘文件名' if want == 'filename' else '刮削结果'}")
+    # 【选了同一个也要套用一遍】设置存在本地，条目改在 Emby 上，两边可能不一致 ——
+    # 上一版套用失败时就是这样：设置显示"网盘文件名"，Emby 里一个没改。这时候用户
+    # 再选一次同样的值，本意是"再来一次"，而旧代码答"没有改动"然后什么都不做，
+    # 把唯一的重试入口堵死了。
+    if want != cur:
+        save_ms_state(title_policy=want)
+        ok(f"已改成：{'网盘文件名' if want == 'filename' else '刮削结果'}")
+    else:
+        print(f"  {DIM}选的还是当前这个，按它重新套用一遍。{RST}")
     d = ms_install_dir()
     key = (read_yaml_scalar(os.path.join(d, "mediawarp", "config", "config.yaml"),
                             "auth") if is_installed(d) else "")


### PR DESCRIPTION
## 现象

用户设成「网盘文件名」之后 Emby 没变（上一个 PR 修的接口错），于是再进去选一次 `2` 想重试：

```
当前：网盘文件名
选 1 或 2（回车不改）: 2
没有改动。
```

**什么都没做。**

## 判断错在只比了「设置」

设置存在本地（`ms_state`），条目改在 Emby 上——**两边完全可能不一致**。

套用失败时就是这样：菜单显示「当前：网盘文件名」，Emby 里一个都没改。用户这时候再选同一项，本意就是"再来一次"，而旧代码把这个入口堵死了，而且给出的理由（"没有改动"）恰好会让人以为已经是对的。

## 改动

选了值就套用，只有值**真的变了**才存盘。直接回车仍然是不改。

```
选的还是当前这个，按它重新套用一遍。
✔ 2 个条目的片名已改成网盘文件名（并锁定，刮削不再覆盖）
```

## 顺手

`CLI_TEMPLATE` 改成 r-string，消掉 `invalid escape sequence '\.'` 那条 SyntaxWarning——每次进菜单都打一行，看着像出错了。

## 验证

| 操作 | 套用 | 存盘 |
|---|---|---|
| 当前 filename，又选 2 | ✔ | 不重复存 |
| 当前 filename，选 1 | ✔ | 存 scrape |
| 直接回车 | ✗ | ✗ |

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_