### PR TITLE
context canceled 和 context deadline exceeded 不是一回事

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -36,7 +36,7 @@ import zipfile
 
 # 版本号：改了代码就 +1，让「7 更新」能显示 vX → vY。
 # 仓库主人定的规矩：只动最后一位，1.5.0 一路加到 1.5.999，前两位不要自己动。
-SCRIPT_VERSION = "1.5.45"
+SCRIPT_VERSION = "1.5.46"
 
 # 本脚本在仓库里的地址，「更新」时用它把自己换成最新版
 SELF_URL = "https://raw.githubusercontent.com/bgpeer/nodekit/main/media-stack.py"
@@ -9747,6 +9747,12 @@ def _short_err(s):
     s = re.sub(r"\s+", " ", s).strip()
     # 常见网络错误给个人话结论,原文太长且对定位没有额外帮助
     for pat, msg in (("context deadline exceeded", "网盘接口超时"),
+                     # 【canceled 和 deadline exceeded 不是一回事，别混成一句】
+                     # deadline exceeded = 等到我们自己设的时限，网盘没回话；
+                     # canceled = 【发起方主动撤了】—— 网页上就是浏览器等不下去先断了，
+                     # OpenList 顺手把上游那个请求也取消掉。前者要去查网盘，
+                     # 后者说明请求慢到了人先放弃，慢的根子仍在网盘，但不是同一种证据。
+                     ("context canceled", "请求被中途取消（多半是页面等太久先断了）"),
                      ("i/o timeout", "网盘接口超时"),
                      ("TLS handshake timeout", "网盘接口 TLS 握手超时"),
                      ("connection refused", "连接被拒绝"),

--- a/tools/ol-file.sh
+++ b/tools/ol-file.sh
@@ -14,7 +14,7 @@
 #   ③ 拉 1 MiB     慢 = 地址拿到了但拉不动，那是限速/线路
 set -u
 
-TOOL_VER="2026-08-31d"          # 见 link-history.sh 里的说明：CDN 会缓存
+TOOL_VER="2026-09-02a"          # 见 link-history.sh 里的说明：CDN 会缓存
 echo "  ${0##*/}  版本 $TOOL_VER"
 
 P="${1:-}"
@@ -122,6 +122,10 @@ def show_logs():
     print(f"  {D}· too many requests / 429      网盘在限流，等一会儿{X}")
     print(f"  {D}· token / 401 / unauthorized   授权失效了，去 OpenList 重新扫码{X}")
     print(f"  {D}· context deadline exceeded    网盘接口没在时限内回话，限流或线路{X}")
+    print(f"  {D}· context canceled             【发起方先断了】—— 网页等不下去，"
+          f"自己把请求取消了；{X}")
+    print(f"  {D}                               OpenList 顺手也取消了上游那一条。"
+          f"不是网盘拒绝，是它太慢{X}")
     print(f"  {D}· 一行都没有                    问题不在 OpenList，往浏览器/线路那边看{X}")
 
 


### PR DESCRIPTION
挂载页面报的是 `failed to list objs: Get https://open-api-drive.quark.cn/file?…: context canceled`，而脚本这边把它归进了「网盘接口超时」那一类 —— **归错了**，两者指向相反的一头：

| | 含义 | 证据指向 |
| --- | --- | --- |
| `deadline exceeded` | 等到了我们设的时限，网盘**没回话** | 网盘那边 |
| `canceled` | **发起方主动撤了** —— 网页等不下去先断开，OpenList 顺手把上游那条也取消 | 网盘可能根本没来得及答 |

结论方向不一样：前者要去查网盘接口，后者只说明「慢到了人先放弃」—— 慢的根子仍在网盘，但这一条本身**不是网盘拒绝的证据**。混成一句话，排查时会一直盯着网盘找一个它没犯的错。

`_short_err` 单独列一条；`ol-file.sh` 的报错对照表也补上这一行。

另外修一个我自己刚捅的语法错：那行说明里嵌了一对双引号，而它在 f-string 里，整段 heredoc 直接语法错误 —— 提交前只跑了 `bash -n`，没编译内嵌的 python。这次两个都验了。

v1.5.45 → v1.5.46

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_