### PR TITLE
内置兜底名单里成人库也要默认 private，兜底得往安全方向倒

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2118,7 +2118,12 @@ LIB_RULES_DEFAULT = [
     {"name": "动漫",   "kw": ["动漫", "动画", "番剧", "anime"],      "type": "tvshows", "mt": False, "lang": "zh", "country": "CN"},
     {"name": "动漫电影", "kw": ["动漫电影", "剧场版"],               "type": "movies",  "mt": False, "lang": "zh", "country": "CN"},
     {"name": "纪录片", "kw": ["纪录片", "纪录", "documentary"],      "type": "movies",  "mt": False, "lang": "zh", "country": "CN"},
-    {"name": "AV影片", "kw": ["av", "写真", "番号"],                 "type": "movies",  "mt": True,  "lang": "ja", "country": "JP"},
+    # 【兜底要往安全的方向倒】private 默认开着。这份内置名单是拉不到仓库那份
+    # library-rules.yaml 时才用的（刚装完还没跑过「4」、或者机器连不上 GitHub）。
+    # 那种时候如果成人库对所有账号可见，用户多半还不知道有这回事 —— 而这个
+    # 疏忽是当场、当着人暴露的，不像配置错了还能慢慢修。
+    # 想让所有账号都能看，在规则文件里显式写 private: false 就行。
+    {"name": "AV影片", "kw": ["av", "写真", "番号"],                 "type": "movies",  "mt": True,  "lang": "ja", "country": "JP", "private": True},
 ]
 LIB_TYPES = {"movies": "电影", "tvshows": "电视剧", "homevideos": "家庭影像", "": "混合"}
 


### PR DESCRIPTION
## 怎么发现的

用户问「刚装的机器不就是用的最新版吗」—— 是。但顺着这个问题查出来一个漏洞。

`LIB_RULES_DEFAULT` 是拉不到仓库那份 `library-rules.yaml` 时的兜底，而 `fetch_lib_rules` **只在「4 生成媒体库」和「6 更新」里调**。

所以这两种情况走的是内置名单：

- 刚装完，还没跑过「4」或「6」
- 机器连不上 GitHub

而内置名单的 `AV影片` **没有 `private`** —— 成人库对所有账号可见。

## 为什么这个必须改

这个疏忽和一般的配置错不一样：它是**当场、当着人**暴露的，事后修没有意义。

兜底应该往安全的方向倒。内置名单给成人库默认 `private: true`；想让所有账号都能看，在规则文件里显式写 `private: false` 就行。

## 顺带验的

两份名单现在都只有成人库是 private。`private` 的取值解析：`true` / `True` / `yes` / `1` / `on` 认作开，其余（包括拼错的字）一律当 `false` —— 不会因为写错一个词就把库悄悄公开、或者悄悄藏起来。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_