### PR TITLE
预热的请求之间隔开，别让自己撞上夸克风控

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -1091,6 +1091,11 @@ WARM_STEP_T    = 45     # 后台跑，等久点没关系 —— 热不成才是�
 WARM_BUDGET    = 600    # 整轮封顶（秒）。用满就收工，剩下的交给一小时后那轮
 WARM_RETRY     = 2      # 每部最多试几次。跨境超时多是偶发，隔一轮再试往往就成了
 WARM_LIMIT     = 10     # 每轮热几部。「继续观看」里靠前的那几部才是真会被点开的
+# 每部之间歇一下。AutoFilm 的配置里为同一个理由留了 wait_time: 0.2，注释写着
+# "夸克风控较严，别调成 0"。预热连着打十几个换直链请求，不隔开的话很可能被风控
+# 盯上 —— 那会连累列目录、播放一起超时，等于自己把自己的链路搞垮。
+# 预热是后台任务，多花二十秒毫无代价。
+WARM_GAP       = 2
 WARM_BYTES     = 65536  # 每部拉多少字节 —— 够让网盘把那一段准备好，又不占带宽
 # 每天对齐一次的时刻（北京时间），钉在 AutoFilm 生成 strm 之后半小时 —— 先有
 # 文件，再去清失效、补时长。和 DEFAULT_STRM_CRON 一起改
@@ -4840,6 +4845,8 @@ def warm_links(d, key, limit=None):
                 todo_q = []
                 break
             t0 = time.monotonic()
+            if done or again:            # 第一个不等，之后每个之间歇一下
+                time.sleep(WARM_GAP)
             url = (f"http://127.0.0.1:{MEDIAWARP_PORT}/Videos/{iid}/stream"
                    f"?MediaSourceId=mediasource_{iid}&Static=true&api_key={key}")
             loc, why = "", ""


### PR DESCRIPTION
## 现象

```
列目录 /quark/电影   ✖ timed out
换直链               ✖ timed out
链路保活             ✔ 12 分钟前成功，耗时 2.0 秒
```

这个"忽好忽坏"在加预热之前就反复测到过（97 秒、106 秒、79 秒都录过），是晚高峰的老毛病。

**但既然刚加了每小时预热，得先确保不是自己把接口打爆的。**

## 风险是真的

预热一轮要连着打十几个换直链请求（10 部 + 失败重试），**中间没有任何间隔**。

而 AutoFilm 的配置里为同一个理由留了 `wait_time: 0.2`，注释白纸黑字写着「夸克风控较严，别调成 0」。

被风控盯上的话，列目录、播放会一起超时——**等于自己把自己的链路搞垮，而且现象和线路问题一模一样，根本分不出来**。

## 改动

每部之间歇 2 秒。10 部一轮多花 20 秒，而这是后台任务，没有任何代价。

```
4 部片子 → 间隔 3 次 × 2s = 6s
✔ 第一个不等，之后每个之间歇 2 秒
```

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_