### PR TITLE
体检加内存那一项：链路全绿但放不了，是机器没内存了

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -6762,6 +6762,33 @@ def do_healthcheck():
         _hc("Emby API Key", "bad", "空 —— 302 不会生效")
         todo.append(("MediaWarp 没有 Emby API Key", "3 后补参数 → 1 添加 API 密钥"))
 
+    # 【内存要单独报】实测撞过：库涨到 3 万多条目后 Emby 刮削把 3.8 GB 吃到只剩
+    # 300 MB，OpenList 和 MediaWarp 跟着挨饿，表现是「视频都看不了」—— 而链路那
+    # 一组全是绿的，因为链路本身没坏，是整台机器没内存了。
+    # 这正是这个体检要抓的「看起来正常、实际是废的」，而且它只在大库上才出现。
+    try:
+        _mi = {}
+        for _ln in open("/proc/meminfo"):
+            _k, _, _v = _ln.partition(":")
+            _mi[_k] = int(_v.split()[0]) // 1024          # MiB
+        _tot = _mi.get("MemTotal", 0)
+        _av = _mi.get("MemAvailable", 0)
+        if _tot:
+            _pct = _av * 100 // _tot
+            _n_strm = strm_count(d)
+            _st = "ok" if _pct >= 25 else ("warn" if _pct >= 12 else "bad")
+            _hc("内存", _st, f"可用 {_av} MiB / {_tot} MiB（{_pct}%）"
+                             + (f"   {DIM}{_n_strm} 个 strm{RST}" if _n_strm else ""))
+            if _st != "ok":
+                todo.append((f"内存只剩 {_pct}%（{_av} MiB）—— 这时候播放会失败，"
+                             f"而链路各项还是绿的：不是链路坏了，是整台机器没内存了",
+                             f"多半是 Emby 在刮削 {_n_strm} 个条目。"
+                             f"docker restart emby 先止血；"
+                             f"要长期稳，把大库从扫描路径里去掉、"
+                             f"或者在 Emby 里删掉那个媒体库"))
+    except (OSError, ValueError):
+        pass
+
     _hc_group("片子对不对", "链路是通的，但库里的东西可能不对")
 
     # ---- strm / 媒体库 ----


### PR DESCRIPTION
## 实测撞墙

库涨到 3 万多条目之后，Emby 刮削把 3.8 GB 吃到只剩 **309 MB**，OpenList 和 MediaWarp 跟着挨饿，用户看到的是「视频都看不了」。

而链路那一组**全是绿的** —— 因为链路本身没坏。

这正是这个体检一路在防的「看起来正常、实际是废的」，只不过这次的瓶颈不在任何一个组件里，而在**整台机器**上。链路各项挨个测过去，一项都发现不了。

## 输出

```
内存   ✔  可用 2900 MiB / 3800 MiB（76%）   62 个 strm
内存   ⚠  可用 430 MiB / 3800 MiB（11%）    34231 个 strm
内存   ✖  可用 309 MiB / 3800 MiB（8%）     34231 个 strm
```

**把 strm 数一起打出来是有意的** —— 这两个数字并排，因果关系不用解释。

阈值 25% / 12% 按后果定：低于 12% 时播放已经开始失败。

## 待办

直接说清楚「不是链路坏了」，并给两条路：

- **止血**：`docker restart emby` 立刻回内存
- **长期**：把大库从扫描路径去掉，或在 Emby 里删掉那个媒体库

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_