### PR TITLE
排查脚本只找剧集，电影一个都查不到

### DIFF
--- a/tools/why-slow.sh
+++ b/tools/why-slow.sh
@@ -1,21 +1,28 @@
 #!/usr/bin/env bash
-# 为什么【这一集】卡，别的不卡 —— 把两集拉出来并排比一遍。
+# 为什么【这个片子】卡/放不了，别的正常 —— 把整条链路挨个量一遍。
+# 电影和剧集都能查。
 #
 # 用法（在装了 media-stack 的机器上）：
-#     bash why-slow.sh 238 237
-#           ^卡的那集  ^不卡的那集（对照组，可以不填，默认 237）
+#     bash why-slow.sh 238 237        两集并排比
+#     bash why-slow.sh 龙虎门           只查一个（电影也行）
+#           ^集号、片名的一部分、或文件名的一部分都能找
 #
 # 只读，不改任何东西。
 #
 # 一集卡、别的不卡，可能性就那么几种，这个脚本把它们逐条量出来：
-#   1. 那一集的码率/分辨率/编码本来就更重   → 看「媒体信息」那段
+#   1. 这个片子的码率/分辨率/编码本来就更重 → 看「媒体信息」那段
 #   2. Emby 在转码它（2 核的机器转 4K = 必卡）→ 看「Emby 有没有在转码」
 #   3. 直链落到了不同的节点，或者那条线本身慢 → 看「直链实测」那段
-#   4. 网盘对这个文件单独限速                 → 同上，两集速度差一个量级就是它
+#   4. 网盘对这个文件单独限速                 → 同上，速度差一个量级就是它
 set -u
 
-SLOW="${1:-238}"
-GOOD="${2:-237}"
+SLOW="${1:-}"
+GOOD="${2:-}"
+if [ -z "$SLOW" ]; then
+  echo "用法：bash why-slow.sh <卡的那个> [不卡的那个]"
+  echo "     可以填集号（238）、片名的一部分（龙虎门）、或文件名的一部分"
+  exit 1
+fi
 DIR="${MS_DIR:-/opt/media-stack}"
 
 # ---- 配置：全部从落盘的文件里读，不写死 ----
@@ -34,22 +41,35 @@ fi
 
 hr() { printf '%s\n' "------------------------------------------------------------"; }
 
-# ---- 找条目 ----
-find_item() {   # $1=集号 -> "Id<TAB>Name<TAB>Path"
+# ---- 找条目：电影和剧集都要找，按集号 / 片名 / 文件名匹配 ----
+find_item() {   # $1=要找的东西 -> "Id<TAB>Name<TAB>Path"
   python3 - "$EMBY" "$KEY" "$1" <<'PY'
 import json,sys,urllib.request,urllib.parse
-emby,key,ep=sys.argv[1],sys.argv[2],sys.argv[3]
-u=(f"{emby}/Items?Recursive=true&IncludeItemTypes=Episode"
-   f"&Fields=Path,MediaSources,IndexNumber&Limit=2000&api_key={key}")
-try: d=json.load(urllib.request.urlopen(u,timeout=60))
-except Exception as e: print(f"ERR\t{e}\t"); raise SystemExit
-for i in d.get("Items") or []:
+emby,key,q=sys.argv[1],sys.argv[2],sys.argv[3]
+out,start=[],0
+while True:
+    u=(f"{emby}/Items?Recursive=true&IncludeItemTypes=Movie,Episode,Video"
+       f"&Fields=Path,IndexNumber&StartIndex={start}&Limit=500&api_key={key}")
+    try: d=json.load(urllib.request.urlopen(u,timeout=60))
+    except Exception as e: print(f"ERR\t{e}\t"); raise SystemExit
+    b=d.get("Items") or []; out+=b; start+=len(b)
+    if not b or start>=int(d.get("TotalRecordCount") or 0): break
+# 【三种匹配都要，从严到宽】集号最准，其次片名，最后文件名。
+# 只按集号找的话，电影一个都找不到 —— 电影没有 IndexNumber。
+cands=[]
+for i in out:
     p=str(i.get("Path") or "")
     if not p.endswith(".strm"): continue
-    # 集号对上，或者网盘文件名里带这个数
-    if str(i.get("IndexNumber") or "")==ep or ep in p.rsplit("/",1)[-1]:
-        print(f"{i.get('Id')}\t{i.get('Name')}\t{p}"); raise SystemExit
-print("NOTFOUND\t\t")
+    base=p.rsplit("/",1)[-1]
+    name=str(i.get("Name") or "")
+    if q.isdigit() and str(i.get("IndexNumber") or "")==q: cands.insert(0,i)
+    elif q in name or q in base: cands.append(i)
+if not cands: print("NOTFOUND\t\t"); raise SystemExit
+if len(cands)>1:
+    print(f"MANY\t{len(cands)}\t"+" ／ ".join(
+        str(x.get("Name")) for x in cands[:6])); raise SystemExit
+i=cands[0]
+print(f"{i.get('Id')}\t{i.get('Name')}\t{i.get('Path')}")
 PY
 }
 
@@ -73,8 +93,8 @@ print(f"  容器      {cont}" + ("   ← 转码流：网盘给的是播放列表
 print(f"  文件大小  {size/1024/1024:.0f} MiB" if size
       else ("  文件大小  —（HLS 没有单一文件）" if hls else "  文件大小  未知"))
 print(f"  时长      {dur/60:.1f} 分钟" if dur else "  时长      未知（时长为 0 会让续播点存不下来）")
-if br: print(f"  总码率    {br/1_000_000:.2f} Mbps   <<< 两集差得多的话，卡就是它")
-elif size and dur: print(f"  总码率    {size*8/dur/1_000_000:.2f} Mbps（按大小/时长算）  <<< 两集差得多的话，卡就是它")
+if br: print(f"  总码率    {br/1_000_000:.2f} Mbps   <<< 和对照组差得多的话，卡就是它")
+elif size and dur: print(f"  总码率    {size*8/dur/1_000_000:.2f} Mbps（按大小/时长算）  <<< 和对照组差得多的话，卡就是它")
 elif hls: print("  总码率    —（HLS 的码率看下面「流码率」那行）")
 else: print("  总码率    未知")
 for s in (ms.get("MediaStreams") or []):
@@ -122,7 +142,7 @@ except urllib.error.HTTPError as e:
     else:
         print(f"  换直链    {dt:.1f} 秒   {'✖ HTTP %d' % e.code}")
         print(f"  ✖ 没拿到直链：{dt:.1f} 秒之后回了个 {e.code}。"
-              f"这一集【这会儿根本放不了】——")
+              f"这个片子【这会儿根本放不了】——")
         print(f"    换直链是每次播放都要走一遍的，它失败就是点开转圈。"
               f"多半是网盘接口在限流（跑「5 体检」看「列目录历史」那张图）。")
         raise SystemExit
@@ -162,7 +182,7 @@ if not is_hls:
     print(f"  首字节    {ttfb:.2f} 秒")
     print(f"  实测速度  {got/dt/1048576:.2f} MB/s = {got*8/dt/1e6:.1f} Mbps"
           f"（从第 {off//1048576} MiB 处拉了 {got/1048576:.1f} MiB）")
-    print("  ↑ 要大于这一集的总码率才不卡。")
+    print("  ↑ 要大于上面那个总码率才不卡。")
     raise SystemExit
 
 # --- HLS：整个播放列表才几 KB，拿 Range 去测它是【没有意义】的。
@@ -230,20 +250,26 @@ PY
 }
 
 echo
-hr; echo "  为什么第 $SLOW 集卡、第 $GOOD 集不卡"; hr
+hr
+if [ -n "$GOOD" ]; then echo "  「$SLOW」和「$GOOD」并排比"
+else echo "  查「$SLOW」"; fi
+hr
 
-for ep in "$SLOW" "$GOOD"; do
+for ep in "$SLOW" ${GOOD:+"$GOOD"}; do
   line="$(find_item "$ep")"
   id="$(printf '%s' "$line" | cut -f1)"
   nm="$(printf '%s' "$line" | cut -f2)"
   pth="$(printf '%s' "$line" | cut -f3)"
   echo
   if [ "$id" = "NOTFOUND" ] || [ -z "$id" ]; then
-    echo "【第 $ep 集】在 Emby 里没找到 —— 集号对不上？换个数字试试"
+    echo "【$ep】在 Emby 里没找到 —— 换个词试试（片名的一部分就行）"
     continue
   fi
-  if [ "$id" = "ERR" ]; then echo "【第 $ep 集】问 Emby 失败：$nm"; continue; fi
-  echo "【第 $ep 集】$nm"
+  if [ "$id" = "ERR" ]; then echo "【$ep】问 Emby 失败：$nm"; continue; fi
+  if [ "$id" = "MANY" ]; then
+    echo "【$ep】匹配到 $nm 个，说得再具体一点：$pth"; continue
+  fi
+  echo "【$ep】$nm"
   echo "  条目 id   $id"
   echo "  strm      $pth"
   # 容器内路径 -> 宿主机路径，把 strm 内容（网盘全路径）打出来
@@ -280,7 +306,7 @@ for s in d or []:
         print(f"    转码中    {ti.get('VideoCodec')}  {ti.get('Bitrate',0)/1_000_000:.1f}Mbps "
               f"CPU {ti.get('CompletionPercentage','?')}%  原因：{'、'.join(ti.get('TranscodeReasons') or []) or '?'}")
 if not busy:
-    print("  当前没有在播的会话 —— 想抓转码的话，让第 238 集放着，再跑一次这个脚本")
+    print("  当前没有在播的会话 —— 想抓转码的话，让那个片子放着，再跑一次这个脚本")
 PY
 
 echo
@@ -303,7 +329,7 @@ cat <<'TIP'
                                             从「转码流」换成「原画」试试：
                                             原画是直接拉整文件，不经过网盘的
                                             转码服务器，通常更稳
-    · 换直链 ✖（404 / 超时）              → 这一集【当下根本放不了】，点开就转圈。
+    · 换直链 ✖（404 / 超时）              → 这个片子【当下根本放不了】，点开就转圈。
                                             换直链是每次播放都要走一遍的。
                                             多半是网盘接口在限流 ——
                                             跑「5 体检」看「列目录历史」那张图
@@ -311,6 +337,6 @@ cat <<'TIP'
     · 播放方式不是 DirectPlay             → Emby 在转码，2 核的机器扛不住。
                                             多半是编码客户端不认
                                             （HEVC 10bit / AV1 / 特殊音轨）
-    · 两集各项都差不多、就是卡            → 不是这一集的问题，是网盘那会儿在限流
+    · 各项都正常、就是卡                  → 不是这个片子的问题，是网盘那会儿在限流
 TIP
 echo


### PR DESCRIPTION
## 问题

用户报「龙虎门播放不了」—— 那是**电影**。而 `find_item` 写死了 `IncludeItemTypes=Episode`，匹配也只按集号。电影没有 `IndexNumber`，两条都对不上，脚本直接说「没找到」。

## 改动

- 改成 `Movie,Episode,Video` 都拉，翻页拉完
- 三种匹配**从严到宽**：集号（最准）→ 片名 → 文件名
- 匹配到多个时**列出来**让用户说具体点，不闷头挑第一个
- 第二个参数（对照组）改成**可选**：只查一个片子时不需要它。原来 `GOOD` 默认 `237`，查电影时会莫名其妙多比一集动漫
- 一个参数都不给时打印用法，不再默认去查 238
- 文案里的「这一集」「两集」改成中性说法（电影场景下读着别扭）

## 用法

```bash
bash why-slow.sh 龙虎门           # 查一个
bash why-slow.sh 238 237          # 两个并排比
```

## 验证

假 Emby 里放了一部电影（mkv / 11.5 GB / 16.6 Mbps）、一集动漫（hls）、外加一部同名电影，五条路径都跑通：

1. 按片名查电影 → 找到，容器/大小/码率/编码/音轨全部解析正确
2. 只给一个参数 → 不比对照组
3. 集号照旧能找到剧集
4. `龙虎门` 匹配到 2 个 → 列出来提示说具体点
5. 找不到 → 提示换个词

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_