### PR TITLE
永远停在「1/3 个网盘」：只有第一个任务的定时被改了

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -4361,9 +4361,13 @@ def do_strm():
     t = (hm[0] * 60 + hm[1] + 2) % 1440
     fire = f"0 {t % 60:02d} {t // 60:02d} * * *"
 
-    patched = re.sub(r'(?m)^(\s*cron:\s*)".*"$', lambda m: f'{m.group(1)}"{fire}"',
-                     original, count=1)
-    if patched == original:
+    # 【每个任务都要改，不能只改第一个】原来这里写死 count=1。单网盘时只有一条
+    # cron，看不出问题；一个网盘一个任务之后，只有排在最前面那个任务被改成
+    # "两分钟后触发"，其余的还是原来的凌晨定时 —— 于是永远停在「已完成 1/3」，
+    # 剩下两个根本没启动，而界面上看着像是它们卡住了。
+    patched, n_fire = re.subn(r'(?m)^(\s*cron:\s*)".*"$',
+                              lambda m: f'{m.group(1)}"{fire}"', original)
+    if not n_fire:
         # 还没动过文件就退出，别进 try —— 否则 finally 会白写一次文件
         err("没能改写 cron 那一行，为安全起见没有继续。")
         return


### PR DESCRIPTION
## 现象

用户连跑几轮，每次都停在「已完成 1/3 个网盘」，然后干等六七分钟没有任何日志：

```
...正在扫描网盘（已完成 1/3 个网盘），已等 7 分 28 秒
   日志 335 秒没有新内容，还停在上面那行
```

看着像另外两个网盘卡住了。**其实它们根本没启动。**

## 原因

```python
patched = re.sub(r'(?m)^(\s*cron:\s*)".*"$', ..., original, count=1)
                                                            ^^^^^^^
```

`do_strm` 是靠把 AutoFilm 的 cron 临时改成「两分钟后触发」来立刻跑一次的，而这里写死 `count=1` —— **只改了配置里第一条 cron**。

单网盘时只有一条，看不出问题；改成「一个网盘一个任务」之后，其余任务的 cron 还是原来的凌晨定时，永不触发。

于是等待循环在等 3 行「任务完成」，而实际只有 1 个任务在跑，剩下的时间全花在等两个压根没启动的任务上，直到静默超时才收工。而上一版还把这个结果报成「✔ 生成完成」（已在 #294 修掉）。

## 改动

改用 `re.subn` 替换全部，并按实际替换条数判断成败 —— 原来靠 `patched == original` 猜，现在有确切的数字。

## 验证

三任务配置下：旧写法只改 1 条，新写法改 3 条。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_