### PR TITLE
小火箭模板删掉写死的 6 个国家组，交回给脚本按实际节点自动生成

### DIFF
--- a/shadowrocket-template.conf
+++ b/shadowrocket-template.conf
@@ -22,34 +22,28 @@ block-quic = all-proxy
 __XY_NODES__
 
 [Proxy Group]
-🌍全球加速 = select,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,policy-regex-filter=.*,policy-select-name=♻️全部随机
-🎷抖音 = select,🎯直连,🌍全球加速,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,policy-regex-filter=.*,policy-select-name=🎯直连
-🎬TikTok = select,🌍全球加速,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
-🎮国际游戏 = select,🌍全球加速,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
-💻Telegram = select,🌍全球加速,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
-🧠OpenAI = select,🌍全球加速,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
-🤖Claude = select,🌍全球加速,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
-💳PayPal = select,🌍全球加速,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
-🌐Google服务 = select,🌍全球加速,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
-📱Meta = select,🌍全球加速,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
-🐦X = select,🌍全球加速,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
-📽️Netflix = select,🌍全球加速,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
-😈GitHub = select,🌍全球加速,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
-😊微软服务 = select,🎯直连,🌍全球加速,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,policy-regex-filter=.*,policy-select-name=🎯直连
-🍎苹果服务 = select,🎯直连,🌍全球加速,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,policy-regex-filter=.*,policy-select-name=🎯直连
-💰加密货币 = select,🎯直连,🌍全球加速,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,policy-regex-filter=.*,policy-select-name=🎯直连
-📺哔哩哔哩 = select,🎯直连,🌍全球加速,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,policy-regex-filter=.*,policy-select-name=🎯直连
-📕小红书 = select,🎯直连,🌍全球加速,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,policy-regex-filter=.*,policy-select-name=🎯直连
+🌍全球加速 = select,♻️全部随机__XY_NAMES__,policy-regex-filter=.*,policy-select-name=♻️全部随机
+🎷抖音 = select,🎯直连,🌍全球加速,♻️全部随机__XY_NAMES__,policy-regex-filter=.*,policy-select-name=🎯直连
+🎬TikTok = select,🌍全球加速,♻️全部随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
+🎮国际游戏 = select,🌍全球加速,♻️全部随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
+💻Telegram = select,🌍全球加速,♻️全部随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
+🧠OpenAI = select,🌍全球加速,♻️全部随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
+🤖Claude = select,🌍全球加速,♻️全部随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
+💳PayPal = select,🌍全球加速,♻️全部随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
+🌐Google服务 = select,🌍全球加速,♻️全部随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
+📱Meta = select,🌍全球加速,♻️全部随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
+🐦X = select,🌍全球加速,♻️全部随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
+📽️Netflix = select,🌍全球加速,♻️全部随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
+😈GitHub = select,🌍全球加速,♻️全部随机__XY_NAMES__,🎯直连,policy-regex-filter=.*,policy-select-name=🌍全球加速
+😊微软服务 = select,🎯直连,🌍全球加速,♻️全部随机__XY_NAMES__,policy-regex-filter=.*,policy-select-name=🎯直连
+🍎苹果服务 = select,🎯直连,🌍全球加速,♻️全部随机__XY_NAMES__,policy-regex-filter=.*,policy-select-name=🎯直连
+💰加密货币 = select,🎯直连,🌍全球加速,♻️全部随机__XY_NAMES__,policy-regex-filter=.*,policy-select-name=🎯直连
+📺哔哩哔哩 = select,🎯直连,🌍全球加速,♻️全部随机__XY_NAMES__,policy-regex-filter=.*,policy-select-name=🎯直连
+📕小红书 = select,🎯直连,🌍全球加速,♻️全部随机__XY_NAMES__,policy-regex-filter=.*,policy-select-name=🎯直连
 ⛩️阿里腾讯 = select,🎯直连,🌍全球加速,policy-select-name=🎯直连
 🎯直连 = select,DIRECT,🌍全球加速,policy-select-name=DIRECT
 🤡漏网之鱼 = select,🌍全球加速,🎯直连,policy-select-name=🌍全球加速
 
-🇭🇰香港随机 = url-test,url=http://www.gstatic.com/generate_204,interval=120,tolerance=30,timeout=5,select=0,policy-regex-filter=🇭🇰|HK|Hong|hong|香港|深港|沪港|京港|港
-🇹🇼台湾随机 = url-test,url=http://www.gstatic.com/generate_204,interval=120,tolerance=30,timeout=5,select=0,policy-regex-filter=🇹🇼|TW|TWN|Taiwan|Taipei|台湾|台灣|台北
-🇯🇵日本随机 = url-test,url=http://www.gstatic.com/generate_204,interval=120,tolerance=30,timeout=5,select=0,policy-regex-filter=🇯🇵|JP|Japan|japan|Tokyo|东京|大阪|日本
-🇸🇬新加坡随机 = url-test,url=http://www.gstatic.com/generate_204,interval=120,tolerance=30,timeout=5,select=0,policy-regex-filter=🇸🇬|SG|Singapore|singapore|新加坡|狮城
-🇰🇷韩国随机 = url-test,url=http://www.gstatic.com/generate_204,interval=120,tolerance=30,timeout=5,select=0,policy-regex-filter=🇰🇷|KR|Korea|korea|韩国|首尔
-🇺🇸美国随机 = url-test,url=http://www.gstatic.com/generate_204,interval=120,tolerance=30,timeout=5,select=0,policy-regex-filter=🇺🇸|🇺🇲|US|USA|America|美国|洛杉矶|纽约|西雅图|圣何塞|硅谷
 __XY_GROUPS__
 ♻️全部随机 = url-test,url=http://www.gstatic.com/generate_204,interval=120,tolerance=30,timeout=5,policy-regex-filter=.*
 


### PR DESCRIPTION
## 为什么删

写死的国家组有两个毛病：

1. **没有那个国家的节点时会留一个空组**（只有美国节点，港台日新韩五个组照样在面板上占位）
2. **成员靠小火箭自己的 `policy-regex-filter` 收拢**，依赖客户端正则引擎；而脚本本来就会
   算好成员显式列进去（老模板就是这么做的，稳）

## 一起删的

**服务组行里写死的那 6 个国家名也删了** —— 组定义没了还留着名字就是悬空引用：

```diff
- 🌍全球加速 = select,♻️全部随机,🇭🇰香港随机,🇹🇼台湾随机,🇯🇵日本随机,🇸🇬新加坡随机,🇰🇷韩国随机,🇺🇸美国随机__XY_NAMES__,policy-regex-filter=.*,…
+ 🌍全球加速 = select,♻️全部随机__XY_NAMES__,policy-regex-filter=.*,…
```

名字改回由 `__XY_NAMES__` 提供，**只展开实际存在的国家**。

删掉之后 `_sr_group_names` 不再把国家组算作「模板已有」，`_sr_country_groups` 就会按
`COUNTRY_GROUPS` 检测并生成，成员显式列出，连英国/德国/`🎲其他随机` 一起覆盖。

上一版为兼容写死国家组加的「`__XY_NAMES__` 按行去重」**保留** —— 自定义模板真写死了
国家组时仍然防重复。

## 回归（离线，跑全套函数 + 引用完整性检查）

**A — 只有美国节点（脚本默认名带 `🇺🇲`）**

```
🇺🇸美国随机 = url-test,🇺🇲 VLESS_Reality_Vision,🇺🇲 AnyTLS,🇺🇲 Hysteria2_TLS,🇺🇲 Trojan_TCP,url=…
🌍全球加速 = select,♻️全部随机,🇺🇸美国随机,policy-regex-filter=.*,policy-select-name=♻️全部随机
```

只建一个组，港台日新韩不再空占位。

**B — 美+日+德+1 个漏网**

```
🇯🇵日本随机 = url-test,🇯🇵 JP1,🇯🇵 JP2,url=…
🇺🇸美国随机 = url-test,🇺🇲 A,🇺🇲 B,url=…
🇩🇪德国随机 = url-test,🇩🇪 DE1,🇩🇪 DE2,url=…
🎲其他随机 = url-test,🎈自建中转,url=…
🌍全球加速 = select,♻️全部随机,🇯🇵日本随机,🇺🇸美国随机,🇩🇪德国随机,🎲其他随机,…
```

**C — 全是没国家标记的名字**

```
🌍全球加速 = select,♻️全部随机,policy-regex-filter=.*,policy-select-name=♻️全部随机
```

一个国家组都不建。

三种情形都通过：锚点清干净（`__XY` 不残留）、`FINAL,🤡漏网之鱼` 和 `dns-server` 行都在
（`_sr_direct_ip` / `_sr_selfdns` 靠它们定位）、**`select` 行引用的组名全部有定义，无悬空引用**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqKxHpC9nKXiUUkhwfLHt2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqKxHpC9nKXiUUkhwfLHt2)_