### PR TITLE
片名没匹配上，就断言「strm 还没进库」—— 而那是三种可能里最少见的一种

### DIFF
--- a/tools/cant-play.sh
+++ b/tools/cant-play.sh
@@ -20,7 +20,7 @@
 # 猜是猜不出来的，一段一段问，坏在哪一段就报哪一段。
 set -u
 
-TOOL_VER="2026-09-05a"          # 见 link-history.sh 里的说明：CDN 会缓存
+TOOL_VER="2026-09-05b"          # 见 link-history.sh 里的说明：CDN 会缓存
 echo "  ${0##*/}  版本 $TOOL_VER"
 
 Q="${1:-}"
@@ -112,9 +112,36 @@ hit = [i for i in items
        if Q.lower() in str(i.get("Name") or "").lower()
        or Q.lower() in str(i.get("Path") or "").lower()]
 if not hit:
-    print(f"  {R}✖ Emby 里没有匹配「{Q}」的条目{X}")
-    print(f"  {D}strm 还没进库。点「5 生成媒体库」，完了看它最后那段"
-          f"「Emby 媒体库可以指向这些路径」有没有建库。{X}")
+    print(f"  {R}✖ Emby 里没有匹配「{safe(Q)}」的条目{X}")
+    # 【先数一数，别急着下结论】库里有没有东西是当场能数出来的。上一版不数，
+    # 张口就说「strm 还没进库，点 5 生成媒体库」—— 而那是三种可能里最少见的
+    # 一种。实测把说明里的占位词原样敲进来，得到的就是这句，于是人以为库没建，
+    # 去重扫一遍，白等半小时，回来还是同一句话。
+    if not items:
+        print(f"  {D}Emby 库里一个条目都没有 —— 这种情况才轮得到重建库。{X}")
+        print(f"  {B}修：点一次「5 生成媒体库」{X}{D}，完了看它最后那段"
+              f"「Emby 媒体库可以指向这些路径」有没有建库。{X}")
+        raise SystemExit
+    print(f"  {D}库里现在有 {len(items)} 个条目，所以多半只是【片名对不上】——"
+          f"打错了，或者填的不是 Emby 里显示的那个名字。{X}")
+    # 【给几个能直接抄的名字】一个照着做的例子胜过一句正确的废话。按盘分组，
+    # 人要查哪个盘的片子就从那一组里挑一个。
+    by_drive = {}
+    for i in items:
+        p = str(i.get("Path") or "")
+        mount = (p[len("/data/strm/"):].split("/")[0]
+                 if p.startswith("/data/strm/") else "其它")
+        by_drive.setdefault(mount, []).append(str(i.get("Name") or ""))
+    print()
+    print(f"  {D}库里现有的片名，一个盘举三个（抄一个填进去就行）：{X}")
+    for mount in sorted(by_drive)[:5]:
+        names = [n for n in by_drive[mount] if n][:3]
+        print(f"    {C}{mount}{X}  {D}（共 {len(by_drive[mount])} 个）{X}")
+        for n in names:
+            print(f"      {D}·{X} {n[:44]}")
+    print()
+    print(f"  {D}片名只填一小段就行，不用全名 —— 它是按包含匹配的，"
+          f"路径里的字也算。{X}")
     raise SystemExit
 
 def _facts(i):


### PR DESCRIPTION
实测撞上的：把说明里的**占位词**「七米蓝里某部片名」原样敲了进去，脚本回

```
✖ Emby 里没有匹配「七米蓝里某部片名」的条目
strm 还没进库。点「5 生成媒体库」…
```

于是人得到的结论是「他竟然说我没生成媒体库」—— 库里明明有 2783 个条目。

诊断工具把一个**打字问题**报成了**系统故障**，这比不给结论更坏：它会把人支去重扫一遍库，白等半小时，回来还是同一句话。

## 找不到条目一共三种可能，按实际频率排

1. 片名对不上（打错、写的是文件名不是刮削后的片名、填了占位词）
2. 这部片子确实不在库里
3. 整个库是空的 ← **只有这一种**才轮得到「点 5 生成媒体库」

分辨它们不用猜——库里有多少条目当场就能数出来。

## 改法

- **库里一个条目都没有** → 才说「点 5 生成媒体库」，那时这句话是对的
- **库里有东西** → 报出总数，点破多半只是片名对不上，然后**按盘列几个真实存在的片名**让人直接抄一个。一个能照着做的例子胜过一句正确的废话
- 补一句「只填一小段就行，路径里的字也算」—— 它本来就是包含匹配，而上一版从没说过，人会以为要一字不差
- 顺带把回显的片名过了脱敏（`safe`），那串是用户输入的

## 效果

```
✖ Emby 里没有匹配「七米蓝里某部片名」的条目
库里现在有 2783 个条目，所以多半只是【片名对不上】——打错了，或者填的不是 Emby 里显示的那个名字。

库里现有的片名，一个盘举三个（抄一个填进去就行）：
  aliyun      （共 412 个）
    · …
  quark       （共 1103 个）
    · …
  七米蓝影视   （共 1268 个）
    · …

片名只填一小段就行，不用全名 —— 它是按包含匹配的，路径里的字也算。
```

`bash -n` + 内嵌 python 单独 `py_compile` 都过；两条分支（库空 / 库非空）都实跑验证过。

`cant-play.sh`：`2026-09-05a` → `2026-09-05b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw

---
_Generated by [Claude Code](https://claude.ai/code/session_015iLfUz3pdSEFfF8pDMCwgw)_