### PR TITLE
语言和 metatube 无条件同步：它们被压在刮削器的判断下面，没写 scrapers 的库全漏了

### DIFF
--- a/library-rules.yaml
+++ b/library-rules.yaml
@@ -8,7 +8,9 @@
 #   name      媒体库在 Emby 里显示的名字
 #   type      movies 电影 / tvshows 电视剧
 #             tvshows 要求网盘里是「剧名/Season 01/剧名 - S01E01.mp4」结构
-#   language  刮削语言 zh / ja / en，留空会按英文搜，中文片名搜不到
+#   language  刮削语言。元数据和海报都用它，留空会按服务器默认（通常英文）搜，
+#             中文片名一条都搜不到。想要「简体中文」而不是笼统的「中文」，
+#             写 zh-CN；日语写 ja，英语 en
 #   country   CN / JP / US，跟着 language 走
 #   metatube  true 时额外挂上 MetaTube（按番号刮成人片），只给成人库开
 #   scrapers  可选。这个库用哪些【元数据】刮削器，逗号隔开、按优先级排。
@@ -25,21 +27,21 @@
 
 - name: 电影
   type: movies
-  language: zh
+  language: zh-CN
   country: CN
   metatube: false
   keywords: 电影, movies, movie
 
 - name: 电视剧
   type: tvshows
-  language: zh
+  language: zh-CN
   country: CN
   metatube: false
   keywords: 电视剧, 剧集, 连续剧, tv
 
 - name: 动漫
   type: tvshows
-  language: zh
+  language: zh-CN
   country: CN
   scrapers: TheTVDB, TheMovieDb
   image_scrapers: TheTVDB, FanArt, TheMovieDb
@@ -48,14 +50,14 @@
 
 - name: 动漫电影
   type: movies
-  language: zh
+  language: zh-CN
   country: CN
   metatube: false
   keywords: 动漫电影, 剧场版
 
 - name: 纪录片
   type: movies
-  language: zh
+  language: zh-CN
   country: CN
   metatube: false
   keywords: 纪录片, 纪录, documentary

--- a/media-stack.py
+++ b/media-stack.py
@@ -2238,6 +2238,7 @@ def _emby_add_library(key, name, ctype, paths, lang="zh", country="CN"):
     opts = {
         "PreferredMetadataLanguage": lang,
         "MetadataCountryCode": country,
+        "PreferredImageLanguage": lang,
         "EnableRealtimeMonitor": False,   # strm 是脚本批量增删的，实时监控只会
                                           # 让 Emby 在扫库中途反复触发重扫
         "PathInfos": [{"Path": x} for x in paths],
@@ -6076,13 +6077,25 @@ def sync_library_options(d, key, rules):
         fs = sorted({f for t in tos for f in (t.get("MetadataFetchers") or [])})
         broken = bool(tos) and (not fs or fs == [METATUBE_FETCHER])
         explicit = bool(rule.get("scr") or rule.get("img"))
-        if not explicit and not broken:
-            continue
         ct = (lb.get("CollectionType") or "").lower()
-        want = desired_type_options(key, ct, rule)
-        if not want:
-            continue
-        if rule.get("mt") and metatube_on(d):
+        # 【语言是无条件同步的，不能挂在刮削器那个条件下面】原来这里写的是
+        # "既没写 scrapers、刮削器也没坏 → 直接 continue"，于是没写 scrapers
+        # 的库连语言都不会被设。用户三个库的截图：只有写了 scrapers 的那个
+        # 语言是「Chinese」，另外两个「首选元数据下载语言」和「认证国家」全是空的。
+        #
+        # 语言和刮削器不是一回事：language/country 每条规则都有，是这份 yaml
+        # 最基本的字段；刮削器是可选的、而且要尊重用户在 Emby 里的手动调整。
+        # 两者的写入条件本来就该分开。
+        want = desired_type_options(key, ct, rule) if (explicit or broken) else None
+        # 【metatube: true 也是明确意图，和 language 一样无条件生效】
+        # 名单本来是好的、yaml 里又没写 scrapers 时，want 是 None、整段跳过 ——
+        # 于是 AV 库明明标着 metatube: true，MetaTube 却一直没挂上。
+        # 这时候拿现有名单当底，只往里补一个 MetaTube，别的一律不动。
+        if want is None and rule.get("mt") and metatube_on(d) and tos:
+            if METATUBE_FETCHER not in {f for t in tos
+                                        for f in (t.get("MetadataFetchers") or [])}:
+                want = json.loads(json.dumps(tos))
+        if want and rule.get("mt") and metatube_on(d):
             for t in want:
                 for fk, ok_ in (("MetadataFetchers", "MetadataFetcherOrder"),
                                 ("ImageFetchers", "ImageFetcherOrder")):
@@ -6091,14 +6104,22 @@ def sync_library_options(d, key, rules):
                         t[ok_] = list(t.get(ok_) or []) + [METATUBE_FETCHER]
         # 语言也一起对齐 —— 它和刮削器是同一件事的两面，分开同步只会让人困惑
         lang, country = rule.get("lang") or "zh", rule.get("country") or "CN"
-        same = (o.get("TypeOptions") == want
+        # 【图像语言也要设】用户截图里「首选图像下载语言」那一栏三个库全是空的 ——
+        # 我只写了元数据语言。空着的后果和元数据语言留空一样：海报按服务器默认
+        # 语言挑，中文片子会拿到英文版海报，或者干脆挑不出来。
+        # 它跟元数据语言用同一个值，没有分开填的道理。
+        img_lang = rule.get("img_lang") or lang
+        same = ((want is None or o.get("TypeOptions") == want)
                 and o.get("PreferredMetadataLanguage") == lang
-                and o.get("MetadataCountryCode") == country)
+                and o.get("MetadataCountryCode") == country
+                and o.get("PreferredImageLanguage") == img_lang)
         if same:
             continue
-        o["TypeOptions"] = want
+        if want is not None:
+            o["TypeOptions"] = want
         o["PreferredMetadataLanguage"] = lang
         o["MetadataCountryCode"] = country
+        o["PreferredImageLanguage"] = img_lang
         try:
             _emby("/Library/VirtualFolders/LibraryOptions", key, method="POST",
                   body={"Id": lb.get("ItemId"), "LibraryOptions": o}, timeout=30)
@@ -6107,7 +6128,8 @@ def sync_library_options(d, key, rules):
         except Exception as e:
             warn(f"「{nm}」的刮削器设置写不进去：{_short_err(e)}")
     if changed:
-        ok(f"{len(changed)} 个媒体库的刮削器/语言已按规则文件设好：{'、'.join(changed)}")
+        ok(f"{len(changed)} 个媒体库的语言/刮削器已按规则文件设好："
+           f"{'、'.join(changed)}")
         for iid, nm in changed_ids:
             n_item = _lib_item_count(key, iid)
             if n_item > REFRESH_AUTO_MAX:


### PR DESCRIPTION
用户：

> 没有赋予首选语言，代码里面不是写了 CN、JP 的为什么没有带上去

截图对得很清楚：

| 库 | yaml 里写了 scrapers？ | 首选元数据语言 | 认证国家 |
|---|---|---|---|
| 动漫 | 是 | Chinese | 中国 |
| 动漫电影 | 否 | **空** | **空** |
| AV影片 | 否 | **空** | **空** |

## 原因

`sync_library_options` 开头那句：

```python
if not explicit and not broken: continue
```

「既没写 scrapers、刮削器也没坏」就整段跳过——**语言、国家跟着一起跳过了**。

语言和刮削器不是一回事：`language` / `country` 每条规则都有，是这份 yaml 最基本的字段；刮削器是可选的，而且要尊重用户在 Emby 界面上的手动调整。两者的写入条件本来就该分开。

同一个毛病还压住了 `metatube`：名单本来是好的、yaml 里又没写 scrapers 时整段跳过，于是 AV 库明明标着 `metatube: true`，MetaTube 一直没挂上。现在拿现有名单当底只补一个 MetaTube，别的一律不动。

## 还漏了一整个字段

**首选图像下载语言**（`PreferredImageLanguage`）我根本没设，用户三张截图里那一栏全是空的。后果和元数据语言留空一样：海报按服务器默认语言挑，中文片子会拿到英文版海报或者干脆挑不出来。它跟元数据语言用同一个值，没有分开填的道理。建库时也一起带上。

顺带把默认语言从 `zh` 改成 `zh-CN`——Emby 里 `zh` 显示成笼统的「Chinese」，`zh-CN` 才是「Chinese Simplified」。

## 验证

三个库，只有一个写了 scrapers：

```
动漫      元数据语言=zh-CN 国家=CN 图像语言=zh-CN 刮削器=按 yaml
动漫电影  元数据语言=zh-CN 国家=CN 图像语言=zh-CN 刮削器=没动
AV影片    元数据语言=ja    国家=JP 图像语言=ja    刮削器=只补了 MetaTube
```

metatube 那一支单独测：

```
刮削器好的、缺 MetaTube  → [['TheMovieDb', 'MetaTube']]
已经有 MetaTube 了       → 没动
MetaTube 插件没装        → 没动
```

`py_compile` + `pyflakes` 干净；规则文件 PyYAML 验过仍合法。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_