### PR TITLE
进度表：文件名撞车会漏掉一半，写死 4000 条会漏掉超出的

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2755,23 +2755,35 @@ def plan_episode_renames(d, rules, broken=None):
 
 
 def _strm_items(key, uid):
-    """{strm 文件名: 条目}。用文件名当键，因为改名前后只有它变，条目 id 会换。"""
-    try:
-        r = _emby(f"/Users/{uid}/Items?Recursive=true"
-                  f"&IncludeItemTypes=Movie,Episode,Video"
-                  f"&Fields=Path,UserData&Limit=4000", key, timeout=30) or {}
-    except Exception:
-        return {}
-    out = {}
-    for i in r.get("Items") or []:
-        p = str(i.get("Path") or "")
-        if p.endswith(".strm") and _under(p, STRM_PATH):
-            out[os.path.basename(p)] = i
-    return out
+    """{strm 完整路径: 条目}。覆盖【所有媒体库、所有网盘】，不按库名或类型挑。
 
+    【键必须是完整路径，不能用文件名】剧集的文件名撞车是常态：
+    「动漫/剧A/01.strm」和「动漫/剧B/01.strm」的 basename 都是 01.strm。
+    拿它当键，后一个会把前一个顶掉，那一部剧的进度就静静地漏了 ——
+    正是"只修好个别文件"的典型形状。
 
-
-
+    【必须翻页】这个接口一次只给一批。写死 Limit=4000 的话，片子超过这个数
+    就有一批永远轮不到，而且不会有任何报错 —— 用户看到的是"大部分好了，
+    有几部就是不行"。按 StartIndex 翻到底。
+    """
+    out, start, page = {}, 0, 500
+    while True:
+        try:
+            r = _emby(f"/Users/{uid}/Items?Recursive=true"
+                      f"&IncludeItemTypes=Movie,Episode,Video"
+                      f"&Fields=Path,UserData"
+                      f"&StartIndex={start}&Limit={page}", key, timeout=60) or {}
+        except Exception:
+            return out                # 半路失败就用已经拿到的，别整批丢掉
+        items = r.get("Items") or []
+        for i in items:
+            p = str(i.get("Path") or "")
+            if p.endswith(".strm") and _under(p, STRM_PATH):
+                out[p] = i
+        total = int(r.get("TotalRecordCount") or 0)
+        start += len(items)
+        if not items or start >= total:
+            return out
 
 
 # 观看进度按【网盘文件路径】存一份。
@@ -2834,8 +2846,7 @@ def sync_progress_map(d, key):
         uid = u.get("Id")
         if not uid:
             continue
-        for base, it in _strm_items(key, uid).items():
-            path = str(it.get("Path") or "")
+        for path, it in _strm_items(key, uid).items():
             try:
                 with open(path, encoding="utf-8") as f:
                     tgt = strm_target_path(f.read())


### PR DESCRIPTION
## 起因

> 现在这个是针对所有的媒体库所有的网盘吧，不要又是修好了个别媒体库

去查了。**覆盖范围本身是对的** —— 查询没有 `ParentId`（所有库）、`Recursive=true`、`Movie,Episode,Video` 都要、过滤只看「是不是 .strm 且在 STRM_PATH 底下」、外层遍历所有用户，没有任何按库名或按规则的筛选。

但 `_strm_items` 里有两个**会造成「只修好一部分」的实现 bug**：

## 一、键用了 basename，同名文件互相覆盖

剧集文件名撞车是常态：

```
动漫/剧A/01.strm     basename = 01.strm
动漫/剧B/01.strm     basename = 01.strm   ← 把上一个顶掉
```

那一部剧的进度就**静静地漏了** —— 正是「只修好个别文件」的典型形状。改成用完整路径当键。

（basename 是给上一版 `carry_over_progress` 用的，那个函数已经删了，这里跟着改过来才对。）

## 二、写死 `Limit=4000`

超过这个数就有一批永远轮不到，而且**不会有任何报错** —— 用户看到的是「大部分好了，有几部就是不行」。

改成按 `StartIndex` 翻到底；中途失败就用已经拿到的那部分，不整批丢。

## 验证

| 测试 | 结果 |
|---|---|
| 两部剧各有 `01.strm` | 两条都记进表，互不覆盖（旧版只剩 1 条） |
| 6000 个条目 | 全部取到（旧版漏后 2000 个） |
| 查询本身 | 无 `ParentId`、有 `Recursive`、有翻页 |
| `sync_progress_map` | 无任何按库名/按规则/按类型的筛选 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_