### PR TITLE
给六个容器加日志上限：Docker 默认不封顶，一次扫库就是三万行

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -334,6 +334,18 @@ def ensure_docker():
 
 
 # ============================================================================ 配置生成
+# Docker 默认的 json-file 日志【没有上限】—— 六个容器一直往里写，Emby 扫一次
+# 三万个条目就是三万行访问日志，磁盘和页缓存都会被慢慢吃掉，而且脚本自己也靠
+# docker logs 做诊断，文件越大读得越慢。
+# 实测那台机器上 mediawarp 在 docker stats 里显示 939 MiB —— 而它刚重启 20 秒、
+# CPU 0.11%，一个 Go 反代不可能真占这么多，绝大部分是日志文件的页缓存。
+# 每个容器封顶 3 个 10 MB，六个加起来最多 180 MB，够查问题也不会失控。
+LOG_LIMIT = """    logging:
+      driver: json-file
+      options: {max-size: "10m", max-file: "3"}
+"""
+
+
 def gen_compose(cfg):
     """生成 docker-compose.yml。
 
@@ -350,7 +362,7 @@ def gen_compose(cfg):
     image: emby/embyserver:latest
     container_name: emby
     restart: unless-stopped
-    environment:
+{LOG_LIMIT}    environment:
       - UID=${{PUID}}
       - GID=${{PGID}}
       - TZ=${{TZ}}
@@ -366,7 +378,7 @@ def gen_compose(cfg):
     image: openlistteam/openlist:latest
     container_name: openlist
     restart: unless-stopped
-    user: "${{PUID}}:${{PGID}}"
+{LOG_LIMIT}    user: "${{PUID}}:${{PGID}}"
     environment:
       - UMASK=022
       - TZ=${{TZ}}
@@ -380,7 +392,7 @@ def gen_compose(cfg):
     image: akimio/autofilm:latest
     container_name: autofilm
     restart: unless-stopped
-    # AutoFilm 读不到 TZ 环境变量（启动日志里会打印「使用应用时区 timezone=UTC」），
+{LOG_LIMIT}    # AutoFilm 读不到 TZ 环境变量（启动日志里会打印「使用应用时区 timezone=UTC」），
     # 所以定时任务的时刻必须靠 --timezone 显式指定，否则 cron 里写的 05:15 会被当成
     # 05:15 UTC —— 对国内用户就是下午一点多，完全不是想要的"凌晨闲时"。
     # 钉死在北京时间而不是跟随服务器本地时区：网盘在国内，"闲时"是按北京时间定义的，
@@ -399,7 +411,7 @@ def gen_compose(cfg):
     image: akimio/mediawarp:latest
     container_name: mediawarp
     restart: unless-stopped
-    environment:
+{LOG_LIMIT}    environment:
       - TZ=${{TZ}}
     volumes:
       - {d}/mediawarp/config:/config
@@ -416,7 +428,7 @@ def gen_compose(cfg):
     image: ghcr.io/gethomepage/homepage:latest
     container_name: homepage
     restart: unless-stopped
-    environment:
+{LOG_LIMIT}    environment:
       - PUID=${{PUID}}
       - PGID=${{PGID}}
       - TZ=${{TZ}}
@@ -441,7 +453,7 @@ def gen_compose(cfg):
     image: {METATUBE_IMAGE}
     container_name: metatube
     restart: unless-stopped
-    environment:
+{LOG_LIMIT}    environment:
       - TZ=${{TZ}}
     volumes:
       - {d}/metatube:/data


### PR DESCRIPTION
## 线索

```
mediawarp  939.9MiB / 3.8GiB  0.11%      ← 刚重启 20 秒
```

一个 Go 反代刚起来、CPU 0.11%，不可能真占 940 MB。绝大部分是**日志文件的页缓存**。

MediaWarp 的访问日志是 `console: true`，全部进 `docker logs`；而 compose 里**没有任何 logging 配置** —— Docker 的 json-file 驱动默认**不封顶**。Emby 扫一次三万个条目就是三万行访问日志，一直涨。

后果有三层：

1. 磁盘被慢慢吃掉
2. 页缓存把 `docker stats` / 面板的内存数字顶到吓人的高度
3. **脚本自己靠 `docker logs` 做诊断**，文件越大读得越慢（体检、等扫描都读它）

## 改动

每个容器封顶 3 个 10 MB，六个加起来最多 180 MB —— 够查问题，也不会失控。

渲染验证：6 处全部插入，无字面量残留，PyYAML 解析通过。

## 顺带记一笔今天的教训

主机面板显示内存 93.8%、可用 242 MB，看着像爆了。`free -m` 一跑：

```
              total   used   free  buff/cache  available
Mem:           3890   2075   1026        1106       1815
load average: 0.13, 0.05, 0.01
```

**内存根本没紧张** —— available 1815 MB，面板把可回收的页缓存算进「已用」了。真正让机器卡死的是 CPU 100%。

两次判断都是「数字看着吓人」，两次真相都在别处。这也是 #305 / #306 把内存和负载并排报的理由。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_