### PR TITLE
要打中文/emoji 的输入独占一行，删过头不再啃掉提示语

### DIFF
--- a/xy-installer.py
+++ b/xy-installer.py
@@ -2452,10 +2452,12 @@ def rename_prefix():
     print(f"  当前前缀：{cur or '(无)'}      节点名 = 前缀·协议名")
     print("  例：🇯🇵 / 🇺🇸2 / 东京 / DMIT / 家宽")
     print("  ⓘ 前缀带国旗或国家代码(JP/US/HK…)，客户端才能自动分出「日本随机」这类分组。")
-    new = _ask("  新前缀（回车取消；输 - 表示不要前缀）: ").strip()
+    new = _ask_free("  新前缀（回车取消；输 - 表示不要前缀）：").strip()
     if not new:
         print("  已取消。"); return
     new = "" if new == "-" else new
+    # 明确回显一次：中文/emoji 在终端里删改容易看花，以实际收到的为准
+    print(f"  收到前缀：{('「%s」' % new) if new else '(清空前缀)'}")
     if set(new) & _BAD_PREFIX_CHARS:
         print("  ✗ 前缀里不能有引号、# \\ 和换行/制表符（会把分享链接和配置弄坏）。已取消。"); return
     if len(new) > 24:
@@ -4403,9 +4405,9 @@ def cdn_add():
 
     ipfx = _state_prefix()
     if ipfx:
-        prefix = _ask(f"  节点名称前缀（回车=沿用安装前缀「{ipfx}」，或输入自定义）: ").strip() or ipfx
+        prefix = _ask_free(f"  节点名称前缀（回车=沿用安装前缀「{ipfx}」，或输入自定义）：").strip() or ipfx
     else:
-        prefix = _ask("  节点名称前缀（回车=默认 CDN，自定义如 🇯🇵/家宽）: ").strip()
+        prefix = _ask_free("  节点名称前缀（回车=默认 CDN，自定义如 🇯🇵/家宽）：").strip()
 
     # 追加时新节点沿用已设的优选地址；首装留空——装完统一问要不要筛一批候选
     pref = next((n.get("pref") for n in nodes if n.get("pref")), "")
@@ -5104,6 +5106,16 @@ def _ask(prompt=""):
     except (OSError, EOFError):
         return input(prompt).strip()
 
+def _ask_free(prompt):
+    """要打中文/emoji 的自由文本输入（前缀之类）：提示语单独占一行，输入从下一行的 > 开始。
+
+       为什么不像别处那样提示和输入挤同一行：终端的行编辑按【字符】发退格，而中文和
+       emoji 占【两列】——删一个字只擦掉一列，光标会越删越往前跑，最后啃进提示语里，
+       看着像把界面删坏了（其实输入缓冲区是好的，只是屏幕花了）。让输入独占一行，
+       删过头也只啃到那个 '> '，提示语毁不掉。"""
+    print(prompt)
+    return _ask("  > ")
+
 def _pick(title, options, default=None):
     """列出带编号的协议，返回选中的 key 列表。
        回车 = default（缺省=全选）；0/all 永远=全选；也可逗号分隔编号自选。"""
@@ -5161,7 +5173,7 @@ def install_flow():
                         .lower() in ("y", "yes")) else ""
     _sni_rand = secrets.choice(REALITY_SNI_POOL)         # 回车就用这个随机挑的（不同机器各不同，不扎堆）
     sni = _ask(f"reality 借用目标站 SNI (回车=随机挑，本次随机到 {_sni_rand}): ") or _sni_rand
-    prefix = _ask("节点名称前缀(如 🇺🇸/🇯🇵/家宽，回车=无前缀): ")
+    prefix = _ask_free("节点名称前缀（如 🇺🇸/🇯🇵/家宽，回车=无前缀）：")
     hy2p = ""
     if "hy2" in sb_names:
         hy2p = _ask("hy2 端口跳跃范围 起-止(回车=30000-31000，自定义直接输数字，输 n 不用端口跳跃): ")


### PR DESCRIPTION
## 现象

在「新前缀」那里输错按退格，光标一路删进提示语里，屏幕上看着像把界面删坏了：

```
  新前缀（回车取消；输 - 表示不要前缀█      ← 「）: 」被吃掉了
```

## 这不是脚本的 bug

终端行编辑按**字符**发退格，而中文和 emoji 占**两列**——删一个字只擦掉一列，光标每删一个字就多往前跑一列，最后越过输入起点啃进提示语。**输入缓冲区其实是好的，只是屏幕花了。**

`termios` 那边也没有旋钮能解决双宽字符（`IUTF8` 只管多字节，不管显示宽度），只能从布局上躲。

## 改法

加 `_ask_free()`：提示语单独占一行，输入从下一行的 `>` 开始。

```
  新前缀（回车取消；输 - 表示不要前缀）：
  > 🇯🇵东京软银
  收到前缀：「🇯🇵东京软银」
```

删过头最多啃掉那个 `>`，提示语毁不掉。再回显一次实际收到的值，屏幕即使花了也能对得上。

用在**三处要打中文/emoji 的地方**：改名前缀、安装时的名称前缀、CDN 节点名称前缀。其余菜单选项都是打数字，不受影响，不动它们的布局。

## 测试

改名 `🇺🇸2` → `🇯🇵东京软银` 后三格式全部跟着变：

```
mihomo  : ['🇯🇵东京软银·vless-ws', '🇯🇵东京软银·trojan', '🇯🇵东京软银·hy2']
sing-box: ['🇯🇵东京软银·vless-ws', '🇯🇵东京软银·trojan', '🇯🇵东京软银·hy2']
小火箭   : ['🇯🇵东京软银·vless-ws', '🇯🇵东京软银·trojan', '🇯🇵东京软银·hy2']
国家分组 : 🇯🇵日本随机  ← 从「🇺🇸美国随机」切过来
```

清空前缀（输 `-`）也正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqKxHpC9nKXiUUkhwfLHt2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqKxHpC9nKXiUUkhwfLHt2)_