### PR TITLE
strm 目录树改成网盘目录树的镜像：扫描路径那几段不该被吃掉

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -476,7 +476,17 @@ def parse_scan_spec(s):
     接受三种写法，因为这三种都是用户会自然打出来的：
       · y / Y / auto / 自动        → SCAN_AUTO，跟随 OpenList 里已挂载的存储
       · /quark                     → 单条路径
-      · /quark,/aliyun  或空格分隔  → 多条路径
+      · /quark,/aliyun             → 多条路径，【只认逗号】
+
+    【空格曾经也当分隔符，这是个会毁数据的错】实测：用户想填 /quark/电影，
+    中间多打了一个空格，于是被切成 /quark/电 和 /影 两条 —— 两条都不存在，
+    这个盘从此扫不到任何东西。而目录名里带空格本来就常见
+    （/quark/My Movies、/115/4K REMUX），按空格切等于这类路径永远填不进来。
+
+    切错的代价不止是"扫不到"：扫描路径决定了哪些主目录算孤儿，切歪之后
+    下游那个清理会认为本地所有 strm 都不该留 —— 那次就是这么把 39786 个
+    全删了。所以这里只认逗号，宁可让一条填错的路径原样留着去撞
+    「不在已挂载的存储里」那个警告，也不要自作主张替用户切开。
 
     返回 SCAN_AUTO 或去重后的路径列表；给不出有效内容时返回 None，由调用方决定兜底。
     """
@@ -486,7 +496,7 @@ def parse_scan_spec(s):
     if s.lower() in ("y", "yes", "auto") or s in ("自动", "是"):
         return SCAN_AUTO
     out, seen = [], set()
-    for p in re.split(r"[,，\s]+", s):
+    for p in re.split(r"[,，]+", s):
         p = p.strip().rstrip("/")
         if not p:
             continue
@@ -5795,12 +5805,12 @@ def set_scan_paths():
     print(f"  将扫描：{BOLD}{'、'.join(paths)}{RST}")
     # 提前把「填了但没挂上」挑出来:AutoFilm 扫不存在的目录只会在日志里留一行 WARN,
     # 用户看到的是"点了生成但什么都没多",很难联想到是路径打错了
-    if mounted:
-        unknown = [p for p in paths if not any(p == mp or p.startswith(mp.rstrip("/") + "/")
-                                               for mp in mounted)]
-        if unknown:
-            warn(f"这些路径不在已挂载的存储里：{'、'.join(unknown)}")
-            print(f"  {DIM}拼错了或者还没在 OpenList 里挂上，扫的时候会被跳过。{RST}")
+    unknown = [p for p in paths
+               if not any(p == mp or p.startswith(mp.rstrip("/") + "/")
+                          for mp in mounted)] if mounted else []
+    if unknown:
+        warn(f"这些路径不在已挂载的存储里：{'、'.join(unknown)}")
+        print(f"  {DIM}拼错了或者还没在 OpenList 里挂上，扫的时候会被跳过。{RST}")
 
     # 扫网盘根目录是个大坑,而且是「看起来成功了」的那种坑:
     #   1. 整个盘都会被镜像成 strm —— 手机备份、微信截图、扫描件、壁纸全堆进媒体库,
@@ -5827,11 +5837,11 @@ def set_scan_paths():
     save_ms_state(scan_spec=spec)
     subprocess.run(["docker", "restart", "autofilm"], capture_output=True)
     ok(f"已改成 {len(paths)} 条扫描路径，AutoFilm 已重启")
-    drop_orphan_strm_dirs(d, paths)
+    drop_orphan_strm_dirs(d, paths, unknown)
     print(f"  {DIM}回菜单点「4 生成媒体库」立刻扫一次，或等每天定时任务。{RST}")
 
 
-def drop_orphan_strm_dirs(d, paths):
+def drop_orphan_strm_dirs(d, paths, unknown=()):
     """把不再属于任何扫描路径的主目录清掉（问过之后）。
 
     【缩小扫描范围原来是个没有效果的按钮】—— 这是实测撞出来的，而且撞得很难看：
@@ -5847,13 +5857,44 @@ def drop_orphan_strm_dirs(d, paths):
 
     删之前【必须问】，而且默认否：这是这整个脚本里少数几个真的删用户文件的
     地方。删的只是本地生成的 strm 和刮削缓存，网盘上的片子一个都不碰。
+
+    【这个函数第一版把用户的 39786 个 strm 全删了】，两个错叠在一起：
+
+      1. 挂载目录在 <DATA_ROOT>/strm/cloud/<盘名>，而这里列的是
+         <DATA_ROOT>/strm —— 那一层只有一个子目录 "cloud"。"cloud" 当然不在
+         keep 里，于是它被当成孤儿，一刀下去连 115 和 quark 一起没了。
+         strm_dirs_uncovered() 早就用对了 STRM_SUBDIR，这里漏了。
+      2. 没有下限保护。keep 算出来一个都对不上时，正确的反应是「我算错了，
+         什么都别删」，而不是「那就全是孤儿，删吧」。用户看到的提示是
+         「cloud　39786 个 strm」—— 一个不像盘名的名字、一个大得离谱的数字，
+         而提示本身写得理直气壮，他就按了 y。
+
+    所以下面那道 keep 检查不是冗余：宁可漏删（用户再点一次就是了），
+    也绝不能因为算错就把整棵树端了。
     """
+    # 【有一条路径填歪就整个不删】删除的依据是「这些盘不在扫描范围里了」，
+    # 而这个推理的前提是那几条路径本身是对的。有路径对不上已挂载的存储时，
+    # 前提就已经塌了 —— 那次事故里 /影 就是这么来的，它旁边还立着一行
+    # 「这些路径不在已挂载的存储里」的警告，而清理照删不误。
+    if unknown:
+        print(f"  {DIM}有路径对不上已挂载的存储，本地 strm 一个都不动 ——"
+              f"先把路径填对，再回来改一次就会问。{RST}")
+        return
     keep = {m for m in (strm_mount_dir(p) for p in paths) if m}
-    root = strm_root(d)
+    root = os.path.join(strm_root(d), STRM_SUBDIR)     # 盘名在 cloud/ 这一层
     try:
-        orphans = sorted(x for x in os.listdir(root)
-                         if os.path.isdir(os.path.join(root, x)) and x not in keep)
+        dirs = sorted(x for x in os.listdir(root)
+                      if os.path.isdir(os.path.join(root, x)))
     except OSError:
+        return
+    orphans = [x for x in dirs if x not in keep]
+    if dirs and not (set(dirs) & keep):
+        # 一个都没留下 = keep 算错了（路径填歪了、或者盘名对不上）。这时候
+        # 「全都是孤儿」是推理错误，不是事实 —— 闭嘴，什么都别删。
+        warn(f"扫描路径算出来的主目录（{'、'.join(sorted(keep)) or '空'}）"
+             f"和本地已有的（{'、'.join(dirs)}）一个都对不上。")
+        print(f"  {DIM}不动任何文件 —— 这种情况多半是扫描路径填歪了。"
+              f"确认一下上面那几条路径对不对。{RST}")
         return
     if not orphans:
         return
@@ -5867,6 +5908,10 @@ def drop_orphan_strm_dirs(d, paths):
     warn(f"这 {len(orphans)} 个主目录已经不在扫描范围里了，但它们的 strm 还在本地：")
     for x in orphans:
         print(f"  {DIM}·{RST} {x}　{BOLD}{sizes[x]}{RST} 个 strm")
+    # 【把留下的也列出来】只报要删的，用户没有参照物。第一版就是这样把
+    # 「cloud　39786 个」摆在人面前，看不出那其实是整棵树。
+    kept = [x for x in dirs if x in keep]
+    print(f"  {DIM}会留下：{RST}{'、'.join(kept) if kept else f'{RED}没有{RST}'}")
     print(f"  {DIM}留着的话 Emby 会继续刮削它们、继续占内存，体检里那些"
           f"「没时长」「没收录」的数字也会一直挂着。{RST}")
     print(f"  {DIM}删掉的只是本机生成的 strm 和刮削缓存，{RST}"

--- a/media-stack.py
+++ b/media-stack.py
@@ -542,7 +542,7 @@ def order_scan_paths(d, paths):
     def local_strm(p):
         n = 0
         try:
-            for _r, _ds, fs in os.walk(os.path.join(base, strm_mount_dir(p))):
+            for _r, _ds, fs in os.walk(os.path.join(base, *strm_subpath(p).split("/"))):
                 n += sum(1 for f in fs if f.endswith(".strm"))
         except OSError:
             pass
@@ -572,17 +572,43 @@ def order_scan_paths(d, paths):
     return [p for _n, p in scanned] + fresh
 
 
-def strm_mount_dir(scan_path):
-    """扫描路径 → 它在 strm 树里的主目录名。/quark/电影 → quark；/115 → 115
+def strm_subpath(scan_path):
+    """扫描路径 → strm 树里对应的相对目录。就是网盘全路径去掉开头的斜杠。
 
-    每个网盘一条主路径，是这套目录结构唯一能长期站得住的形状：
+        /quark        → quark
+        /quark/电影   → quark/电影
+
+    【strm 树是网盘树的镜像】。这条规则唯一的要求就是"一一对应"，而它换来的
+    是扫描路径怎么改都不会让已有的 strm 搬家。
+
+    原来的规则是「target = cloud/<盘名>，底下接【相对扫描路径】的部分」——
+    扫描路径自己那几段被吃掉。实测撞出来的样子：
+
+        网盘 /quark/电影/仙逆/x.mp4     → cloud/quark/仙逆/x.strm      「电影」没了
+        网盘 /quark/电影/电影/功夫/…    → cloud/quark/电影/功夫/…      这个「电影」是里层那个
+
+    两个问题：
+      1. cloud/quark/电影 这个路径，在扫 /quark 时指外层「电影」，在扫
+         /quark/电影 时指内层「电影」—— 同一个字符串换了含义。
+      2. 而 Emby 媒体库的路径是用户在 Emby 界面里手填的，脚本改扫描路径时
+         碰不到它。于是用户把扫描路径填深一层，库还指着老字符串，覆盖范围
+         悄悄变了：那次是 7 个 strm 里 6 个掉到库外面，Emby 不报任何错。
+
+    镜像全路径之后，cloud/quark/电影 永远等于网盘的 /quark/电影，跟当时扫的是
+    哪一层无关。已有的 strm 由 migrate_strm_layout() 挪过去，续播点跟着搬。
+    """
+    return "/".join(x for x in (scan_path or "").split("/") if x)
+
+
+def strm_mount_dir(scan_path):
+    """扫描路径 → 它在 strm 树里的【顶层】目录名。/quark/电影 → quark；/115 → 115
+
+    只在"这个网盘还要不要"这种整盘级别的判断里用（比如清理孤儿主目录）。
+    落点用 strm_subpath()，别拿这个去拼路径 —— 那正是上面记的那个坑。
+
+    每个网盘一条主路径这件事本身是对的，保留：
       · 挂第 N 个网盘时不用改任何已有配置，它自己长出 cloud/<盘名>/
       · 两个盘里都有「电影」文件夹也不会混在一起
-      · 扫描路径改深改浅（/quark → /quark/电影）只影响那个盘自己的子树，
-        不会像共用 target_dir 时那样把【所有】盘的 strm 整体挪位
-    最后一条是实测踩出来的：扫描路径从 /quark/电影 改成自动展开的 /quark，
-    7 个 strm 全部换了位置，旧的又不会被 prune 清掉（网盘上还在），
-    结果是每部片在 Emby 里变成两个条目、续播点全丢。
     """
     segs = [x for x in (scan_path or "").split("/") if x]
     return segs[0] if segs else ""
@@ -677,7 +703,7 @@ def _gen_strm_task(cfg, path):
     cron: "{cfg['strm_cron']}"
     alist: openlist
     source_dir: "{path}"
-    target_dir: "{STRM_PATH}/{strm_mount_dir(path)}"
+    target_dir: "{STRM_PATH}/{strm_subpath(path)}"
     mode: AlistPath         # 见 gen_autofilm_conf 的注释，三种取值都实测过
     flatten_mode: false
     overwrite: false
@@ -1785,7 +1811,7 @@ def planned_strm_path(d, netdisk_path, scan_paths):
     rel = netdisk_path[len(best.rstrip("/")):].lstrip("/")
     if not rel:
         return ""
-    return os.path.join(strm_root(d), STRM_SUBDIR, strm_mount_dir(best),
+    return os.path.join(strm_root(d), STRM_SUBDIR, *strm_subpath(best).split("/"),
                         os.path.splitext(rel)[0] + ".strm")
 
 
@@ -1986,7 +2012,7 @@ def _sweep_empty_dirs(root_dir):
 
 
 def migrate_strm_layout(d, key):
-    """把已有的 strm 挪到「每个网盘一个主目录」的新布局里。返回挪了几个。
+    """把已有的 strm 挪到它按当前规则【应该】在的位置。返回挪了几个。
 
     为什么必须由脚本来挪、而不是让 AutoFilm 在新位置重新生成一遍：旧位置的
     strm 【不会】被 prune 清掉 —— prune 只删网盘上确认没有的，而这些文件在网盘上
@@ -2012,7 +2038,7 @@ def migrate_strm_layout(d, key):
         _sweep_empty_dirs(strm_root(d))
         return 0
     print()
-    info(f"扫描路径变了，{len(moves)} 个 strm 要挪到新位置（每个网盘一个主目录）")
+    info(f"{len(moves)} 个 strm 要挪位置（strm 目录树要和网盘目录树对上）")
     print(f"  {DIM}不挪的话新旧两份并存，每部片在 Emby 里会变成两个条目。{RST}")
     saved = _progress_by_target(d, key) if key else {}
     if saved:
@@ -2041,7 +2067,7 @@ def migrate_strm_layout(d, key):
             warn(f"挪不动 {os.path.basename(src)}：{_short_err(e)}")
     # 顺手把空掉的旧目录收干净，否则 Emby 里会留一堆空文件夹条目
     _sweep_empty_dirs(strm_root(d))
-    ok(f"{n} 个 strm 已挪到新布局")
+    ok(f"{n} 个 strm 已挪好，strm 目录树和网盘对上了")
     if key:
         emby_scan_wait(key, timeout=900)
         back = _restore_progress(d, key, saved)


### PR DESCRIPTION
## 现场

用户的夸克网盘（外层「电影」下面还有一个「电影」）：

```
夸克网盘/电影/仙逆/仙逆 [第154集•4K].mp4
夸克网盘/电影/美女动作片/小仙女.mp4
夸克网盘/电影/电影/功夫 (2004) 4K 60帧 高码/…
```

扫描路径填 `/quark/电影`，生成出来：

```
cloud/quark/仙逆/…            ← 「电影」没了
cloud/quark/美女动作片/…
cloud/quark/电影/功夫…/…      ← 这个「电影」是里层那个
```

## 问题

旧规则是「target = `cloud/<盘名>`，底下接**相对扫描路径**的部分」——扫描路径自己那几段被吃掉。于是 `cloud/quark/电影` 这个字符串：

| 扫描路径 | `cloud/quark/电影` 实际指 |
|---|---|
| `/quark` | 外层「电影」 |
| `/quark/电影` | 内层「电影」 |

**同一个路径换了含义。** 而 Emby 媒体库的路径是用户在 Emby 界面里手填的，脚本改扫描路径时碰不到它。用户把扫描路径填深一层，库还指着老字符串，覆盖范围就悄悄变了：

```
⚠ 有 6 个 strm 生成了，但 Emby 里没有对应的独立条目
```

7 个里 6 个掉到库外面，Emby 不报任何错，日志里一个字都没有——和之前那个「功夫扫不进来」是同一类沉默故障。

## 改动

```
strm 落点 = /data/strm/cloud + 网盘全路径

/quark/电影/仙逆/x.mp4  →  cloud/quark/电影/仙逆/x.strm
```

`cloud/quark/电影` 永远等于网盘的 `/quark/电影`，跟当时扫的是哪一层无关。

「每个网盘一个主目录」这件事本身是对的，保留：`strm_mount_dir()` 还在，但只用于整盘级别的判断（清理孤儿主目录），不再拿去拼路径。落点走新的 `strm_subpath()`。

## 迁移

不用额外写。`migrate_strm_layout()` 本来就是拿现状和 `planned_strm_path()` 比对，改了后者它就自动做对的事——附属的 nfo/海报/字幕跟着搬，空掉的旧目录清掉，续播点按网盘路径（不是条目 id）贴回。

## 验证

落点在不同扫描深度下一致：

```
扫 /quark/电影 → /cloud/quark/电影/仙逆/仙逆 [第154集•4K].strm
扫 /quark      → /cloud/quark/电影/仙逆/仙逆 [第154集•4K].strm
✔ 一致
```

端到端迁移（旧布局 → 新布局，带 nfo）：

```
挪了 3 个

  /quark/电影/仙逆/仙逆 [第154集•4K].nfo
  /quark/电影/仙逆/仙逆 [第154集•4K].strm
  /quark/电影/电影/功夫 (2004) 4K 60帧 高码/功夫.nfo
  /quark/电影/电影/功夫 (2004) 4K 60帧 高码/功夫.strm
  /quark/电影/美女动作片/小仙女.nfo
  /quark/电影/美女动作片/小仙女.strm
```

`py_compile` + `pyflakes` 干净。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_