### PR TITLE
ol-file.sh 补上"为什么"：存储实时状态 + OpenList 日志原文

### DIFF
--- a/tools/ol-file.sh
+++ b/tools/ol-file.sh
@@ -14,7 +14,7 @@
 #   ③ 拉 1 MiB     慢 = 地址拿到了但拉不动，那是限速/线路
 set -u
 
-TOOL_VER="2026-08-31b"          # 见 link-history.sh 里的说明：CDN 会缓存
+TOOL_VER="2026-08-31c"          # 见 link-history.sh 里的说明：CDN 会缓存
 echo "  ${0##*/}  版本 $TOOL_VER"
 
 P="${1:-}"
@@ -27,7 +27,7 @@ OLPW="$(sed -nE 's/^OPENLIST_PASS=(.*)$/\1/p' "$DIR/.secrets" 2>/dev/null | head
 
 export OL_PATH="$P" OL_PW="$OLPW"
 python3 - <<'PY'
-import json, os, time, urllib.error, urllib.request
+import json, os, re, subprocess, time, urllib.error, urllib.request
 
 BASE = "http://127.0.0.1:5244"
 G="\033[32m"; Y="\033[33m"; R="\033[31m"; C="\033[36m"; D="\033[2m"; B="\033[1m"; X="\033[0m"
@@ -45,6 +45,64 @@ def api(p, body, tok=None, timeout=180):
         return json.loads(r.read().decode("utf-8", "replace")), time.monotonic() - t0
 
 
+# ---- OpenList 自己说了什么。上面那几行是"卡在哪"，这一段才是"为什么" ----
+#
+# 【必须脱敏】OpenList 的报错里带着 access_token（"failed get link: ... token=eyJ..."），
+# 而这个输出是会被截图发出来的。整串一律打码，只留够判断的前几位。
+#
+# 【目录和文件两条路都要能走到】早一版把它写在文件那条路的末尾，而查目录的那条
+# 中途就 SystemExit 了 —— "新文件夹刷不出来"恰恰最需要看日志，偏偏一行都看不到。
+# 【键名前面【不要】限定 ? 或 &】日志里常常是裸的 "token=xxx"，前面既没有问号也没有
+# & —— 实测就是这么漏出去一整串的。用 \b 认词边界，两种写法都盖得住。
+TOK = re.compile(r"\b((?:access_token|refresh_token|token|auth_key|cookie|sign|"
+                 r"password|pwd)=)[^&\s\"']+", re.I)
+JWT = re.compile(r"\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+")
+# 【24 不是 40】阈值定在 40 时，一串 39 位的令牌原样留在了屏幕上。宁可把长一点的
+# 容器 id、哈希也截断 —— 那些截断了不影响判断，令牌漏一次就是漏了。
+LONG = re.compile(r"\b[A-Za-z0-9_\-]{24,}\b")
+ANSI = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def clean(line):
+    line = ANSI.sub("", line)
+    line = TOK.sub(lambda m: m.group(1) + "***", line)
+    line = JWT.sub("eyJ***", line)
+    return LONG.sub(lambda m: m.group(0)[:6] + "***", line)
+
+
+def show_logs():
+    print()
+    print(f"  {B}OpenList 最近说了什么{X}  {D}（最近 10 分钟里带报错的行，令牌已打码）{X}")
+    print("=" * 58)
+    try:
+        out = subprocess.run(["docker", "logs", "--since", "10m", "openlist"],
+                             capture_output=True, text=True, timeout=60)
+        if out.returncode != 0:
+            # docker 自己的报错不能混进来当成 OpenList 说的话 —— 那会让人以为
+            # 网盘出了问题，其实是这台机器上根本没读到容器
+            print(f"  {D}读不到 openlist 的日志：{out.stderr.strip()[:120]}{X}")
+            raise SystemExit(0)
+        bad = [ln for ln in (out.stdout + out.stderr).splitlines()
+               if re.search(r"(?i)error|fail|invalid|expire|denied|refus|timeout|"
+                            r"429|401|403|too many|limit", ln)]
+        if not bad:
+            print(f"  {G}✔{X} 最近 10 分钟没有报错 —— 那就不是 OpenList 这一层的问题")
+        for ln in bad[-12:]:
+            print(f"  {D}·{X} {clean(ln)[:200]}")
+        if len(bad) > 12:
+            print(f"  {D}…另外 {len(bad) - 12} 行：docker logs --since 10m openlist{X}")
+    except FileNotFoundError:
+        print(f"  {D}这台机器上没有 docker 命令，跳过{X}")
+    except Exception as e:
+        print(f"  {D}读日志失败：{type(e).__name__}{X}")
+    print()
+    print(f"  {D}这一段里常见的几句，各自是什么意思：{X}")
+    print(f"  {D}· too many requests / 429      网盘在限流，等一会儿{X}")
+    print(f"  {D}· token / 401 / unauthorized   授权失效了，去 OpenList 重新扫码{X}")
+    print(f"  {D}· context deadline exceeded    网盘接口没在时限内回话，限流或线路{X}")
+    print(f"  {D}· 一行都没有                    问题不在 OpenList，往浏览器/线路那边看{X}")
+
+
 try:
     r, _ = api("/api/auth/login", {"username": "admin", "password": os.environ["OL_PW"]},
                timeout=20)
@@ -59,6 +117,30 @@ if not tok:
 print()
 print(f"  {B}{path}{X}")
 print("=" * 58)
+
+# ---- ⓪ 这个盘此刻的状态。问【接口】，不是 sqlite 里那份陈年记录 ----
+#
+# x_storages.status 是【存储初始化那一刻】写进去的，之后恢复了也不会改回 work，
+# 拿它当实时状态用会把陈年记录报成当前故障。接口给的这份才是此刻的。
+mount = ""
+try:
+    r, _ = api("/api/admin/storage/list", {"page": 1, "per_page": 100}, tok, timeout=30)
+    for st in ((r.get("data") or {}).get("content") or []):
+        mp = str(st.get("mount_path") or "")
+        if path == mp or path.startswith(mp.rstrip("/") + "/"):
+            mount = mp
+            stat = str(st.get("status") or "")
+            dis = st.get("disabled")
+            c = G if (stat == "work" and not dis) else R
+            print(f"  ⓪ 这个盘      {c}{stat or '?'}{X}"
+                  f"{'  ' + R + '已停用' + X if dis else ''}"
+                  f"  {D}{mp}  {st.get('driver', '')}"
+                  f"  缓存 {st.get('cache_expiration', '?')} 分钟{X}")
+            break
+    else:
+        print(f"  ⓪ 这个盘      {Y}没找到对应的存储{X}  {D}路径打错了？{X}")
+except Exception as e:
+    print(f"  ⓪ 这个盘      {D}问不到存储状态（{type(e).__name__}）{X}")
 
 # ---- ① 列目录。带 refresh 才是问网盘，不带就是读缓存 ----
 #
@@ -104,6 +186,7 @@ if not is_file:
     print(f"  {D}上面这份是【强制刷新后网盘真正返回的】名单。{X}")
     print(f"  {D}要找的文件夹不在里面 = 网盘那边就没有（分享目录的自动更新还没同步、{X}")
     print(f"  {D}或者转存进的是另一个目录），跟本机的缓存无关，清缓存也变不出来。{X}")
+    show_logs()
     raise SystemExit(0)
 
 # ---- ② fs/get：网页点开文件卡住的就是这一下 ----
@@ -154,4 +237,6 @@ print(f"  {D}在后台慢慢做的，刚放进去的片子【还没转完】—�
 print(f"  {D}判断方法：拿同一个目录里的【老片子】再跑一次这个脚本。老的秒回、新的卡住，{X}")
 print(f"  {D}就是在等网盘转码，不是你的机器有问题。{X}")
 print(f"  {D}不想等：media-stack →「4 挂载路径」→ 选这个盘 →「2 直链方式」→ 原画直链。{X}")
+
+show_logs()
 PY


### PR DESCRIPTION
前三步只回答「卡在哪一步」，答不了「为什么」。补两段：

- **⓪ 这个盘此刻的状态** —— 问 `/api/admin/storage/list`，不是 sqlite 里那份陈年记录（`status` 是初始化那一刻写的，恢复了也不会改回 `work`）。顺带把驱动和当前缓存分钟数打出来
- **④ OpenList 最近 10 分钟里带报错的日志原文**，并附上常见几句各自什么意思（429 限流 / 401 令牌失效 / context deadline exceeded / 一行都没有）

### 日志要脱敏，而且第一版没脱干净

OpenList 的报错里带 `access_token`，而这个输出是会被截图发出来的。拿五种形状、六种长度、七种写法交叉验证，逮到两个漏洞：

- 键名前面限定了 `?` 或 `&` —— 而日志里常常是**裸的 `token=xxx`**，整串漏出去
- 长串阈值定在 40 —— **一串 39 位的令牌原样留在了屏幕上**

改成按词边界认键名（再加上 cookie/password/pwd），阈值降到 24。重测 126 种组合一个都不漏，而 `429`、`context deadline exceeded` 这些真正要看的报错保持原样可读。

### 目录和文件两条路都要走到

早一版把日志段写在文件那条路的末尾，而查目录的那条中途就 `SystemExit` 了 —— **「新文件夹刷不出来」恰恰最需要看日志**，偏偏一行都看不到。抽成函数，两边都调。

另外 docker 自己的报错不再混进来冒充 OpenList 说的话。

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_