### PR TITLE
菜单把卸载放回最后：节点分流 7、卸载 8

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -6239,7 +6239,7 @@ def do_healthcheck():
                 f"{YELLOW}{'、'.join(_miss)} 里已经没有了{RST}"
                 f"  {DIM}节点脚本重建过订阅{RST}")
             todo.append(("节点分流规则被节点脚本冲掉了（重建订阅会整个重写配置）",
-                         "「8 节点分流规则」→ 1 写入，再在客户端更新一次订阅"))
+                         "「7 节点分流规则」→ 1 写入，再在客户端更新一次订阅"))
         else:
             _hc("节点分流", "ok",
                 f"已写入 {'、'.join(lb for lb, _ in _nf)}"
@@ -6347,8 +6347,8 @@ def main_menu():
         print("  5. 链路体检（卡住 / 不出片子时先跑这个）")
         print("  6. 更新（拉最新镜像 + 按新版本刷新配置）")
         # IP 被墙时才用得上，所以排在体检/更新后面、卸载前面
-        print("  8. 节点分流规则（本机 IP 被墙时，让播放器改走 CDN 节点）")
-        print("  7. 卸载")
+        print("  7. 节点分流规则（本机 IP 被墙时，让播放器改走 CDN 节点）")
+        print("  8. 卸载")
         print("  0. 返回")
         print("-" * 60)
         c = ask("请选择").strip()
@@ -6367,10 +6367,10 @@ def main_menu():
             do_healthcheck()
         elif c == "6":
             do_update(from_menu=True)
-        elif c == "8":
+        elif c == "7":
             node_rule_menu()
             continue          # 子菜单自己管停顿
-        elif c == "7":
+        elif c == "8":
             do_uninstall()
         else:
             print("无效选择。")


### PR DESCRIPTION
上一版为了不动已有编号，把新功能塞成 8、卸载留在 7，于是菜单印出来是：

```
  6. 更新（拉最新镜像 + 按新版本刷新配置）
  8. 节点分流规则（本机 IP 被墙时，让播放器改走 CDN 节点）
  7. 卸载
```

数字跳着走，而且**卸载夹在中间** —— 最危险的那一项本来就该在最末尾。

改成：

```
  6. 更新（拉最新镜像 + 按新版本刷新配置）
  7. 节点分流规则（本机 IP 被墙时，让播放器改走 CDN 节点）
  8. 卸载
```

体检待办里那句「8 节点分流规则」也跟着改成 7，别指错门。

改完核对了一遍编号 / 分支 / 动作三者对得上，没有重号漏号：

```
1 -> main()          5 -> do_healthcheck()
2 -> show_info()     6 -> do_update()
3 -> params_menu()   7 -> node_rule_menu()
4 -> do_strm()       8 -> do_uninstall()
```

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_