### PR TITLE
「任务并发」那行写短：正常情况下的措辞把下一项顶到了同一行

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -7284,14 +7284,19 @@ def do_healthcheck():
     # 分组上它属于"后台在跑"，但影响是实打实的播放中断，所以 todo 里按高优先给。
     tasks = running_tasks()
     if not tasks:
-        _hc("任务并发", "ok", f"没有正在跑的后台任务{DIM}（都装了互斥锁，"
-                              f"同类任务同时只跑一个）{RST}")
+        _hc("任务并发", "ok", f"没有堆积{DIM}　同类任务同时只跑一个{RST}")
     else:
         by_sub = {}
         for _p, sub, age in tasks:
             by_sub.setdefault(sub, []).append(age)
-        desc = "、".join(f"{s}×{len(a)}（最久 {a[0] // 60} 分钟）"
-                         for s, a in sorted(by_sub.items()))
+        # 【正常和异常要用不同的写法】叠起来的时候「×N」是重点，没叠的时候它
+        # 恒等于 ×1，写出来只是噪音 —— 而这一行挤，实测过长到把下一项顶到同一行。
+        def _one(s, a):
+            mins = a[0] // 60
+            when = f"{mins} 分钟" if mins else f"{a[0]} 秒"
+            return (f"{s}×{len(a)}（最久 {when}）" if len(a) > 1
+                    else f"{s} 在跑 {when}")
+        desc = "、".join(_one(s, a) for s, a in sorted(by_sub.items()))
         piled = [s for s, a in by_sub.items() if len(a) > 1]
         # 超时是按"下一次触发之前"设的，所以跑过头 = timeout 没生效（缺 coreutils，
         # 或者这进程是装 flock 之前起来的）
@@ -7306,7 +7311,7 @@ def do_healthcheck():
                 "跑一次「6 更新」：会先杀掉卡住的，再给三条 cron 装上互斥锁和超时。"
                 "急的话先手动清：pkill -f 'media-stack.py (keepalive|warm|sync)'"))
         else:
-            _hc("任务并发", "ok", f"{desc}{DIM}（各一个，正常）{RST}")
+            _hc("任务并发", "ok", f"{desc}{DIM}　没有堆积{RST}")
 
     # ---- 保活 ----
     ka = keepalive_state(d)


### PR DESCRIPTION
## 现场

```
任务并发   ✔ warm×1（最久 3 分钟）（各一个，正常）  链路保活  ✔ 20 分钟前成功
```

两段解释叠在一起，长到把下一项挤上来。而且没叠的时候「×1」恒为真，写出来只是噪音——真正要突出「×N」的是叠起来那一支。

## 改后

| 情况 | 输出 |
|---|---|
| 一个在跑 | `warm 在跑 3 分钟 没有堆积` |
| 刚起来 | `keepalive 在跑 12 秒 没有堆积` |
| 叠起来（判红） | `3 个后台任务同时在跑：warm×3（最久 15 分钟）` |
| 没有任务 | `没有堆积 同类任务同时只跑一个` |

顺带：不足一分钟报秒，原来会显示「最久 0 分钟」。

判红那一支的措辞和 todo 不变。

## 验证

```
一个 warm 跑了 3 分钟   → warm 在跑 3 分钟
一个 keepalive 刚起     → keepalive 在跑 12 秒
warm 叠了 3 个          → warm×3（最久 15 分钟）
混合叠                  → keepalive 在跑 1 分钟、warm×2（最久 15 分钟）
```

`py_compile` + `pyflakes` 干净。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_