### PR TITLE
观看进度改成按「网盘文件」记，不再跟着 strm 路径走

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2770,85 +2770,132 @@ def _strm_items(key, uid):
     return out
 
 
-def snapshot_progress(key, pairs):
-    """改名【之前】把这些条目的观看进度记下来。返回要存进状态的列表。
 
-    pairs 是 [(旧文件名, 新文件名)]。键用【新文件名】，因为改完之后要靠它
-    去找那个新生成的条目。
 
-    【为什么必须记】Emby 的观看记录是挂在条目上的，而条目是按【路径】认的 ——
-    strm 一改名，Emby 下次扫描会当成一个全新的条目，旧的进度接不回去。
-    这是改名功能唯一的实质代价，能补上就该补。
+
+
+# 观看进度按【网盘文件路径】存一份。
+#
+# 【为什么不能只靠 Emby 自己那份】Emby 把观看记录挂在条目上，而条目是按
+# strm 的【路径】认的。路径一变就是另一个条目，进度接不回去 —— 而这套东西里
+# 路径变化是家常便饭：脚本给剧集补季集编号会改名，AutoFilm 按新配置重新生成
+# 会换目录，用户在网盘里挪一下文件也会。每一种都能把观看记录抹掉一批。
+#
+# 而 strm 的【内容】—— 那条网盘路径 —— 是稳定的：它指向网盘里那个文件本身，
+# 不随本地怎么摆放而变。拿它当键，进度就跟着"哪个视频"走，而不是跟着
+# "文件放在哪儿"走。这才是用户要的"按 ID 记忆"。
+PROGRESS_MAP = "progress-map.json"
+
+
+def _progress_map(d):
+    try:
+        with open(os.path.join(d, PROGRESS_MAP), encoding="utf-8") as f:
+            v = json.load(f)
+            return v if isinstance(v, dict) else {}
+    except Exception:
+        return {}
+
+
+def _save_progress_map(d, m):
+    try:
+        with open(os.path.join(d, PROGRESS_MAP), "w", encoding="utf-8") as f:
+            json.dump(m, f, ensure_ascii=False)
+    except OSError:
+        pass
+
+
+def _has_progress(ud):
+    ud = ud or {}
+    return bool(ud.get("PlaybackPositionTicks") or ud.get("Played")
+                or ud.get("PlayCount"))
+
+
+def sync_progress_map(d, key):
+    """记录 + 补回观看进度，按网盘路径认。返回补回了几条。
+
+    一趟过，两个方向：
+      · 条目【有】进度  → 记下来（连同当时的条目 id）
+      · 条目【没有】进度 → 记录里有的话看情况补回去
+
+    【补回去之前要分清"新条目"和"用户自己清的"】两者现在都是"没进度"，
+    但该做的事正好相反。判据是条目 id：
+      · id 和记录里的【一样】 = 同一个条目，进度从有变没 = 用户自己标了未播放。
+        这时候要把记录删掉，否则下一轮又给他补回去，他怎么清都清不掉。
+      · id 【不一样】 = 路径变了、Emby 重新建的条目。这才是要补的。
     """
-    out = []
+    if not key:
+        return 0
     try:
         users = _emby("/Users", key, timeout=20) or []
     except Exception:
-        return out
+        return 0
+    m, n, dirty = _progress_map(d), 0, False
     for u in users:
         uid = u.get("Id")
         if not uid:
             continue
-        have = _strm_items(key, uid)
-        for old, new in pairs:
-            it = have.get(old)
-            ud = (it or {}).get("UserData") or {}
-            # 没看过的不用记 —— 省得状态文件里堆一堆空壳
-            if not (ud.get("PlaybackPositionTicks") or ud.get("Played")
-                    or ud.get("PlayCount")):
+        for base, it in _strm_items(key, uid).items():
+            path = str(it.get("Path") or "")
+            try:
+                with open(path, encoding="utf-8") as f:
+                    tgt = strm_target_path(f.read())
+            except OSError:
                 continue
-            out.append({"to": new, "u": uid, "n": 0, "d": {
-                "PlaybackPositionTicks": int(ud.get("PlaybackPositionTicks") or 0),
-                "PlayCount": int(ud.get("PlayCount") or 0),
-                "Played": bool(ud.get("Played")),
-                "IsFavorite": bool(ud.get("IsFavorite")),
-            }})
-    return out
-
-
-# 改名后的条目要等 Emby 扫出来才存在，扫描是异步的。多给几轮机会，
-# 但不能无限攒着 —— 找不到就是找不到，留在状态文件里只会越积越多。
-CARRY_TRIES = 5
-
-
-def carry_over_progress(d, key):
-    """把改名前记下的观看进度搬到新条目上。返回搬成了几条。
-
-    在【扫描之后】跑：新条目得先被 Emby 扫出来才找得到。找不到就留着下一轮
-    再试，试满 CARRY_TRIES 轮还没有就丢掉。
-    """
-    pend = ms_state().get("ep_carry") or []
-    if not pend or not key:
-        return 0
-    done, keep, byuser = 0, [], {}
-    for e in pend:
-        uid = e.get("u")
-        if uid not in byuser:
-            byuser[uid] = _strm_items(key, uid)
-        it = byuser[uid].get(e.get("to"))
-        if not it:
-            e["n"] = int(e.get("n") or 0) + 1
-            if e["n"] < CARRY_TRIES:
-                keep.append(e)          # 还没扫出来，下一轮再说
-            continue
-        cur = it.get("UserData") or {}
-        if cur.get("PlaybackPositionTicks") or cur.get("Played"):
-            continue                    # 新条目已经有进度了，别覆盖用户新看的
-        try:
-            _emby(f"/Users/{uid}/Items/{it.get('Id')}/UserData", key,
-                  method="POST", body=e.get("d") or {}, timeout=30)
-            done += 1
-        except Exception:
-            e["n"] = int(e.get("n") or 0) + 1
-            if e["n"] < CARRY_TRIES:
-                keep.append(e)
-    # 【无条件写回】ms_state() 返回的是一份拷贝，上面对 e["n"] 的自增只改在
-    # 拷贝上。不写回的话计数永远停在 0，试满丢弃那条路一辈子走不到，
-    # 状态文件里的死条目越攒越多。
-    save_ms_state(ep_carry=keep)
-    if done:
-        ok(f"{done} 条观看进度已经跟着改名搬到新条目上")
-    return done
+            if not tgt:
+                continue
+            iid, ud = it.get("Id"), (it.get("UserData") or {})
+            slot = (m.get(tgt) or {}).get(uid) or {}
+            if _has_progress(ud):
+                cur = {"id": iid, "ts": int(time.time()), "d": {
+                    "PlaybackPositionTicks": int(ud.get("PlaybackPositionTicks") or 0),
+                    "PlayCount": int(ud.get("PlayCount") or 0),
+                    "Played": bool(ud.get("Played")),
+                    "IsFavorite": bool(ud.get("IsFavorite")),
+                }}
+                if slot.get("d") != cur["d"] or slot.get("id") != iid:
+                    m.setdefault(tgt, {})[uid] = cur
+                    dirty = True
+                continue
+            if not slot:
+                continue
+            if slot.get("id") == iid:
+                # 同一个条目、进度没了 = 用户自己清的，尊重他
+                m[tgt].pop(uid, None)
+                if not m[tgt]:
+                    m.pop(tgt, None)
+                dirty = True
+                continue
+            try:
+                _emby(f"/Users/{uid}/Items/{iid}/UserData", key, method="POST",
+                      body=slot.get("d") or {}, timeout=30)
+                slot["id"] = iid
+                m[tgt][uid] = slot
+                dirty = True
+                n += 1
+            except Exception:
+                pass
+    # 网盘上已经没有的文件，记录也该跟着走 —— 否则这个文件只会越长越大
+    if len(m) > 200:
+        alive = set()
+        for dp, _dn, fs in os.walk(os.path.join(strm_root(d), STRM_SUBDIR)):
+            for f in fs:
+                if not f.endswith(".strm"):
+                    continue
+                try:
+                    with open(os.path.join(dp, f), encoding="utf-8") as fh:
+                        alive.add(strm_target_path(fh.read()))
+                except OSError:
+                    pass
+        gone = [k for k in m if k not in alive]
+        if gone:
+            for k in gone:
+                m.pop(k, None)
+            dirty = True
+    if dirty:
+        _save_progress_map(d, m)
+    if n:
+        ok(f"{n} 条观看进度按网盘文件补回来了{DIM}（条目换了但视频还是那个）{RST}")
+    return n
 
 
 def fix_episode_strm_names(d, rules, key, interactive=True):
@@ -2881,21 +2928,16 @@ def fix_episode_strm_names(d, rules, key, interactive=True):
                   f"{BOLD}{os.path.basename(dst)}{RST}")
         if len(ren) > 5:
             print(f"    {DIM}…还有 {len(ren) - 5} 个{RST}")
-        print(f"  {DIM}Emby 按路径认条目，改名后这些集算新条目 —— 脚本会先把"
-              f"观看进度记下来，等新条目扫出来再搬过去。{RST}")
-        print(f"  {YELLOW}搬不过去的话（Emby 没扫出来）那几集的进度会丢。{RST}")
+        print(f"  {DIM}Emby 按路径认条目，改名后这些集算新条目 —— 观看进度由脚本"
+              f"按【网盘文件】记着，扫出新条目后会自动补回去。{RST}")
         st = ask_yn("改吗？（以后不再问，按这次的答案自动做）", True)
         save_ms_state(ep_fix=bool(st))
     if not st:
         return 0, 0
-    # 【改名之前先把进度记下来】改完就找不回来了 —— 条目是按路径认的。
-    # 记完存进状态，等 Emby 扫出新条目之后由 carry_over_progress 搬过去。
+    # 【改名之前先把进度记进那张表】改完条目就换了，那时再记已经晚了。
+    # 记的键是 strm 内容里的网盘路径 —— 改名不动内容，所以改完还能对上。
     try:
-        _pairs = [(os.path.basename(a), os.path.basename(b))
-                  for a, b, dup in todo if not dup]
-        _snap = snapshot_progress(key, _pairs) if key else []
-        if _snap:
-            save_ms_state(ep_carry=(ms_state().get("ep_carry") or []) + _snap)
+        sync_progress_map(d, key)
     except Exception as e:
         warn(f"记录观看进度失败，改名后这些集的进度会丢：{_short_err(e)}")
     n_ren = n_dup = 0
@@ -3457,11 +3499,12 @@ def align_library(d, key, heal=True):
     clear_impossible_progress(key)    # 条目级：清掉位置 > 片长的脏数据
     # 库选项改过就必须重扫（见上），哪怕文件数一个没变
     scan_if_grown(d, key, force=bool(n_tuned))
-    # 【必须排在扫描之后】改名产生的新条目要等 Emby 扫出来才存在
+    # 【必须排在扫描之后】路径变过的条目要等 Emby 重新扫出来才找得到。
+    # 这一趟同时做两件事：把现有进度记下来，把新条目缺的补回去。
     try:
-        carry_over_progress(d, key)
+        sync_progress_map(d, key)
     except Exception as e:
-        warn(f"搬运观看进度失败：{_short_err(e)}")
+        warn(f"同步观看进度失败：{_short_err(e)}")
 
 
 def scan_if_grown(d, key, force=False):


### PR DESCRIPTION
## 为什么要做成模块

> 你应该写从兼容的做法，改名后和 ID 享有同等进度条记忆……这个应该把模块做好

对。上一版（#371）是给改名功能打的补丁，只护住那一种情况。

Emby 把观看记录挂在条目上，条目按 strm 的**路径**认。而这套东西里路径变化是家常便饭：

- 脚本给剧集补季集编号 → 改名
- AutoFilm 按新配置重新生成 → 换目录
- 用户在网盘里挪一下文件 → 换目录

每一种都能抹掉一批观看记录，而补丁式的修法每次只能救一种。

## 稳定的键是网盘路径

strm 的**内容** —— 那条网盘路径 —— 指向网盘里那个文件本身，不随本地怎么摆放而变。拿它当键，进度就跟着「哪个视频」走，而不是跟着「文件放在哪儿」走。这才是「按 ID 记忆」。

`sync_progress_map()`：一趟过，两个方向。有进度的记下来（连同当时的条目 id），没进度的看记录补回去。每次对齐都跑，自维护。

## 补回去之前必须分清两件事

「新条目」和「用户自己清的」现在都是**没进度**，该做的事却相反。判据是条目 id：

| 情况 | 含义 | 动作 |
|---|---|---|
| id 和记录里**一样** | 同一个条目，进度从有变没 = 用户标了未播放 | **删记录** —— 否则他怎么清都清不掉 |
| id **不一样** | 路径变了、Emby 重新建的条目 | 补回去 |

表超过 200 条时顺带清掉网盘上已经没有的文件，不让它无限长。

## 删掉 #371

`snapshot_progress` / `carry_over_progress` / `ep_carry` 全删 —— 新模块把它们覆盖了，两套机制做同一件事只会互相干扰。

## 顺带纠正一个前提

切回「网盘文件名」**不会**丢进度。片名策略只改条目的 `Name` 字段，条目 id 和路径都不变。丢进度的只有路径变了那种。

## 验证

记录 / 改名后补回 / 用户清空后不复活（跑 3 轮验证）/ AutoFilm 换目录后照样认 / URL 形式的 strm 也认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_