### PR TITLE
把每个网盘的状态摊开：只报 2/3 会让人以为一直在扫别人的盘

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -4569,6 +4569,18 @@ def do_strm():
                 prog = (f"（已完成 {len(done_lines)}/{want_tasks} 个网盘）"
                         if want_tasks > 1 else "")
                 print(f"  {DIM}...{phase}{prog}，已等 {el // 60} 分 {el % 60} 秒{RST}")
+                # 【按盘列出来，不能只给个 2/3】三个任务是并行跑的（AutoFilm 把
+                # 它们排在同一分钟，调度器一次性全启动），而文件最多的那个盘话最密，
+                # 日志里滚的全是它 —— 用户看到的是"一直在扫别人的盘"，
+                # 其实自己的盘早跑完了。把每个盘的状态摊开，这个误会就没了。
+                if want_tasks > 1:
+                    fin = set(re.findall(r"task_id=(\S+)", "\n".join(done_lines)))
+                    run = [t for t in re.findall(r"task_id=(\S+)", out) if t not in fin]
+                    seen_run = list(dict.fromkeys(run))[:4]
+                    bits = [f"{GREEN}✔{RST}{DIM}{t}{RST}" for t in sorted(fin)]
+                    bits += [f"{YELLOW}…{RST}{DIM}{t}{RST}" for t in seen_run]
+                    if bits:
+                        print("       " + "  ".join(bits))
                 if last and last != shown:
                     print(f"  {DIM}   {last[-88:]}{RST}")
                     shown = last


### PR DESCRIPTION
## 现象

用户连着两轮说「这还是在扫他的」，而日志里明明写着：

```
...正在扫描网盘（已完成 1/3 个网盘），已等 2 分 9 秒
...正在扫描网盘（已完成 2/3 个网盘），已等 2 分 40 秒
```

**他的夸克和 115 在 2 分 40 秒就跑完了**，滚在屏幕上的全是七米蓝。

## 原因

三个任务是**并行**跑的 —— AutoFilm 把它们排在同一分钟，调度器一次性全启动。文件最多的那个盘话最密，日志就全是它。

所以上一版（#298 / #299）按大小排序**对这个场景没用**：配置里的先后根本不影响启动顺序。排序本身留着（AutoFilm 若改成串行仍然有意义），但不该让用户以为它解决了这个问题。

## 真正的缺口

看不出谁完成了谁没完成。进度行下面按盘摊开：

```
...正在扫描网盘（已完成 2/3 个网盘），已等 3 分 46 秒
     ✔115  ✔quark  …七米蓝影视
```

完成的从「任务完成」行取 `task_id`，进行中的从全部日志里取 `task_id` 再减掉已完成的。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_