### PR TITLE
补时长也只看 strm 媒体库：别去管用户自己建的本地库

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2617,7 +2617,11 @@ def items_without_duration(key):
         return out
     for lb in libs:
         pid = lb.get("ItemId")
-        if not pid:
+        # 和其它几处保持一致：只看指向本脚本 strm 目录的媒体库。用户自己建的本地库
+        # 不归这个脚本管 —— 本地文件 Emby 自己就能探到时长，报出来只是噪音，而且
+        # heal 那边拿到非 strm 路径也只会跳过，等于报了一堆修不了的东西
+        if not pid or not any(STRM_PATH in p or p in STRM_PATH
+                              for p in (lb.get("Locations") or [])):
             continue
         try:
             d = _emby(f"/Users/{uid}/Items?ParentId={pid}&Recursive=true"


### PR DESCRIPTION
## 发现

查"新建的媒体库会不会自动纳入"时顺手核对了作用域，发现七个维护动作里有一个漏了过滤：

| 函数 | 过滤 |
|---|---|
| `tune_strm_libraries` | ✔ |
| `apply_title_policy` | ✔ |
| `shared_identity_items` / `split_shared_identities` | ✔ |
| `clear_impossible_progress` | ✔ |
| `strm_not_in_emby` | ✔ |
| **`items_without_duration`** | **✖ 扫全部媒体库** |

## 后果

不算严重但确实是噪音：用户自己建的本地电影库里若有条目没探到时长，会被报进「条目时长」那一项，而 `heal_media_info` 拿到非 strm 路径只会跳过——**等于报了一堆这个脚本修不了的东西**，用户还得自己判断哪些与它有关。

## 改动

加上同一道路径过滤，七个函数的作用域这下一致了，并用 AST 断言钉住（`split_shared_identities` 走委托，单独放行）。

## 验证

三个库（两个 strm、一个本地 `/mnt/movies`）：

```
补时长扫到: ['1', '2']   查撞车扫到: ['1', '2']
✔ 新建的 strm 库自动纳入；本地库一个字节不碰
```

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_