### PR TITLE
link-history：216 行刷满屏、而且只记成功 —— 折起来，并且把失败也记上

### DIFF
--- a/tools/link-history.sh
+++ b/tools/link-history.sh
@@ -37,12 +37,26 @@ B, D, R, G, Y, C, X = ("\033[1m", "\033[2m", "\033[31m", "\033[32m",
 #   【INFO】 2026-08-30 05:10:01 | AlistStrm 重定向至：https://dl1-v6.aliyundrive.cloud/...
 LINE = re.compile(r"(\d{4}-\d\d-\d\d[ T]\d\d:\d\d:\d\d).*?重定向至：?\s*(\S+)")
 
-rows = []
+# 【失败也要记】这一屏原来只收"重定向至"，也就是只有【成功】的那些。
+# 可是"点都点不开"这种症状，证据恰恰是【没有成功记录】和那些 404 ——
+# 只看成功记录，屏幕上就是一片空白，跟"这段时间没人播"长得一模一样。
+FAIL = re.compile(r"(\d{4}-\d\d-\d\d[ T]\d\d:\d\d:\d\d).*?\|\s*(\d{3})\s*\|"
+                  r".*?/Videos/(\d+)/stream")
+ANY_TS = re.compile(r"(\d{4}-\d\d-\d\d[ T]\d\d:\d\d:\d\d)")
+
+rows, fails, last_ts = [], [], ""
 with open(LOGFILE, encoding="utf-8", errors="replace") as f:
     for ln in f:
         m = LINE.search(ln)
         if m:
             rows.append((m.group(1), m.group(2)))
+        else:
+            fm = FAIL.search(ln)
+            if fm and fm.group(2) not in ("200", "204", "206", "302", "304"):
+                fails.append((fm.group(1), fm.group(2), fm.group(3)))
+        am = ANY_TS.search(ln)
+        if am and am.group(1) > last_ts:
+            last_ts = am.group(1)
 
 if not rows:
     print(f"{Y}⚠{X} 日志里没有「重定向至」的记录。")
@@ -114,33 +128,68 @@ print()
 print("=" * 64)
 print(f"  {B}{title(hit[-1][1])}{X}   {D}共 {len(hit)} 次换直链{X}")
 print("=" * 64)
-print(f"  {D}时间{' ' * 16}指向哪　　　　　　　　　　形态{X}")
 
-prev = None
+# 【连着一样的要折起来】实测一部片子 216 次换直链，一行一条刷了满屏，
+# 而要找的"什么时候变的"反而淹在里面。连续同一条路折成一行：起止时间 + 次数，
+# 变化的那一行自然就凸出来了 —— 这一屏存在的意义就是让变化一眼可见。
+runs = []
 for t, u in hit:
-    host = urlsplit(u).netloc
-    k = kind(u)
-    # 换了节点或换了形态就标出来 —— "什么时候变的"正是要找的东西
-    mark = ""
-    if prev and prev != (host, k):
-        mark = f"  {Y}← 从这里开始变了{X}"
-    prev = (host, k)
-    col = G if k == "HLS 分片流" else C
-    print(f"  {t}   {col}{host:<34}{X}{k}{mark}")
+    key = (urlsplit(u).netloc, kind(u))
+    if runs and runs[-1][0] == key:
+        runs[-1][2] = t
+        runs[-1][3] += 1
+    else:
+        runs.append([key, t, t, 1])
 
-print()
+for i, ((host, k), t0, t1, n) in enumerate(runs):
+    col = G if k == "HLS 分片流" else C
+    span = t0 if n == 1 else f"{t0} ~ {t1[11:]}"
+    mark = f"  {Y}← 从这里开始变了{X}" if i else ""
+    print(f"  {col}{host}{X}  {k}")
+    print(f"    {D}{span}　{n} 次{X}{mark}")
+
+# 【"之后再没成功过"必须有失败记录撑着】只看"最后一条成功之后日志还有别的行"
+# 是不够的：那可能只是【别的片子】在放。拿那个当证据，就会对着一部好好的片子
+# 报"当下换不到直链"。所以只认这部片最后一次成功【之后】真的出现过的失败请求。
+# 测试里就是被"仙逆播了一次"这条无关记录骗到的。
+after = [f for f in fails if hit and f[0] > hit[-1][0]]
+stalled = bool(after)
+if stalled:
+    print(f"  {Y}最后一次成功换直链：{hit[-1][0]}{X}")
+    print(f"  {D}之后到 {after[-1][0]} 为止，播放请求只拿到失败 —— "
+          f"这段时间点开它只会一直转圈。{X}")
+    print()
+
+if after:
+    print(f"  {B}这之后失败的播放请求{X}{D}（Emby 要地址、MediaWarp 没给出来）{X}")
+    for t, code, iid in after[-8:]:
+        print(f"    {R}{t}   HTTP {code}   条目 {iid}{X}")
+    if len(after) > 8:
+        print(f"    {D}…共 {len(after)} 条，只列最近 8 条{X}")
+    print(f"  {D}这些不分片名 —— 换直链没成功，日志里就没有片名可认。{X}")
+    print()
+
 hosts = {}
 for t, u in hit:
     hosts.setdefault((urlsplit(u).netloc, kind(u)), []).append(t)
+# 【结论要看当下，不只看历史】"换不到直链"和"直链变慢"是两回事，修法也完全不同：
+# 前者点开根本不动，后者能动但一直缓冲。历史里全是成功、而最近只剩失败的话，
+# 当下的问题就是前者 —— 这时再说"速度变了"是把人往错的方向指。
 if len(hosts) == 1:
     (h, k), ts = next(iter(hosts.items()))
-    print(f"  {D}从头到尾都是同一条路：{h}（{k}）{X}")
-    print(f"  {D}那「以前流畅现在卡」就不是路变了，是那条路本身的速度变了 —— "
-          f"用 tools/ali-403.sh 量一下当下能跑多少{X}")
+    print(f"  {D}历史上从头到尾都是同一条路：{h}（{k}）{X}")
+    if stalled:
+        print(f"  {B}但当下换不到直链{X}{D} —— 这不是快慢的事，是这个盘现在取不到"
+              f"地址。跑「6 链路体检」看那个存储的实测结果{X}")
+    else:
+        print(f"  {D}那「以前流畅现在卡」就不是路变了，是那条路本身的速度变了 —— "
+              f"用 tools/ali-403.sh 量一下当下能跑多少{X}")
 else:
     print(f"  {B}换过 {len(hosts)} 种走法：{X}")
     for (h, k), ts in hosts.items():
         print(f"    {C}{h}{X}  {k}   {D}{ts[0]} ~ {ts[-1]}，{len(ts)} 次{X}")
     print(f"  {D}形态从「HLS 分片流」变成「整文件」= 从转码流掉回了原画，"
           f"那正是「忽然变卡」最常见的原因{X}")
+    if stalled:
+        print(f"  {B}另外：当下换不到直链{X}{D} —— 先把这个解决，再谈快慢{X}")
 PY


### PR DESCRIPTION
现场跑出来 **216 条**，一行一条刷了满屏，要找的「什么时候变的」反而淹在里面。

而且它只收「重定向至」，也就是只有**成功**的那些 —— 可症状恰恰是「点都点不开」，那种情况下日志里一条成功记录都没有，屏幕上一片空白，跟「这段时间没人播」长得一模一样。

## 改动

- 连续同一条路折成一行：起止时间 + 次数。变化那一行自然凸出来
- 收 Access 里 `/Videos/{id}/stream` 的失败状态码，单列一段
- 报出「最后一次成功换直链」是什么时候，之后只拿到失败
- 结论按当下走：换不到直链时说「这不是快慢的事」，而不是照旧说「速度变了」—— 这两件事修法完全不同

```
================================================================
  龙虎门 (2006) 1080P.mkv   共 30 次换直链
================================================================
  dl1-v6.aliyundrive.cloud  整文件
    2026-08-29 14:00:00 ~ 23:02:00 30 次
  最后一次成功换直链：2026-08-29 23:02:00
  之后到 2026-08-30 13:45:00 为止，播放请求只拿到失败 —— 这段时间点开它只会一直转圈。

  这之后失败的播放请求（Emby 要地址、MediaWarp 没给出来）
    2026-08-30 13:40:00   HTTP 404   条目 113376
    ...

  历史上从头到尾都是同一条路：dl1-v6.aliyundrive.cloud（整文件）
  但当下换不到直链 —— 这不是快慢的事，是这个盘现在取不到地址
```

## 测试当场抓到一个误报

第一版判「之后再没成功过」用的是「最后一条成功之后日志还有别的行」。可那**可能只是别的片子在放** —— 于是对着一部好好的片子报「当下换不到直链」。改成必须有**这部片最后一次成功之后**真的出现过的失败请求。

## 测试

九条：双重编码匹配、折叠、换不到直链时的三处措辞、换过走法、没有失败记录时不乱报、别的片子找得到、片名真不存在、日志里没有重定向。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_