### PR TITLE
MetaTube「在名单里」不够，还得排第一：在但排最后 = 配了等于没配

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -6128,8 +6128,18 @@ def sync_library_options(d, key, rules):
             # 而这正是用户一路在问的："只要是这个媒体库里面的影片该是带什么刮削
             # 就带什么刮削……但是你不赋予是怎么回事"。他说的对，是我这儿漏了。
             # 空名单时从 Emby 的默认值起一份底，再把 MetaTube 放前面。
-            if METATUBE_FETCHER not in {f for t in tos
-                                        for f in (t.get("MetadataFetchers") or [])}:
+            # 【"在名单里"不够，还得在【最前面】】上一版的条件是"MetaTube 不在
+            # 名单里才补"，于是"在、但排在最后"这种情况一次都不会被处理 ——
+            # 而它恰恰是最常见的：set_metatube_libraries 是往名单末尾追加的。
+            #
+            # 实测现场，体检打出来的就是这个：
+            #     AV影片    TheMovieDb、TheTVDB、MetaTube
+            # 挂是挂上了，可 Emby 按顺序查，TheMovieDb 先查到就赢，MetaTube
+            # 永远只是那个"填空缺"的。用户看到的是"配了等于没配"。
+            _cur = [f for t in tos
+                    for f in (t.get("MetadataFetcherOrder")
+                              or t.get("MetadataFetchers") or [])]
+            if not _cur or _cur[0] != METATUBE_FETCHER:
                 want = (json.loads(json.dumps(tos)) if tos
                         else desired_type_options(key, ct, rule))
         if want and rule.get("mt") and metatube_on(d):


### PR DESCRIPTION
用户：

> 只要这个库建好了这个库里面的所有视频都应该补上相应的刮削插件，排序前后你也可以调整一下，但是现在为什么就是补不上去

## 这一轮体检把答案摊出来了

（#340 那行列表的价值就在这儿）

```
刮削器  ✔ 4 个库（按优先级，排前面的先查）
  电影           跟随 Emby 默认
  动漫           TheTVDB、TheMovieDb
  动漫电影       跟随 Emby 默认
  AV影片         TheMovieDb、TheTVDB、MetaTube
                                      ↑ 挂上了，但在最后
```

**MetaTube 确实已经赋予了**（`MetaTube 范围 ✔ AV影片` 也写着）。问题是**位置**：Emby 按顺序查，TheMovieDb 先查到就赢，MetaTube 永远只是「填空缺」的那个。「小仙女」就是这么被 TheMovieDb 抢走的。

而 #336 加的前置逻辑一次都没生效，因为触发条件写的是「MetaTube **不在**名单里才补」——**在、但排在最后**这种情况漏掉了。而它恰恰是最常见的：`set_metatube_libraries` 就是往名单末尾追加的。

## 改动

条件改成「不在名单第一位就重排」。

```
MetaTube 在最后    → ['MetaTube', 'TheMovieDb', 'TheTVDB']
名单是空的         → ['MetaTube', 'TheMovieDb']
完全没有 MetaTube  → ['MetaTube', 'TheMovieDb']
已经排第一         → 不动（幂等）
```

`py_compile` + `pyflakes` 干净。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_