### PR TITLE
.nfo 里的 id 要认全七种写法，抠完还要自查

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2431,9 +2431,17 @@ def clear_impossible_progress(key):
     return n
 
 
+# 三种写法都要认。只写成对标签的话，自闭合和空标签会漏网 —— 实测漏掉一行之后
+# grep 还能在文件里搜到 uniqueid，而"清干净了没有"这种事不该靠肉眼去数。
+_NFO_ID_TAGS = "tmdbid|imdbid|tvdbid|uniqueid|tmdbcolid"
 NFO_ID_RE = re.compile(
-    r"[ \t]*<(tmdbid|imdbid|tvdbid|uniqueid)\b[^>]*>.*?</\1>[ \t]*\r?\n?",
+    r"[ \t]*(?:"
+    rf"<({_NFO_ID_TAGS})\b[^>]*/>"          # <uniqueid type="tmdb"/>
+    rf"|<({_NFO_ID_TAGS})\b[^>]*>.*?</\2>"  # <tmdbid>123</tmdbid>
+    r")[ \t]*\r?\n?",
     re.IGNORECASE | re.DOTALL)
+# 抠完回头自查用：文件里还能搜到这些词，就说明有形态没覆盖到
+NFO_ID_LEFT_RE = re.compile(rf"<(?:{_NFO_ID_TAGS})\b", re.IGNORECASE)
 
 
 def strip_nfo_ids(strm_host_path):
@@ -2458,11 +2466,19 @@ def strip_nfo_ids(strm_host_path):
     try:
         with open(nfo, "w", encoding="utf-8") as f:
             f.write(out)
-        print(f"  {DIM}·{RST} 已从 {os.path.basename(nfo)} 里抠掉刮削 id")
-        return True
     except OSError as e:
         warn(f"改 {os.path.basename(nfo)} 失败：{e}")
         return False
+    # 【自查】写完再搜一遍。漏掉一种写法的后果不是"少清了一行"，而是刮削身份
+    # 下次扫描又被灌回去 —— 也就是这个函数存在的全部意义落空，而且从输出上
+    # 完全看不出来。宁可吵一句，不要静悄悄地留个尾巴
+    if NFO_ID_LEFT_RE.search(out):
+        warn(f"{os.path.basename(nfo)} 里还残留 id 标签，可能是没见过的写法。")
+        print(f"  {DIM}这个条目的刮削身份可能会被扫描重新读回去。"
+              f"看一眼：grep -n 'uniqueid\\|tmdbid' '{nfo}'{RST}")
+        return False
+    print(f"  {DIM}·{RST} 已从 {os.path.basename(nfo)} 里抠掉刮削 id")
+    return True
 
 
 def split_shared_identities(d, key):


### PR DESCRIPTION
## 问题

用户清完之后 `grep -c "uniqueid\|tmdbid"` 仍然返回 **1**——上一版的正则只认成对标签，自闭合（`<uniqueid type="tmdb"/>`）和空标签漏网了。

## 漏一种写法的后果不是「少清了一行」

那个 id 会在**下次扫描时被读回数据库**，两个条目重新共用观看进度——这个函数存在的全部意义落空，而且**从输出上完全看不出来**。

## 改动

正则改成成对 / 自闭合两条分支，标签名补上 `tmdbcolid`。七种形态都测过：

| 写法 | 结果 |
|---|---|
| `<tmdbid>123</tmdbid>` | ✔ |
| `<uniqueid type="tmdb"/>` | ✔ |
| `<uniqueid type="tmdb" />` | ✔ |
| `<tmdbid></tmdbid>` | ✔ |
| 跨行的 `<uniqueid>` | ✔ |
| `<tmdbcolid>` | ✔ |
| `<uniqueid type="imdb" default="true">` | ✔ |

每种都清干净，且标题、时长这些原样保留。

## 更要紧的是写后自查

抠完再搜一遍，还能搜到 id 标签就说明有**没见过的写法**，直接报出来并给排查命令，返回 `False`。

宁可吵一句，不要静悄悄留个尾巴——**这一整轮排查耗掉一晚上，起因就是几个"看起来成功了"的静默失败。**

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_