### PR TITLE
MetaTube 范围站错队了，它不是定时任务

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -5839,6 +5839,16 @@ def do_healthcheck():
         except Exception as e:
             _hc("Emby 媒体库", "warn", _short_err(e))
 
+    # MetaTube 是按番号刮成人片的。它出现在动画库/电影库的刮削器名单里，几乎肯定
+    # 是装插件时被 Emby 默认加进去的，而不是用户的本意 —— 后果是那些库里冒出
+    # JAV 封面。这种事必须主动报，用户不会想到去每个库翻刮削器名单。
+    # 只陈述当前在哪些库生效，不判断对错 —— 开几个库是用户自己的事，体检的职责
+    # 是让他看得见。真出问题（动画库冒 JAV 封面）时，这一行就是他要的那条线索
+    if metatube_on(d) and key:
+        mt_on = [n for n, _i, on, _o in metatube_libraries(key) if on]
+        _hc("MetaTube 范围", "ok",
+            "、".join(mt_on) if mt_on else f"{DIM}所有媒体库都没启用{RST}")
+
     _hc_group("后台在跑", "这些是定时任务，红了不影响当下播放")
 
     # ---- 保活 ----
@@ -5856,16 +5866,6 @@ def do_healthcheck():
         else:
             _hc("链路保活", "warn",
                 f"{mins} 分钟前失败：{ka.get('error', '')[:40]}")
-
-    # MetaTube 是按番号刮成人片的。它出现在动画库/电影库的刮削器名单里，几乎肯定
-    # 是装插件时被 Emby 默认加进去的，而不是用户的本意 —— 后果是那些库里冒出
-    # JAV 封面。这种事必须主动报，用户不会想到去每个库翻刮削器名单。
-    # 只陈述当前在哪些库生效，不判断对错 —— 开几个库是用户自己的事，体检的职责
-    # 是让他看得见。真出问题（动画库冒 JAV 封面）时，这一行就是他要的那条线索
-    if metatube_on(d) and key:
-        mt_on = [n for n, _i, on, _o in metatube_libraries(key) if on]
-        _hc("MetaTube 范围", "ok",
-            "、".join(mt_on) if mt_on else f"{DIM}所有媒体库都没启用{RST}")
 
     if os.path.exists(WARM_CRON):
         _hc("直链预热", "ok",


### PR DESCRIPTION
上一版分组时，MetaTube 那块代码正好夹在「保活」和「预热」之间，于是被「后台在跑」的标题一并扫了进去：

```
后台在跑  这些是定时任务，红了不影响当下播放
  链路保活        ✔  1 分钟前成功，耗时 1.6 秒
  MetaTube 范围   ✔  美女动作片          ← 不属于这里
  直链预热        ✔  每 1 小时热一次
  每日对齐        ✔  3 小时前跑过
```

它报的是「哪些媒体库启用了 JAV 刮削器」，和定时任务毫无关系 —— 属于「片子对不对」。

放错组不只是难看：那一组的说明写着**「红了不影响当下播放」**，而动画库冒 JAV 封面恰恰是要马上处理的事。

挪到「片子对不对」末尾，紧跟 `Emby 收录`。顺手把 `do_healthcheck` 里每一项落在哪个组过了一遍，没有别的站错队的。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_