### PR TITLE
摘要那行印出「原样（默认）」—— 兜底那行写成了反选，新加的开关一律漏进去

### DIFF
--- a/media-stack.py
+++ b/media-stack.py
@@ -36,7 +36,7 @@ import zipfile
 
 # 版本号：改了代码就 +1，让「7 更新」能显示 vX → vY。
 # 仓库主人定的规矩：只动最后一位，1.5.0 一路加到 1.5.999，前两位不要自己动。
-SCRIPT_VERSION = "1.5.61"
+SCRIPT_VERSION = "1.5.62"
 
 # 本脚本在仓库里的地址，「更新」时用它把自己换成最新版
 SELF_URL = "https://raw.githubusercontent.com/bgpeer/nodekit/main/media-stack.py"
@@ -9967,8 +9967,12 @@ def drive_channel(d, mp, drv):
     if not sw:
         return "原画直链", False
     names = [_opt_name(o, c) for k, _w, _t, o, c in sw if k in QUALITY_KEYS] or ["原画直链"]
+    # 【"默认就不写"的那几类要在这里一并排掉】这一行是通道类开关的兜底，条件写成
+    # 反选（w != "source"）就意味着【以后新加的每一类都会默认落进来】—— 探测 UA
+    # 就是这么漏出去的：下面明明只在非默认时才追加，屏上照样印出「原样（默认）」，
+    # 因为这一行已经无条件把它捞进去了。
     names += [_opt_name(o, c) for k, w, _t, o, c in sw
-              if k not in QUALITY_KEYS and w != "source"]
+              if k not in QUALITY_KEYS and w not in ("source", "ua")]
     names += [_opt_name(o, c) for _k, w, _t, o, c in sw
               if w == "source" and c != "direct"]
     # 默认状态不占屏，反常状态必须显眼 —— 跟上面 source 一个规矩


### PR DESCRIPTION
`drive_channel` 里通道类开关那一行的条件是 `w != "source"`，**反选**。意思就是**以后新加的每一类都默认落进来** —— 探测 UA 就是这么漏出去的：下面明明只在非默认时才追加它，屏上照样印着

```
2. 直链方式   当前：原画直链 · 原样（默认） · 本机代理
```

因为上面那行已经无条件把它捞进去了。

这一屏的规矩是「默认状态不占屏，反常状态才显眼」（回源方式一直是这么做的），默认值印出来等于把这条规矩废掉：一眼扫过去分不出哪些是自己改过的。

条件改成排除 `source` 和 `ua` 两类。改完：

| 状态 | 摘要行 |
|---|---|
| 本机代理 + UA 原样 | `原画直链 · 本机代理` |
| 本机代理 + UA 伪装 | `原画直链 · 本机代理 · 伪装成浏览器` |
| 302 直链 + 转码流 | `转码流` |

版本：`1.5.61` → `1.5.62`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_