### PR TITLE
link-history：文件名是双重编码的，解一次不够 —— 说没找到、底下却列着它

### DIFF
--- a/tools/link-history.sh
+++ b/tools/link-history.sh
@@ -85,9 +85,20 @@ def title(u):
     return segs[-1] if segs else u
 
 
-# 【按整条地址匹配，不只按抠出来的名字】名字抠得再准也总有抠不到的形态，
-# 而片名那几个字一定在地址里的某个地方。宁可宽一点，也别漏掉半段历史。
-hit = [(t, u) for t, u in rows if Q.lower() in unquote(u).lower()]
+def haystack(u):
+    """拿来和片名比对的那一大坨文本。
+
+    【必须解码两次】网盘的下载头参数是【双重编码】的：地址里写的是
+    %25E9%25BE%2599，解一次只得到 %E9%BE%99，解两次才是「龙虎门」。
+    只解一次就会出现"说没找到、底下却列着它"这种自相矛盾的输出 ——
+    因为列名字那段（title）恰好解了两次。实测被这个坑到过。
+    把一次、两次、以及抠出来的名字全拼进去比，宁可宽一点也别漏。
+    """
+    one = unquote(u)
+    return (one + "\n" + unquote(one) + "\n" + title(u)).lower()
+
+
+hit = [(t, u) for t, u in rows if Q.lower() in haystack(u)]
 if not hit:
     names = []
     for _t, u in rows:


### PR DESCRIPTION
现场输出自相矛盾：

```
⚠ 这段日志里没有「龙虎门」。出现过的是：
  · media.m3u8
  · ...
  · 龙虎门 (2006) 1080P.mkv        ← 它就在这儿
```

匹配那一步只解码一次，而网盘的下载头参数是**双重编码**的：

```
地址里：  %25E9%25BE%2599...
解一次：  %E9%BE%99...          ← 匹配用的是这个，当然找不到
解两次：  龙虎门                 ← 列名字用的是这个，所以它列得出来
```

两边解码次数不同，于是给出相反的答案。改成一次、两次、外加抠出来的名字全拼进去比。

## 这个坑是假数据放过的

上一版的测试夹具自己造 URL 时**只编码了一次** —— 比现场干净，于是测试全绿、一到真机就废。现在夹具照抄现场那条地址的形态：下载头双重编码、HLS 的文件名夹在路径中段。

## 测试

五条。第一条就是这次的现场；第二条专门盯着「说没找到、却列着它」这种自相矛盾，以后不许再出现。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_