### PR TITLE
发版流水线：回写版本号不再用 rebase，多余的 run 干净跳过

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,30 +80,55 @@ jobs:
           echo "file_ver=$file_ver" >> "$GITHUB_OUTPUT"
 
       - name: Bump SCRIPT_VERSION & push
+        id: bump
         if: steps.ver.outputs.skip == 'false' && steps.ver.outputs.bump == 'true'
         run: |
           set -euo pipefail
           new_ver='${{ steps.ver.outputs.new_ver }}'
-          file_ver='${{ steps.ver.outputs.file_ver }}'
-          sed -i "s/^SCRIPT_VERSION = \"$file_ver\"/SCRIPT_VERSION = \"$new_ver\"/" xy-installer.py
-          grep -q "^SCRIPT_VERSION = \"$new_ver\"" xy-installer.py
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add xy-installer.py
-          git commit -m "chore(release): v$new_ver"
-          # 和 SHA256SUMS 工作流可能同时往 main push，带 rebase 重试
+          # 【不能 rebase】：版本号回写改的永远是 SCRIPT_VERSION 那一行，另一个 run 的
+          # 回写改的也是同一行 —— rebase 必然冲突，重试多少次都一样。所以每一轮都
+          # 站到最新的 main 上【重新打这个补丁】，而不是拿旧提交去 rebase。
           for i in 1 2 3 4 5; do
             git fetch origin main
-            git rebase origin/main || { git rebase --abort || true; echo "Rebase failed."; exit 1; }
+            git fetch origin --tags --force || true
+            git reset --hard origin/main
+            # main 就停在最新 tag 上 = 自上次发布以来没有任何新内容。连续合并 PR 时
+            # 会冒出多余的 run（同一个提交被跑两遍），不拦下来就会白发一个空版本。
+            last_tag=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -1)
+            if [ -n "$last_tag" ] && \
+               [ "$(git rev-parse "$last_tag^{commit}")" = "$(git rev-parse HEAD)" ]; then
+              echo "main 就停在 $last_tag 上，自上次发布以来没有新内容，本轮跳过。"
+              echo "superseded=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            cur=$(grep -Po '^SCRIPT_VERSION\s*=\s*"\K[^"]+' xy-installer.py)
+            # 另一个 run 抢先发布了同等或更高的版本（连续合并 PR 时很常见）：
+            # 那个版本已经包含了本轮要发的全部内容，这里无事可做，干净退出即可。
+            if [ "$cur" = "$new_ver" ] || \
+               [ "$(printf '%s\n' "$cur" "$new_ver" | sort -V | tail -1)" = "$cur" ]; then
+              echo "main 已是 v$cur（≥ v$new_ver），另一个 run 抢先发过了，本轮跳过。"
+              echo "superseded=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sed -i "s/^SCRIPT_VERSION = \"$cur\"/SCRIPT_VERSION = \"$new_ver\"/" xy-installer.py
+            grep -q "^SCRIPT_VERSION = \"$new_ver\"" xy-installer.py
+            git add xy-installer.py
+            git commit -m "chore(release): v$new_ver"
             if git push origin HEAD:main; then
-              echo "Push success."; exit 0
+              echo "Push success."
+              echo "superseded=false" >> "$GITHUB_OUTPUT"
+              exit 0
             fi
             echo "Push rejected (race). retry=${i}"; sleep $((i*2))
           done
           echo "Failed to push after retries."; exit 1
 
       - name: Tag & create GitHub Release
-        if: steps.ver.outputs.skip == 'false'
+        # superseded：回写那步发现另一个 run 已经发了更高的版本 → 这里也别再打 tag，
+        # 否则会给 main 打上一个文件里根本不存在的版本号。
+        if: steps.ver.outputs.skip == 'false' && steps.bump.outputs.superseded != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
## 症状

连续合并几个 PR 之后，Auto Release 跑出一个失败：

```
CONFLICT (content): Merge conflict in xy-installer.py
Rebasing (1/1)
error: could not apply edbd087... chore(release): v1.0.68
Rebase failed.
```

## 根因

重试策略本身就救不了自己：

```bash
git rebase origin/main || { git rebase --abort || true; echo "Rebase failed."; exit 1; }
```

版本号回写改的**永远是 `SCRIPT_VERSION` 那一行**，另一个 run 的回写改的**也是同一行**——rebase **必然冲突**，重试五次也一样。

## 改法

**不 rebase**，每一轮都 `reset --hard` 到最新 main 上**重新打这个补丁**：

```bash
for i in 1 2 3 4 5; do
  git fetch origin main; git fetch origin --tags --force || true
  git reset --hard origin/main
  ... 两道判据 ...
  cur=$(grep -Po '^SCRIPT_VERSION\s*=\s*"\K[^"]+' xy-installer.py)
  sed -i "s/…\"$cur\"/…\"$new_ver\"/" xy-installer.py
  git commit && git push origin HEAD:main && exit 0
done
```

**两道判据让多余的 run 干净退出**，而不是失败或白发一个空版本：

1. **main 上已经是同等或更高的版本** → 另一个 run 抢先发过了，跳过
2. **main 就停在最新 tag 上** → 自上次发布以来没有新内容，跳过

这次失败的那个 run 正是第 2 种——用仓库真实状态验证过：

```
最新 tag : v1.0.67 → 36485e7
origin/main:          36485e7
→ 判定：没有新内容，跳过 ✓
```

跳过时置 `superseded=true`，**Tag 那步跟着不执行**——否则会给 main 打上一个文件里根本不存在的版本号。

`bump=false` 的路径（人工升大版本、补建半截 Release）**不受影响**：那时 bump 步骤整个被 skip，`superseded` 为空，`!= 'true'` 成立，Tag 照常执行。

## 测试

版本比较逐个核对，走 `sort -V` **数字序**不会退化成字典序：

| main | 目标 | 判定 |
|---|---|---|
| 1.0.66 | 1.0.67 | 继续回写 ✓ |
| 1.0.67 | 1.0.67 | 跳过 ✓ |
| 1.0.68 | 1.0.67 | 跳过 ✓ |
| **1.0.70** | **1.0.9** | **跳过 ✓**（字典序会判反） |
| 1.0.9 | 1.0.10 | 继续回写 ✓ |
| 1.1.0 | 1.0.99 | 跳过 ✓ |
| 2.0.0 | 1.0.68 | 跳过 ✓ |

## 现状说明

**main 没坏**：`v1.0.67` 的 tag 就指在 main 头上，文件版本也是 1.0.67，内容完整。那个失败的 run 本来就无事可做。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqKxHpC9nKXiUUkhwfLHt2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqKxHpC9nKXiUUkhwfLHt2)_