### PR TITLE
拉诊断脚本的那句 CDN 提示是错的，?_t= 挡不住

### DIFF
--- a/README.md
+++ b/README.md
@@ -1001,8 +1001,19 @@ OpenList 顺手把上游那条也取消掉，说明的是「慢」而不是「�
 | `playing.sh` | 看正在播的那一路是直接播放还是转码 |
 | `dav-check.sh` | OpenList 自带的 WebDAV，每个盘是走 302 直链还是本机代理（决定了拿 Infuse / VidHub 直连值不值得，以及进度条拖不拖得动） |
 
-⚠️ 拉这些脚本时给 URL 带个时间戳绕开 CDN 缓存，否则可能拿到几分钟前的旧版：
-`curl -fsSL "…/tools/xxx.sh?_t=$(date +%s)" -o /tmp/xxx.sh`
+⚠️ **拉这些脚本会拿到旧版**，而且屏上看不出来 —— 每个脚本第一行都会打印自己的
+`版本 xxx`，对不上就是拿到旧的了（不是「改了没用」）。
+
+`raw.githubusercontent.com` 有 CDN 缓存，**加 `?_t=$(date +%s)` 挡不住** —— 实测：
+带着时间戳连拉两次，拿到的都还是几分钟前那一版。可靠的办法是**指定提交号**：
+
+```bash
+SHA=$(curl -fsSL https://api.github.com/repos/bgpeer/nodekit/commits/main | \
+      sed -nE 's/.*"sha": "([0-9a-f]{40})".*/\1/p' | head -1)
+curl -fsSL "https://raw.githubusercontent.com/bgpeer/nodekit/$SHA/tools/xxx.sh" -o /tmp/xxx.sh
+```
+
+提交号是内容的一部分，那条 URL 永远只对应那一份文件，不存在缓存问题。
 
 ### 三条硬限制
 


### PR DESCRIPTION
README 一直教人给 URL 带个时间戳绕开 `raw.githubusercontent.com` 的 CDN 缓存。

**实测挡不住**：带着 `?_t=$(date +%s)` 连拉两次，拿到的都还是几分钟前那一版（脚本自己打印的版本号对不上 —— 这也正是那个版本号存在的意义）。而人照着做了、又看到版本号不对，只会更糊涂。

改成指定提交号：

```bash
SHA=$(curl -fsSL https://api.github.com/repos/bgpeer/nodekit/commits/main | \
      sed -nE 's/.*"sha": "([0-9a-f]{40})".*/\1/p' | head -1)
curl -fsSL "https://raw.githubusercontent.com/bgpeer/nodekit/$SHA/tools/xxx.sh" -o /tmp/xxx.sh
```

提交号是内容的一部分，那条 URL 永远只对应那一份文件，不存在缓存问题。已实拉验证：按提交号取到的是刚合并的那一版。

顺带把「**对不上版本号 = 拿到旧的了，不是改了没用**」这句话摆到显眼处 —— 原来只写在 `link-history.sh` 的注释里，而看到问题的人不会去读那个文件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_