### PR TITLE
修回归：do_strm 里没有 cfg，上一版直接崩了

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -4421,7 +4421,9 @@ def do_strm():
         # 全在其余任务还在生成的时候执行，Emby 看到的是半成品。
         # 用户从 1 条路径加到 3 条之后立刻撞上：报「发现文件 1 个」，
         # 而实际有 8 个，另外两个盘还没轮到。
-        want_tasks = max(1, len(cfg.get("scan_paths") or []))
+        # 任务数从 AutoFilm 【自己的配置】数，不从脚本的 cfg 猜 —— 那才是它真正
+        # 会跑几个任务；而且 do_strm 这个位置根本没有 cfg（我上一版就是这么崩的）
+        want_tasks = max(1, len(read_yaml_all(cfg_path, "source_dir")))
         done_lines = []
         started, last, shown, quiet_since = False, "", "", time.monotonic()
         slow_warned = False


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/etc/bgpeer/media-stack.py", line 4424, in do_strm
    want_tasks = max(1, len(cfg.get("scan_paths") or []))
NameError: name 'cfg' is not defined
```

用户点「4 生成媒体库」当场崩。是我上一个 PR（#292）引入的 —— `do_strm` 这个位置根本没有 `cfg`。

## 改法

从 **AutoFilm 自己的配置**数 `source_dir`：

```python
want_tasks = max(1, len(read_yaml_all(cfg_path, "source_dir")))
```

这不只是「换个能用的变量」：`cfg["scan_paths"]` 是脚本**认为**要扫什么，而 AutoFilm 实际会跑几个任务取决于它自己配置里有几条 `source_dir`。等待循环要等的是后者，本来就该从那儿数。

配置为空时兜底 1，不会等不到而死循环。

## 顺带

跑了一遍 pyflakes，确认没有别的未定义名称。

这类错误 `py_compile` **查不出来**（编译期不解析名字），而它 100% 会在用户点下去的那一刻炸。以后改完照跑。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_