### PR TITLE
空的刮削器名单不再当成「跟随默认」：Emby 界面照着它画勾，空的就是没配

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -6081,8 +6081,8 @@ def sync_library_options(d, key, rules):
 
     【写了就照办，没写就只修坏的】这条边界很重要：
       · 规则里写了 scrapers/image_scrapers → 以 yaml 为准，覆盖 Emby 里的
-      · 没写 → 只在【明确坏掉】时才动手（一个刮削器都没有、或只剩 MetaTube），
-        用户自己在 Emby 里精简过的名单不碰
+      · 没写 → 只在【名单没配好】时才动手（一个刮削器都没有、或只剩 MetaTube），
+        用户自己在 Emby 里精简过的名单不碰 —— 只要还留着一个正经刮削器就算数
     不这样分的话，用户在 Emby 界面上的任何调整都会被下一次「4」抹掉。
     """
     by_name = {r["name"]: r for r in rules}
@@ -6101,7 +6101,18 @@ def sync_library_options(d, key, rules):
         o = lb.get("LibraryOptions") or {}
         tos = o.get("TypeOptions") or []
         fs = sorted({f for t in tos for f in (t.get("MetadataFetchers") or [])})
-        broken = bool(tos) and (not fs or fs == [METATUBE_FETCHER])
+        # 【"空名单 = 用默认" 这个说法要作废，空的就得把默认值明写进去】
+        # 上一版这里带着 bool(tos)：TypeOptions 整个为空时不算坏、不去动它，
+        # 理由是"空 = 跟随 Emby 默认"。这个理由站不住：
+        #   · Emby 的库编辑界面是照着 TypeOptions 画勾的，空名单画出来就是
+        #     【六个列表一个都没勾】。用户对着那一屏问的是"我代码该配的都配了，
+        #     为什么在 emby 这些配置没有被勾选" —— 他看到的就是没配。
+        #   · "空到底算不算默认"是 Emby 内部行为，版本一变就可能不一样，
+        #     而且从外面没法验证。押在这上面等于把刮削结果交给运气。
+        # 把默认值明写进去，两个问题一起没了：界面上勾是勾着的，行为也确定。
+        # 写进去的内容就是 Emby 自己 AvailableOptions 给的 DefaultEnabled，
+        # 不多不少 —— 不是我们凭空塞一份名单，只是把隐式的变成显式的。
+        broken = (not fs) or fs == [METATUBE_FETCHER]
         explicit = bool(rule.get("scr") or rule.get("img"))
         ct = (lb.get("CollectionType") or "").lower()
         # 【语言是无条件同步的，不能挂在刮削器那个条件下面】原来这里写的是
@@ -6144,6 +6155,12 @@ def sync_library_options(d, key, rules):
                         else desired_type_options(key, ct, rule))
         if want and rule.get("mt") and metatube_on(d):
             _put_metatube_first(want)
+        if want is not None and not want:
+            # 【问不出默认值时宁可不动】desired_type_options 拿不到
+            # AvailableOptions（Emby 没起来、超时、版本没这个接口）时返回空。
+            # 把空的写进去就是真的把这个库的刮削器全关掉 —— 比现状糟得多。
+            # 这一轮跳过刮削器、只同步语言，下一轮再说。
+            want = None
         # 语言也一起对齐 —— 它和刮削器是同一件事的两面，分开同步只会让人困惑
         lang, country = rule.get("lang") or "zh", rule.get("country") or "CN"
         # 【图像语言也要设】用户截图里「首选图像下载语言」那一栏三个库全是空的 ——
@@ -6233,7 +6250,9 @@ def repair_scrapers(key):
         o = lb.get("LibraryOptions") or {}
         tos = o.get("TypeOptions") or []
         if not tos:
-            continue                    # 空 = 用默认，本来就是对的，别碰
+            # 空名单归 sync_library_options 管 —— 它照着规则文件把默认值明写进去。
+            # 这儿只管规则文件之外的库，那些是用户自己建的，不擅自往里写名单。
+            continue
         fs = sorted({f for t in tos for f in (t.get("MetadataFetchers") or [])})
         if fs and fs != [METATUBE_FETCHER]:
             continue                    # 有正经刮削器，不是我们要修的那两种
@@ -8603,9 +8622,13 @@ def do_healthcheck():
                     nofetch.append(_nm)
                     _rows.append((_nm, f"{RED}一个都没勾{RST}"))
                 elif not _tos:
-                    # 空 TypeOptions 在 Emby 那边是"用默认"，是正常状态，
-                    # 但用户看不到具体是哪几个，说明白比打个勾有用
-                    _rows.append((_nm, f"{DIM}跟随 Emby 默认{RST}"))
+                    # 【别再说这是"正常状态"了】上一版这里写的是"跟随 Emby 默认"，
+                    # 报绿。而用户点进 Emby 的库编辑页看到的是六个列表一个都没勾，
+                    # 于是"体检说没问题、界面上什么都没配"两边对不上。
+                    # 名单是空的就是没配好，照实说，并且指出去哪儿改。
+                    nofetch.append(_nm)
+                    _rows.append((_nm, f"{YELLOW}名单是空的{RST}"
+                                       f"{DIM}（Emby 界面上一个勾都没有）{RST}"))
                 else:
                     if _fs == [METATUBE_FETCHER]:
                         mtwrong.append(_nm)
@@ -8622,8 +8645,9 @@ def do_healthcheck():
                     f"媒体库「{_bad[0]}」的刮削器名单不对 —— "
                     f"{'一个刮削器都没启用' if _bad[0] in nofetch else '只剩 MetaTube，TheMovieDb 被挤掉了'}，"
                     f"表现就是「条目都在、一张海报都没有」",
-                    "跑一次「4 生成媒体库」会按规则文件自动设回来；"
-                    "还不对就 Emby → 设置 → 媒体库 → 点该库 → 手动勾"))
+                    "跑一次「4 生成媒体库」会按规则文件把默认刮削器写进去 —— "
+                    "只对规则文件里有名字的库生效。自己在 Emby 里另建的库归你自己管："
+                    "Emby → 设置 → 媒体库 → 点该库 → 手动勾"))
 
             # ---- 空壳媒体库 ----
             # 【删了 strm 不等于删了条目】。Emby 的条目活在它自己的数据库里，

--- a/media-stack.py
+++ b/media-stack.py
@@ -6128,8 +6128,18 @@ def sync_library_options(d, key, rules):
             # 而这正是用户一路在问的："只要是这个媒体库里面的影片该是带什么刮削
             # 就带什么刮削……但是你不赋予是怎么回事"。他说的对，是我这儿漏了。
             # 空名单时从 Emby 的默认值起一份底，再把 MetaTube 放前面。
-            if METATUBE_FETCHER not in {f for t in tos
-                                        for f in (t.get("MetadataFetchers") or [])}:
+            # 【"在名单里"不够，还得在【最前面】】上一版的条件是"MetaTube 不在
+            # 名单里才补"，于是"在、但排在最后"这种情况一次都不会被处理 ——
+            # 而它恰恰是最常见的：set_metatube_libraries 是往名单末尾追加的。
+            #
+            # 实测现场，体检打出来的就是这个：
+            #     AV影片    TheMovieDb、TheTVDB、MetaTube
+            # 挂是挂上了，可 Emby 按顺序查，TheMovieDb 先查到就赢，MetaTube
+            # 永远只是那个"填空缺"的。用户看到的是"配了等于没配"。
+            _cur = [f for t in tos
+                    for f in (t.get("MetadataFetcherOrder")
+                              or t.get("MetadataFetchers") or [])]
+            if not _cur or _cur[0] != METATUBE_FETCHER:
                 want = (json.loads(json.dumps(tos)) if tos
                         else desired_type_options(key, ct, rule))
         if want and rule.get("mt") and metatube_on(d):


### PR DESCRIPTION
## 问题

媒体库编辑页里，元数据和图像六个列表一个勾都没有，只有本地 Nfo 是开的。而体检那一行报绿，写着「跟随 Emby 默认」。两边说的正好相反。

## 原因

`sync_library_options` 判「名单坏掉」时带着 `bool(tos)`：

```python
broken = bool(tos) and (not fs or fs == [METATUBE_FETCHER])
```

`TypeOptions` 整个为空的库不算坏、直接跳过，理由是「空 = 用 Emby 默认」。而通过 API 建出来的库默认就是空的，所以 yaml 里没写 `scrapers` 的库，刮削器名单永远是空的。

这个理由站不住：

- Emby 的库编辑页是照着 `TypeOptions` 画复选框的。空名单画出来就是一个勾都没有 —— 用户看到的就是没配。
- 「空到底算不算默认」是 Emby 内部行为，版本一变就可能不一样，而且从外面没法验证。押在这上面等于把刮削结果交给运气。

## 改动

- `broken` 去掉 `bool(tos)`：名单里一个正经刮削器都没有就算没配好，把 `AvailableOptions` 给的 `DefaultEnabled` 明写进去。不多不少，只是把隐式的变成显式的。用户自己在 Emby 里精简过的名单不受影响 —— 只要还留着一个正经刮削器就算数。
- `desired_type_options` 问不到默认值时返回空，加了兜底：写一份空名单等于真的把刮削器全关掉，这轮宁可只同步语言。
- 体检那行原来给空名单报绿，改成如实报「名单是空的」，并在处理建议里说清「4 生成媒体库」只管规则文件里有名字的库。
- `repair_scrapers` 里那句「空 = 用默认，本来就是对的」的注释同步更正，行为不变。

## 影响

规则文件管着的库，跑一次「4 生成媒体库」之后刮削器会是勾上的状态，条目数在自动重刮上限内的会跟着做一次完整重新识别。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_