### PR TITLE
tools/dav-check.sh：WebDAV 每个盘是 302 直链还是本机代理

### DIFF
--- a/README.md
+++ b/README.md
@@ -977,6 +977,7 @@ OpenList 顺手把上游那条也取消掉，说明的是「慢」而不是「�
 | `compare-speed.sh` | 把 MediaWarp 302 和 OpenList 转码流并排比 |
 | `ali-token.sh` | 查阿里的类型和令牌配不配对 |
 | `playing.sh` | 看正在播的那一路是直接播放还是转码 |
+| `dav-check.sh` | OpenList 自带的 WebDAV，每个盘是走 302 直链还是本机代理（决定了拿 Infuse / VidHub 直连值不值得，以及进度条拖不拖得动） |
 
 ⚠️ 拉这些脚本时给 URL 带个时间戳绕开 CDN 缓存，否则可能拿到几分钟前的旧版：
 `curl -fsSL "…/tools/xxx.sh?_t=$(date +%s)" -o /tmp/xxx.sh`

--- a/tools/dav-check.sh
+++ b/tools/dav-check.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# OpenList 自带的 WebDAV：每个盘走 302 直链还是本机代理。只读。
+#
+#   bash dav-check.sh              每个盘各挑一个视频量一遍
+#   bash dav-check.sh /quark       只量这一个盘
+#
+# 【为什么这件事必须量，不能猜】拿 Infuse / VidHub / Kodi 直接连 OpenList 的 WebDAV，
+# 是绕开 Emby 那一整套（strm、刮削、等扫描）最省事的路。但它值不值得走，全看一件事：
+#
+#   302 到网盘直链  →  视频从播放器直达网盘，不吃 VPS 带宽，进度条随便拖
+#   本机代理转发    →  每一个字节都经过你的 VPS，还得看上游认不认 Range
+#
+# 这两种在客户端里长得一模一样（都是"能播"），差别只在你的流量账单和能不能拖进度条。
+# 而它是【每个盘各自】的：同一台 OpenList 上，夸克可能 302、WebDAV 源必然代理。
+#
+# 路径从接口里取，不用手打中文 —— 裸 curl 打中文路径要自己转义，上一版就是这么 404 的。
+set -u
+
+TOOL_VER="2026-09-04a"          # 见 link-history.sh 里的说明：CDN 会缓存
+echo "  ${0##*/}  版本 $TOOL_VER"
+
+DIR="${MS_DIR:-/opt/media-stack}"
+OLPW="$(sed -nE 's/^OPENLIST_PASS=(.*)$/\1/p' "$DIR/.secrets" 2>/dev/null | head -1)"
+[ -n "$OLPW" ] || OLPW="$(sed -nE 's/^OPENLIST_PASS=(.*)$/\1/p' "$DIR/.env" 2>/dev/null | head -1)"
+[ -n "$OLPW" ] || { echo "✖ 读不到 OpenList 管理密码（$DIR/.secrets 里的 OPENLIST_PASS）"; exit 1; }
+
+export OL_PW="$OLPW" OL_ONLY="${1:-}"
+python3 - <<'PY'
+import base64, json, os, time, urllib.error, urllib.parse, urllib.request
+
+BASE = "http://127.0.0.1:5244"
+VIDEO = (".mp4", ".mkv", ".ts", ".avi", ".mov", ".flv", ".m4v", ".wmv", ".rmvb")
+G="\033[32m"; Y="\033[33m"; R="\033[31m"; D="\033[2m"; B="\033[1m"; X="\033[0m"
+pw = os.environ["OL_PW"]
+only = os.environ.get("OL_ONLY") or ""
+
+
+def api(path, body=None, tok=None, timeout=120, method="POST"):
+    data = json.dumps(body or {}).encode() if method == "POST" else None
+    req = urllib.request.Request(BASE + path, data=data, method=method,
+                                 headers={"Content-Type": "application/json",
+                                          **({"Authorization": tok} if tok else {})})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return json.loads(r.read().decode("utf-8", "replace"))
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """要的就是 302 本身。跟随了就看不见它到底 302 到哪儿去了。"""
+    def redirect_request(self, *a, **k):
+        return None
+
+
+try:
+    tok = (api("/api/auth/login", {"username": "admin", "password": pw},
+               timeout=20).get("data") or {}).get("token", "")
+except Exception as e:
+    print(f"{R}✖{X} 连不上 OpenList：{e}")
+    raise SystemExit(1)
+if not tok:
+    print(f"{R}✖{X} OpenList 登录失败（密码对不上？）")
+    raise SystemExit(1)
+
+try:
+    mounts = [str(s.get("mount_path") or "")
+              for s in ((api("/api/admin/storage/list?page=1&per_page=100", tok=tok,
+                             timeout=30, method="GET").get("data") or {}).get("content") or [])]
+except Exception as e:
+    print(f"{R}✖{X} 问不到存储列表：{e}")
+    raise SystemExit(1)
+if only:
+    mounts = [m for m in mounts if m == only]
+    if not mounts:
+        print(f"{R}✖{X} 没有叫「{only}」的挂载点")
+        raise SystemExit(1)
+
+
+def find_video(root, depth=6):
+    """从挂载点往下钻，找到第一个视频文件。找不到返回 ""。
+
+    【不带 refresh】这里只是要一个能拿来试的文件名，读缓存足够；带 refresh 会去打
+    那个本来就被限流的列目录接口，为了做个检测反而把线路搞得更堵。
+    """
+    path = root
+    for _ in range(depth):
+        try:
+            d = api("/api/fs/list", {"path": path, "password": "", "page": 1,
+                                     "per_page": 100, "refresh": False}, tok).get("data") or {}
+        except Exception:
+            return ""
+        items = d.get("content") or []
+        vids = [i for i in items
+                if not i.get("is_dir") and str(i.get("name", "")).lower().endswith(VIDEO)]
+        if vids:
+            return path.rstrip("/") + "/" + vids[0]["name"]
+        dirs = [i for i in items if i.get("is_dir")]
+        if not dirs:
+            return ""
+        path = path.rstrip("/") + "/" + dirs[0]["name"]
+    return ""
+
+
+auth = "Basic " + base64.b64encode(f"admin:{pw}".encode()).decode()
+print()
+print(f"  {B}OpenList 的 WebDAV：每个盘走哪条路{X}")
+print("=" * 62)
+
+for mp in mounts:
+    f = find_video(mp)
+    if not f:
+        print(f"  {mp:<16}{Y}没找到视频文件{X}  {D}（空盘，或者列目录没通）{X}")
+        continue
+    # WebDAV 的地址要按 URL 转义 —— 中文原样塞进去 urllib 直接 UnicodeEncodeError
+    url = BASE + "/dav" + urllib.parse.quote(f, safe="/")
+    req = urllib.request.Request(url, headers={"Authorization": auth,
+                                               "User-Agent": "Mozilla/5.0",
+                                               "Range": "bytes=0-1023"})
+    t0 = time.monotonic()
+    try:
+        with urllib.request.build_opener(_NoRedirect).open(req, timeout=90) as r:
+            n = len(r.read(1024))
+            code, loc = r.status, ""
+    except urllib.error.HTTPError as e:
+        code, loc, n = e.code, e.headers.get("Location", ""), 0
+    except Exception as e:
+        print(f"  {mp:<16}{R}没回话{X}  {D}{type(e).__name__}　{f}{X}")
+        continue
+    el = time.monotonic() - t0
+
+    if code in (301, 302, 303, 307, 308):
+        host = loc.split("/")[2] if "://" in loc else loc[:40]
+        print(f"  {mp:<16}{G}302 → 网盘直链{X}  {D}{el:.1f} 秒　{host}{X}")
+        print(f"  {' ':<16}{D}视频不经过 VPS，进度条能拖{X}")
+    elif code == 206:
+        print(f"  {mp:<16}{Y}本机代理（206）{X}  {D}{el:.1f} 秒{X}")
+        print(f"  {' ':<16}{D}每个字节都过你的 VPS；Range 认，进度条能拖{X}")
+    elif code == 200:
+        print(f"  {mp:<16}{R}本机代理，且不认 Range（200）{X}  {D}{el:.1f} 秒{X}")
+        print(f"  {' ':<16}{R}进度条拉不动，跳转只能从头下{X}")
+    else:
+        print(f"  {mp:<16}{R}HTTP {code}{X}  {D}{el:.1f} 秒{X}")
+    print(f"  {' ':<16}{D}{f}{X}")
+
+print()
+print(f"  {D}客户端连法：https://list.<你的域名>/dav/　账号 admin + OpenList 的密码{X}")
+print(f"  {D}（list 这个子域没套 Basic Auth，Infuse / VidHub / Kodi 直接连就行）{X}")
+print()
+print(f"  {D}这条路的取舍：省掉 Emby 那一整套（strm、刮削、等扫描），新片放进网盘就在；{X}")
+print(f"  {D}代价是没有海报简介、没有跨设备的观看进度、也没有分账号的权限隔离 ——{X}")
+print(f"  {D}私密库靠的就是 Emby 的账号，WebDAV 这边谁有密码谁全看。两条路可以并存。{X}")
+PY

--- a/tools/ol-file.sh
+++ b/tools/ol-file.sh
@@ -14,7 +14,7 @@
 #   ③ 拉 1 MiB     慢 = 地址拿到了但拉不动，那是限速/线路
 set -u
 
-TOOL_VER="2026-09-02a"          # 见 link-history.sh 里的说明：CDN 会缓存
+TOOL_VER="2026-09-04a"          # 见 link-history.sh 里的说明：CDN 会缓存
 echo "  ${0##*/}  版本 $TOOL_VER"
 
 P="${1:-}"
@@ -27,7 +27,21 @@ OLPW="$(sed -nE 's/^OPENLIST_PASS=(.*)$/\1/p' "$DIR/.secrets" 2>/dev/null | head
 
 export OL_PATH="$P" OL_PW="$OLPW"
 python3 - <<'PY'
-import json, os, re, subprocess, time, urllib.error, urllib.request
+import json, os, re, subprocess, time, urllib.error, urllib.parse, urllib.request
+
+
+def safe_url(u):
+    """把地址里的非 ASCII 字符转义掉，不然 urllib 直接 UnicodeEncodeError。
+
+    【为什么以前没暴露】夸克、阿里那种 CDN 直链本来就是转义好的，一路都对。而
+    【代理型存储】（WebDAV、本地盘）返回的是 OpenList 自己的 /d/ 地址 —— 路径里
+    原样带着中文。于是恰恰是最需要量一量的那类盘，第三步张口就报 UnicodeEncodeError，
+    连"能不能拉"都没测到。safe 里留着 % ，避免把已经转义过的再转一遍。
+    """
+    p = urllib.parse.urlsplit(u)
+    return urllib.parse.urlunsplit((p.scheme, p.netloc,
+                                    urllib.parse.quote(p.path, safe="/%"),
+                                    p.query, p.fragment))
 
 BASE = "http://127.0.0.1:5244"
 G="\033[32m"; Y="\033[33m"; R="\033[31m"; C="\033[36m"; D="\033[2m"; B="\033[1m"; X="\033[0m"
@@ -243,18 +257,32 @@ except Exception as e:
 # ---- ③ 真的拉一段，确认这条地址能不能出数据 ----
 if raw.startswith("http"):
     N = 1 << 20
-    req = urllib.request.Request(raw, headers={"User-Agent": "Mozilla/5.0",
-                                               "Range": f"bytes=0-{N - 1}"})
+    req = urllib.request.Request(safe_url(raw),
+                                 headers={"User-Agent": "Mozilla/5.0",
+                                          "Range": f"bytes=0-{N - 1}"})
     try:
         t0 = time.monotonic()
         with urllib.request.urlopen(req, timeout=60) as resp:
             got = len(resp.read(N))
+            code = resp.status
         t = time.monotonic() - t0
         mbps = got * 8 / t / 1e6 if t > 0 else 0
         c = G if mbps >= 8 else (Y if mbps >= 3 else R)
         print(f"  ③ 拉 1 MiB    {c}{t:6.1f} 秒{X}  {got / 1024:.0f} KB  "
               f"{c}{mbps:.1f} Mbps{X}"
               f"{D}（{got / t / 1024:.0f} KB/s）{X}")
+        # 【206 还是 200，决定了能不能拖进度条】我们发的是 Range 请求：
+        #   206 Partial Content = 对方认 Range，播放器想从哪儿开始就从哪儿开始
+        #   200 OK              = 不认，整个文件从头发。播放器要跳到 30 分钟处，
+        #                         只能把前 30 分钟全下下来 —— 表现就是"进度条拉不动、
+        #                         只能从头看"，而且流量白烧一遍
+        # 这一条对【代理型存储】（WebDAV、本地盘这些没有 CDN 直链的）尤其要紧：
+        # 那条路上 OpenList 要把 Range 透传给上游，上游还得自己支持，缺一环都不行。
+        if code == 206:
+            print(f"  {D}   └ 断点续传  {G}支持{X}{D}（206）—— 进度条能拖{X}")
+        else:
+            print(f"  {D}   └ 断点续传  {R}不支持{X}{D}（HTTP {code}，我们要的是 206）"
+                  f" —— 进度条拉不动，跳转只能从头下{X}")
     except urllib.error.HTTPError as e:
         print(f"  ③ 拉 1 MiB    {R}HTTP {e.code}{X}  地址拿到了，网盘拒绝下载")
     except Exception as e:


### PR DESCRIPTION
OpenList 自己就是一台 WebDAV 服务器，挂进去的盘在 `/dav` 下全都现成可用 —— 拿 Infuse / VidHub / Kodi 直连，是绕开 Emby 那一整套（strm、刮削、等扫描）最省事的路。但它值不值得走，全看一件事：

```
302 到网盘直链  →  视频从播放器直达网盘，不吃 VPS 带宽，进度条随便拖
本机代理转发    →  每一个字节都经过 VPS，还得看上游认不认 Range
```

这两种在客户端里**长得一模一样**（都是「能播」），差别只在流量账单和能不能拖进度条。而且它是**每个盘各自**的：同一台 OpenList 上，夸克可能 302、WebDAV 源必然代理。没有这个数，整条路只能靠猜。

两个实现上的点：

- **路径从接口里取，不用手打中文** —— 裸 curl 打中文路径要自己转义，上一轮就是这么 404 的，白花一个来回
- 找文件时**不带 refresh**：只是要个能拿来试的文件名，读缓存足够；带 refresh 等于为了做个检测反而去打那个本来就被限流的列目录接口

### 验证

拿假 OpenList 演三种盘实测：

```
/quark        302 → 网盘直链      video-play.quark.cn    视频不经过 VPS，进度条能拖
/aliyun       本机代理（206）                            每个字节都过 VPS；Range 认
/七米蓝影视    本机代理，且不认 Range（200）              进度条拉不动，跳转只能从头下
```

指定单个盘、指定不存在的盘也各验过。

另外补上闭合的 `PY` —— heredoc 少了结尾标记，bash 会警告 `here-document delimited by end-of-file`，虽然照跑但是错的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_