### PR TITLE
sing-box 模板不再下发 zashboard 面板

### DIFF
--- a/subbox-template.json
+++ b/subbox-template.json
@@ -25,7 +25,7 @@
   },
   "experimental": {
     "cache_file": {"enabled": true, "path": "cache.db", "store_fakeip": true, "store_dns": true},
-    "clash_api": {"external_controller": "127.0.0.1:9091", "secret": "88888888", "external_ui": "zashboard", "external_ui_download_url": "https://gh-proxy.com/https://codeload.github.com/Zephyruso/zashboard/zip/refs/heads/gh-pages", "default_mode": "规则", "access_control_allow_origin": ["*"], "access_control_allow_private_network": true}
+    "clash_api": {"external_controller": "127.0.0.1:9091", "secret": "88888888", "default_mode": "规则", "access_control_allow_origin": ["*"], "access_control_allow_private_network": true}
   },
   "inbounds": [
     {"tag": "mixed-in", "type": "mixed", "listen": "0.0.0.0", "listen_port": 7898},


### PR DESCRIPTION
zashboard 已不支持 sing-box，模板里再写 `external_ui` 只会让客户端白下一个用不了的面板包。

## 改动

`subbox-template.json` 的 `experimental.clash_api` 摘掉两项：

```diff
 "clash_api": {
   "external_controller": "127.0.0.1:9091",
   "secret": "88888888",
-  "external_ui": "zashboard",
-  "external_ui_download_url": "https://gh-proxy.com/https://codeload.github.com/Zephyruso/zashboard/zip/refs/heads/gh-pages",
   "default_mode": "规则",
   "access_control_allow_origin": ["*"],
   "access_control_allow_private_network": true
 }
```

**`clash_api` 块保留**——`external_controller` / `secret` / `access_control` 是客户端控制 sing-box 的 API 接口，跟面板是两回事，一起删了会连 API 都没有。

mihomo 模板（`sub-template.yaml`）的 zashboard 不动，那边支持照旧。

## 测试

把改后的模板喂进 `build_singbox_sub()` 跑了一遍（reality + CDN 优选 + trojan-ws 三种节点）：

- 生成的 JSON 合法（`json.loads` 通过）
- `clash_api` 只剩 `external_controller` / `secret` / `default_mode` / `access_control_*`
- 全文 `zashboard` 出现 0 次
- 出站节点正常：`🇯🇵reality-vision`、`🇯🇵CDN·优选1`、`🇯🇵CDN·trojan-ws`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqKxHpC9nKXiUUkhwfLHt2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqKxHpC9nKXiUUkhwfLHt2)_