### PR TITLE
凌晨自动扫描看到的是旧目录，新片一个都进不来

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -36,7 +36,7 @@ import zipfile
 
 # 版本号：改了代码就 +1，让「7 更新」能显示 vX → vY。
 # 仓库主人定的规矩：只动最后一位，1.5.0 一路加到 1.5.999，前两位不要自己动。
-SCRIPT_VERSION = "1.5.44"
+SCRIPT_VERSION = "1.5.45"
 
 # 本脚本在仓库里的地址，「更新」时用它把自己换成最新版
 SELF_URL = "https://raw.githubusercontent.com/bgpeer/nodekit/main/media-stack.py"
@@ -1319,6 +1319,9 @@ WARM_BYTES     = 65536  # 每部拉多少字节 —— 够让网盘把那一段�
 # 每天对齐一次的时刻（北京时间），钉在 AutoFilm 生成 strm 之后半小时 —— 先有
 # 文件，再去清失效、补时长。和 DEFAULT_STRM_CRON 一起改
 SYNC_HOUR_CST  = "05:45"
+# 刷目录缓存的时刻。必须【早于】AutoFilm 生成 strm 的 05:15（见 DEFAULT_STRM_CRON），
+# 又不必太早 —— 刷完到开扫之间隔得越久，这中间新加的片子越可能又赶不上。5 分钟够。
+PRECACHE_HOUR_CST = "05:10"
 # 自动更新【只换脚本，不动容器、不重生成配置】。放在每日对齐之前一点，
 # 换完那一轮对齐就是新版脚本在跑。见 do_selfupdate 里为什么只换脚本。
 SELFUP_HOUR_CST = "05:15"
@@ -1347,6 +1350,7 @@ CRON_TIMEOUT   = {
     # 不该在任务正常收尾之前把它砍了
     "heal":      HEAL_BG_BUDGET_T,
     "selfupdate": 300,                       # 就一次 HTTPS 下载 + 语法自检
+    "precache":   300,                       # 每个盘两个 HTTP 请求，不该跑这么久
 }
 
 
@@ -1873,12 +1877,17 @@ def install_sync_cron(install_dir):
         各自一份的，而加库的动作在 Emby 里做，脚本这边毫无感知
     """
     m, h = cst_to_local_cron(SYNC_HOUR_CST)
+    pm, ph = cst_to_local_cron(PRECACHE_HOUR_CST)
     try:
-        txt = (f"# media-stack 每天自动对齐：清失效 strm、给新媒体库调续播门槛、\n"
-               f"# 补时长、通知 Emby 扫描。北京时间 {SYNC_HOUR_CST}"
-               f"（本机 {h:02d}:{m:02d}），在 AutoFilm 生成 strm 之后。\n"
+        txt = (f"# media-stack 每天两件事，顺序不能反：\n"
+               f"# 北京时间 {PRECACHE_HOUR_CST}（本机 {ph:02d}:{pm:02d}）"
+               f"刷目录缓存 —— 必须排在 AutoFilm 生成 strm【之前】，否则它列到的\n"
+               f"# 是一份旧目录，新片一个都扫不进来，而任务照样报完成。\n"
+               f"# 北京时间 {SYNC_HOUR_CST}（本机 {h:02d}:{m:02d}）对齐：清失效 strm、\n"
+               f"# 给新媒体库调续播门槛、补时长、通知 Emby 扫描 —— 排在生成【之后】。\n"
                "SHELL=/bin/bash\n"
                "PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin\n"
+               f"{pm} {ph} * * * root {cron_cmd('precache')} >/dev/null 2>&1\n"
                f"{m} {h} * * * root {cron_cmd('sync')} >/dev/null 2>&1\n")
         with open(SYNC_CRON, "w") as f:
             f.write(txt)
@@ -1887,6 +1896,28 @@ def install_sync_cron(install_dir):
     except OSError as e:
         warn(f"装每日对齐任务失败（不影响使用）：{e}")
         return False
+
+
+def do_precache():
+    """AutoFilm 开扫【之前】几分钟，把要扫的那几个盘的目录缓存刷掉。安静跑。
+
+    【补的是自动那条路上的一个洞】手点「5 生成媒体库」第一步就清缓存，所以点了就能
+    把新片扫进来；而每天凌晨那条自动的路【从来不清】—— AutoFilm 到点就去列目录，
+    OpenList 手里要是还压着一份旧的，它当然一个新文件都看不见，任务照样报"完成"。
+    用户看到的就是"我记得设过每天自动扫描，怎么新片没进来"，而且查不出所以然：
+    定时任务跑了、日志干净、strm 数没变，每一环看着都对。
+
+    缓存设得越长这个洞越大：12 小时的话，凌晨 5 点那次看到的是前一天下午的目录。
+    现在默认 30 分钟，洞小了但没堵上 —— 而且用户随时可以把它调回长的。
+
+    代价几乎为零：每个盘两个 HTTP 请求（停用再启用），不重启容器，也不动别的盘。
+    """
+    d = ms_install_dir()
+    if not is_installed(d):
+        return
+    mounts = {"/" + m for m in
+              (strm_mount_dir(p) for p in effective_scan_paths(d)) if m}
+    reload_storages(d, mounts)
 
 
 def install_warm_cron(install_dir):
@@ -11907,6 +11938,10 @@ if __name__ == "__main__":
         elif arg == "keepalive":          # cron 调的，安静跑，结果写 json
             if take_task_lock("keepalive"):
                 do_keepalive()
+        elif arg == "precache":           # cron 调的：开扫前刷一次目录缓存
+            require_root()
+            if take_task_lock("precache"):
+                do_precache()
         elif arg == "sync":               # cron 调的每日对齐，同样不交互
             require_root()
             if take_task_lock("sync"):

--- a/tools/ol-file.sh
+++ b/tools/ol-file.sh
@@ -14,7 +14,7 @@
 #   ③ 拉 1 MiB     慢 = 地址拿到了但拉不动，那是限速/线路
 set -u
 
-TOOL_VER="2026-08-31c"          # 见 link-history.sh 里的说明：CDN 会缓存
+TOOL_VER="2026-08-31d"          # 见 link-history.sh 里的说明：CDN 会缓存
 echo "  ${0##*/}  版本 $TOOL_VER"
 
 P="${1:-}"
@@ -35,14 +35,30 @@ path = os.environ["OL_PATH"]
 parent = path.rsplit("/", 1)[0] or "/"
 
 
-def api(p, body, tok=None, timeout=180):
+# 【令牌从全局取，不靠调用方记得传】上一版把 tok 做成了可选参数，然后 fs/list 和
+# fs/get 两处都忘了传 —— 请求以游客身份发出去，OpenList 当场回
+# "Guest user is disabled, login please"，耗时 0.0 秒。于是那几行看着像"网盘拒绝了"，
+# 其实一步都没走到网盘。这种"测了个寂寞还打印得像模像样"的输出比不测更坏。
+TOKEN = ""
+
+
+def api(p, body=None, timeout=180, method="POST"):
+    """调 OpenList 的接口。GET 的参数拼在 p 里，POST 的放 body。"""
+    data = json.dumps(body or {}).encode() if method == "POST" else None
     req = urllib.request.Request(
-        BASE + p, data=json.dumps(body).encode(), method="POST",
+        BASE + p, data=data, method=method,
         headers={"Content-Type": "application/json",
-                 **({"Authorization": tok} if tok else {})})
+                 **({"Authorization": TOKEN} if TOKEN else {})})
     t0 = time.monotonic()
     with urllib.request.urlopen(req, timeout=timeout) as r:
-        return json.loads(r.read().decode("utf-8", "replace")), time.monotonic() - t0
+        raw = r.read().decode("utf-8", "replace")
+    el = time.monotonic() - t0
+    try:
+        return json.loads(raw), el
+    except ValueError:
+        # 【别把非 JSON 一句 JSONDecodeError 带过】接口路径或方法用错时返回的是一页
+        # HTML，而"问不到状态"这四个字完全看不出是哪种错。原样给回前几十个字符。
+        return {"code": -1, "message": f"返回的不是 JSON：{raw[:80]}"}, el
 
 
 # ---- OpenList 自己说了什么。上面那几行是"卡在哪"，这一段才是"为什么" ----
@@ -88,7 +104,13 @@ def show_logs():
         if not bad:
             print(f"  {G}✔{X} 最近 10 分钟没有报错 —— 那就不是 OpenList 这一层的问题")
         for ln in bad[-12:]:
-            print(f"  {D}·{X} {clean(ln)[:200]}")
+            # 【长行要留头也留尾】RESTY 那种行把整条 URL 铺在中间，而【失败的原因】
+            # 在最末尾。上一版直接砍前 200 字，砍掉的正好是唯一有用的那半句 ——
+            # 屏幕上剩一堆 access_token=***&app_ver=… 什么都说明不了。
+            ln = clean(ln)
+            if len(ln) > 190:
+                ln = ln[:110] + f" {D}…{X} " + ln[-80:]
+            print(f"  {D}·{X} {ln}")
         if len(bad) > 12:
             print(f"  {D}…另外 {len(bad) - 12} 行：docker logs --since 10m openlist{X}")
     except FileNotFoundError:
@@ -106,11 +128,11 @@ def show_logs():
 try:
     r, _ = api("/api/auth/login", {"username": "admin", "password": os.environ["OL_PW"]},
                timeout=20)
-    tok = (r.get("data") or {}).get("token", "")
+    TOKEN = (r.get("data") or {}).get("token", "")
 except Exception as e:
     print(f"{R}✖{X} 连不上 OpenList：{e}")
     raise SystemExit(1)
-if not tok:
+if not TOKEN:
     print(f"{R}✖{X} OpenList 登录失败（密码对不上？）")
     raise SystemExit(1)
 
@@ -124,7 +146,9 @@ print("=" * 58)
 # 拿它当实时状态用会把陈年记录报成当前故障。接口给的这份才是此刻的。
 mount = ""
 try:
-    r, _ = api("/api/admin/storage/list", {"page": 1, "per_page": 100}, tok, timeout=30)
+    # 这个接口是 GET，参数拼在 URL 上。上一版 POST 过去拿回一页 HTML，
+    # 于是只报了一句没头没脑的 JSONDecodeError。
+    r, _ = api("/api/admin/storage/list?page=1&per_page=100", timeout=30, method="GET")
     for st in ((r.get("data") or {}).get("content") or []):
         mp = str(st.get("mount_path") or "")
         if path == mp or path.startswith(mp.rstrip("/") + "/"):
@@ -154,6 +178,13 @@ target, is_file = path, False
 try:
     r, t = api("/api/fs/list", {"path": target, "password": "", "page": 1,
                                 "per_page": 100, "refresh": True})
+    if r.get("code") not in (200, 500):
+        # 【认证类的错要当场停】不然后面每一步都拿同一句拒绝当"网盘的回答"，
+        # 还配上耗时和结论，越看越像网盘出了问题。
+        print(f"  ① 列目录      {R}{r.get('message')}{X}")
+        print(f"\n  {Y}这不是网盘的问题 —— 请求没被 OpenList 认下来。{X}")
+        show_logs()
+        raise SystemExit(1)
     if r.get("code") != 200:
         target, is_file = parent, True
         r, t = api("/api/fs/list", {"path": target, "password": "", "page": 1,


### PR DESCRIPTION
手点「5 生成媒体库」第一步就清目录缓存，所以点了就能把新片扫进来。而每天凌晨那条**自动的路从来不清** —— AutoFilm 05:15 到点去列目录，OpenList 手里压着一份旧的，它当然一个新文件都看不见，任务还照样报「完成」。

用户看到的就是「我记得设过每天自动扫描，怎么新片没进来」，而且查不出所以然：定时任务跑了、日志干净、strm 数没变，每一环看着都对 —— 又是一个「看起来正常、实际是废的」。

缓存设得越长这个洞越大：720 分钟的话，凌晨 5 点那次看到的是**前一天下午**的目录。默认改回 30 分钟之后洞小了，但没堵上，而且用户随时可以把它调回长的。

### 补一条 precache 任务

排在 AutoFilm **之前** 5 分钟，只做一件事：把要扫的那几个盘的目录缓存刷掉。

```
北京 05:10  刷目录缓存   ← 新增
北京 05:15  AutoFilm 生成 strm
北京 05:45  对齐、通知 Emby 扫描
```

代价几乎为零 —— 每个盘两个 HTTP 请求（停用再启用），**不重启容器，不动别的盘**。这是上一版 `reload_storages` 换来的：以前要清缓存只能整个重启 OpenList，那个代价大到不可能挂进定时任务。

和每日对齐写在同一个 cron 文件里，卸载/重装/更新都跟着走。超时预算 300 秒。`running_tasks` 靠 `CRON_TIMEOUT` 认任务，加了键就自动纳入并发检查，不用另外改。

时刻换算和文件内容都实测过：三个时刻按本机时区正确落位，顺序 `510 < 515 < 545`。

v1.5.44 → v1.5.45

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_