### PR TITLE
体检补负载那一项：只报内存会把人引向错的方向

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -6762,6 +6762,27 @@ def do_healthcheck():
         _hc("Emby API Key", "bad", "空 —— 302 不会生效")
         todo.append(("MediaWarp 没有 Emby API Key", "3 后补参数 → 1 添加 API 密钥"))
 
+    # 【负载和内存要一起看】实测撞过一次，而我第一时间判断错了：看到"扫库 + 卡死"
+    # 就归因给 Emby 刮削吃内存，可 docker stats 摆出来是 emby 280 MiB、
+    # mediawarp 969 MiB、六个容器合计才 1.6 GB —— 内存不是被 Emby 吃的，
+    # 而 CPU 那会儿是 100%(2 核)。CPU 打满时什么都卡，跟内存够不够无关。
+    # 所以这两个必须并排报，只报一个会把人引向错的方向。
+    try:
+        _la = os.getloadavg()[0]
+        _nc = os.cpu_count() or 1
+        _r = _la / _nc
+        _st = "ok" if _r < 1.0 else ("warn" if _r < 2.0 else "bad")
+        _hc("负载", _st, f"{_la:.2f} / {_nc} 核（每核 {_r:.2f}）"
+                        + ("" if _st == "ok" else
+                           f"   {YELLOW}CPU 打满时播放会卡，和内存无关{RST}"))
+        if _st == "bad":
+            todo.append((f"负载 {_la:.2f}、只有 {_nc} 个核 —— 这时候播放卡顿、"
+                         f"界面转圈都是 CPU 排队造成的，不是链路问题",
+                         "docker stats 看是谁在烧 CPU。刮削和扫描是常见来源，"
+                         "等它跑完就会回落；一直不回落才需要查"))
+    except (OSError, AttributeError):
+        pass
+
     # 【内存要单独报】实测撞过：库涨到 3 万多条目后 Emby 刮削把 3.8 GB 吃到只剩
     # 300 MB，OpenList 和 MediaWarp 跟着挨饿，表现是「视频都看不了」—— 而链路那
     # 一组全是绿的，因为链路本身没坏，是整台机器没内存了。


### PR DESCRIPTION
## 我上一条判断错了，这里把教训固化成检查项

机器卡死时，我看到「扫库 + 内存爆」就归因给 Emby 刮削。可 `docker stats` 摆出来是：

```
mediawarp   969.4 MiB   ← 最大的一个
emby        280.7 MiB   ← 只有 7%
homepage    182.3 MiB
openlist     83.4 MiB
六个容器合计 ≈ 1.6 GB
```

**内存根本不是被 Emby 吃的。** 而面板上 CPU 是 **100%（2 核）** —— CPU 打满时什么都卡，跟内存够不够无关。

只报内存不够：会让人照着「内存不足」去删库删片，而真凶可能在 CPU 那边。**两个必须并排出现。**

## 输出

```
负载   ✔  0.74 / 2 核（每核 0.37）
负载   ⚠  2.10 / 2 核（每核 1.05）   CPU 打满时播放会卡，和内存无关
负载   ✖  4.80 / 2 核（每核 2.40）   CPU 打满时播放会卡，和内存无关
```

阈值**按每核算，不按绝对值** —— 2 核的 2.0 和 8 核的 2.0 完全是两回事。

待办里明说这不是链路问题，并提示刮削/扫描跑完会自己回落，一直不落才要查。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_