### PR TITLE
「4 生成媒体库」也拉一次仓库里的规则

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2326,6 +2326,14 @@ def auto_libraries_apply(d, key, quiet=False):
     不问是对的：只建【不存在的】库，不动用户已有的任何东西，重叠的直接跳过
     并说明。没有需要建的时候一个字都不打印。
     """
+    # 【这里也要拉一次仓库版】用户在 GitHub 上改完规则，接着点的多半是
+    # 「4 生成媒体库」而不是「6 更新」—— 他刚整理完网盘，想的是"扫一遍把库建好"。
+    # 只在更新里拉的话，他会看到规则没生效，以为改的地方不对。
+    # fetch 失败不影响后面：用本机现有的那份跑。
+    try:
+        fetch_lib_rules(d)
+    except Exception:
+        pass
     try:
         rules, _src = lib_rules(d)
         plan = plan_libraries(d, rules)


### PR DESCRIPTION
用户在 GitHub 上改完规则文件之后，接着点的是「4」而不是「6 更新」——他刚整理完网盘，想的是「扫一遍把库建好」。而 `fetch_lib_rules` 只挂在更新里，于是规则不生效，他会以为改的地方不对。

这不是猜的：用户自己把规则文件顶部的说明改成了

> 这份文件在仓库里，「6 更新，4生成媒体库」时会自动拉到机器上

那是他期待的行为，而当时只有前半句是真的。

`auto_libraries_apply` 开头补一次 fetch。拉失败不影响后面，用本机现有的那份跑。

顺带确认用户新加的 `动漫电影` 规则能正常解析：

```
电影      type=movies   lang=zh/CN mt=False kw=['电影', 'movies', 'movie']
电视剧    type=tvshows  lang=zh/CN mt=False kw=['电视剧', '剧集', '连续剧', 'tv']
动漫      type=tvshows  lang=zh/CN mt=False kw=['动漫', '动画', '番剧', 'anime']
纪录片    type=movies   lang=zh/CN mt=False kw=['纪录片', '纪录', 'documentary']
AV影片    type=movies   lang=ja/JP mt=True  kw=['av', '写真', '番号', 'AV影片']
动漫电影  type=movies   lang=zh/CN mt=False kw=['动漫电影', '剧场版']
```

`py_compile` + `pyflakes` 干净。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_