### PR TITLE
「存储没挂上」是拿陈年记录冒充当前故障，改成「上次初始化报过错」

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -42,7 +42,7 @@ import zipfile
 #   1.5.0 → 1.5.1 → 1.5.2 → … → 1.5.999
 # 中间那位（5）和最前面那位（1）不要自己动 —— 要动也是他说了算。
 # 加满 999 之前，任何改动都只是最后一位 +1，不管改的是一行注释还是一个模块。
-SCRIPT_VERSION = "1.5.23"
+SCRIPT_VERSION = "1.5.24"
 
 # 本脚本在仓库里的地址，「更新」时用它把自己换成最新版
 SELF_URL = "https://raw.githubusercontent.com/bgpeer/nodekit/main/media-stack.py"
@@ -9775,7 +9775,14 @@ def mount_paths_menu():
                 mark = f"{GREEN}✔ 扫{RST}  {DIM}整个盘（自动）{RST}"
             else:
                 mark = f"{DIM}✖ 不扫{RST}"
-            bad = f"  {YELLOW}存储没挂上{RST}" if st != "work" else ""
+            # 【别把 status 当实时状态】它是【存储初始化那一刻】写进去的，
+            # 之后网盘恢复了也不会自己改回 work。写成"存储没挂上"就是拿一条
+            # 陈年记录冒充当前故障 —— 实测那个盘列目录 0.4 秒、换直链 0.2 秒，
+            # 好得很，这一行却红着说它没挂上。「2 使用信息」和体检早就按
+            # "上次初始化时报过错" 措辞了，这里当初没跟上。
+            # 也不打印 status 原文：那是整条 Go 错误，里面带着 access_token，
+            # 而这一屏是会被截图的。要看细节去「6 链路体检」。
+            bad = (f"  {DIM}上次初始化报过错{RST}" if st != "work" else "")
             # 中文名打头（一眼认得是哪个盘），挂载路径跟在后面 ——
             # 同一种网盘挂两个账号时，只有它能把两行分开
             print(f"  {i:>2}. {pad(driver_cn(drv), 20)}{DIM}{pad(mp, 14)}"


### PR DESCRIPTION
`x_storages.status` 是**存储初始化那一刻**写进去的，之后网盘恢复了也不会自己改回 `work`。

那个盘现在列目录 0.4 秒、换直链 0.2 秒，好得很，这一行却红着说「存储没挂上」—— 拿一条陈年记录冒充当前故障。

**这一课这个仓库早就学过**：「2 使用信息」和体检那边都写着「上次初始化时报过错」，体检还专门用中性图标而不是黄灯，注释里说得很清楚：

> 用告警图标表达一个"还不知道"的东西，结果就是每次体检都先亮一个黄灯，而下面全绿、待办也空 —— 用户学会忽略它之后，真出事那次也会被跳过去。

新写的这一屏没跟上。

## 改动

- 改成灰色的「上次初始化报过错」，细节仍旧交给「6 链路体检」实测
- **不打印 `status` 原文** —— 那是整条 Go 错误，里面带着 `access_token`，而这一屏是会被截图的

测试第 19 条同时断言：不出现「存储没挂上」、出现「上次初始化报过错」、`status` 里的令牌不会被打出来。

版本：v1.5.23 → v1.5.24

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_