### PR TITLE
名字里已经写着 SxxExx 的，别再算进「集号认错」

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -2716,6 +2716,13 @@ def misparsed_strm_names(d, key):
             if not (p.endswith(".strm") and _under(p, STRM_PATH)):
                 continue
             base = os.path.basename(p)
+            # 【名字里已经写着 SxxExx 的一律不算"认错"】改名帮不上它，而且
+            # 这里的比法对它本来就不成立：写成 S01E238 之后，Emby 会拿 238 去
+            # 刮削器换算成"第 5 季第 30 集"，IndexNumber 变成 30 —— 那是【对的】，
+            # 季是 TheTVDB 分的，不是认错。不排除的话，每轮都会把它算进
+            # "判定集号不对"里，报出来的数字纯属吓人。
+            if EP_HAS_SE.search(os.path.splitext(base)[0]):
+                continue
             has_id = bool({k: v for k, v in (i.get("ProviderIds") or {}).items()
                            if v and k.lower() != "trakt"})
             hp = host_strm_path(d, p)


### PR DESCRIPTION
## 改名成功之后的一个假象

strm 叫 `S01E238` → Emby 拿 238 去 TheTVDB 换算成「第 5 季第 30 集」→ `IndexNumber` 变成 30。

而 `misparsed_strm_names` 的比法是「`IndexNumber` 对不对得上网盘文件名里的数字」—— `30 ≠ 238`，于是**每一轮都把它算进「判定集号不对」**。

**那是对的，不是错的**：季是刮削器分的，脚本只负责把集号说清楚。

而且这种条目改名也帮不上（`EP_HAS_SE` 那道闸本来就会跳过它），算进去纯粹是让新加的那行诊断报一个吓人的数字。

## 改动

在 `misparsed_strm_names` 里提前排掉名字已带 `SxxExx` 的，判据和后面的跳过对齐。

## 验证

已改名的 `S01E238`（Emby 显示 S5:E30）→ 不算认错；认对的 `07 4K` → 不算。判定数量归 0，不再每轮虚报。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_