### PR TITLE
mihomo 模板：国内 DNS 挂 #🎯直连，不再依赖规则引擎判定

### DIFF
--- a/sub-template.yaml
+++ b/sub-template.yaml
@@ -61,7 +61,13 @@ tun:
   route-exclude-cidr: ["192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12", "100.64.0.0/10", "fc00::/7", "fe80::/10"]
 
 dns-anchor:
-  cn-dns: &cn-dns ["https://223.5.5.5/dns-query", "https://doh.pub/dns-query"]
+  # 国内 DNS 后面挂 #🎯直连：这两台【必须直连】，绕到境外出口去问阿里/腾讯，
+  # 拿回来的是境外视角的解析结果，国内 CDN 全跑偏。
+  # 为什么不靠 rules 里的 cn-ip 兜：dns.respect-rules 打开后 DNS 查询也走规则引擎，
+  # 而规则集是远程拉的——启动那几秒还没下载完，RULE-SET 一条都匹配不上，
+  # 查询直接掉到 MATCH → 🤡漏网之鱼 → 代理（实测连接详情里「规则」显示 Match）。
+  # 写在 nameserver 自己身上就不经过规则引擎，配置一加载就生效。
+  cn-dns: &cn-dns ["https://223.5.5.5/dns-query#🎯直连", "https://doh.pub/dns-query#🎯直连"]
   global-dns: &global-dns ["https://1.1.1.1/dns-query", "https://8.8.8.8/dns-query", "https://9.9.9.9/dns-query", "tls://1.1.1.1:853", "tls://8.8.8.8:853"]
 
 dns:
@@ -81,7 +87,7 @@ dns:
   fake-ip-filter: ["localhost","+.lan","+.local","+.arpa","+.ntp.org","captive.apple.com","connectivitycheck.gstatic.com","msftconnecttest.com","msftncsi.com","openai.*","+.openai.*","report-v2.samsung.japps.cn","rule-set:private"]
   direct-nameserver: ["system"]
   default-nameserver: ["223.5.5.5", "119.29.29.29"]
-  nameserver: ["https://223.5.5.5/dns-query", "https://doh.pub/dns-query", "https://1.1.1.1/dns-query", "https://8.8.8.8/dns-query", "https://9.9.9.9/dns-query", "tls://1.1.1.1:853", "tls://8.8.8.8:853"]
+  nameserver: ["https://223.5.5.5/dns-query#🎯直连", "https://doh.pub/dns-query#🎯直连", "https://1.1.1.1/dns-query", "https://8.8.8.8/dns-query", "https://9.9.9.9/dns-query", "tls://1.1.1.1:853", "tls://8.8.8.8:853"]
   proxy-server-nameserver: ["https://1.1.1.1/dns-query", "https://8.8.8.8/dns-query", "https://9.9.9.9/dns-query"]
   direct-nameserver-follow-policy: true
   nameserver-policy:


### PR DESCRIPTION
## 改动

只动**国内**那两台，境外的一个没碰：

```diff
 dns-anchor:
-  cn-dns: &cn-dns ["https://223.5.5.5/dns-query", "https://doh.pub/dns-query"]
+  cn-dns: &cn-dns ["https://223.5.5.5/dns-query#🎯直连", "https://doh.pub/dns-query#🎯直连"]
   global-dns: &global-dns ["https://1.1.1.1/dns-query", ...]          ← 没动

 dns:
-  nameserver: ["https://223.5.5.5/dns-query", "https://doh.pub/dns-query", "https://1.1.1.1/dns-query", ...]
+  nameserver: ["https://223.5.5.5/dns-query#🎯直连", "https://doh.pub/dns-query#🎯直连", "https://1.1.1.1/dns-query", ...]
```

`cn-dns` 是锚点，`nameserver-policy` 里 8 条国内域名策略（抖音 / B站 / 小红书 /
阿里腾讯 / 加密货币 / games-cn / cn-domain）全都引用它，改一行 8 条一起生效。

## 为什么

`dns.respect-rules: true` 让 DNS 查询也走规则引擎——本意是让境外 DNS 经代理出去、
不被污染。副作用是**国内那两台也被丢进规则引擎**，靠倒数第二条
`RULE-SET,cn-ip,🎯直连,no-resolve` 兜。而规则集是远程拉的，启动那几秒还没下载完，
所有 `RULE-SET` 一条都匹配不上，查询就掉到 `MATCH` → `🤡漏网之鱼` → 代理。

用户实测的连接详情坐实了这一点：

```
目标地址   223.5.5.5:443
规则       Match
目标 IP ASN 45102 Alibaba (US)
代理链     🇯🇵·reality-grpc ← ♻️全部随机 ← 🌍全球加速 ← 🤡漏网之鱼
```

拿国外出口去问阿里 DNS，解析结果按境外视角返回，国内 CDN 全跑偏，还会进缓存。

写在 nameserver 自己身上就**不经过规则引擎**，配置一加载就生效，跟规则集下载快慢、
跟 cn-ip 匹配得对不对都无关。

## 规则数据本身没问题（另外查过）

`geo/geoip/cn` 里 `223.0.0.0/12` 覆盖 `223.5.5.5`，客户端里也确实加载着。
用户截图里看不到 `223.4.0.0/14` 和 `223.5.5.5/32`，是因为 mihomo 编 mrs 时把**被包含
的段合并进 `/12`** 了（9405 → 8270 条），属正常。

## 不动的部分（有意的）

| | 为什么不动 |
|---|---|
| `global-dns` | 必须走代理，现在靠 MATCH 兜底结果也对 |
| `proxy-server-nameserver` | mihomo 本就强制直连这一栏 |
| `default-nameserver` | bootstrap 只收裸 IP |
| `direct-nameserver` | `system`，无关 |

## 验证

raw 模板本身不是合法 YAML（`__XY_NAMES__` 是行内锚点，**改动前也一样报错**），
所以走真实渲染流程验：`_fill_block` 替换锚点后 `yaml.safe_load` 通过。

```
nameserver:  https://223.5.5.5/dns-query#🎯直连
             https://doh.pub/dns-query#🎯直连
             https://1.1.1.1/dns-query          ← 原样
             https://8.8.8.8/dns-query          ← 原样
国内域名用的 (cn-dns): 两台都带 #🎯直连
境外域名用的 (global-dns): 原样
proxy-server / default / direct-nameserver: 逐项确认原样
🎯直连 组在 proxy-groups 里存在 ✓
```

## 已知取舍

`🎯直连` 组的成员是 `["DIRECT", "🌍全球加速"]`。如果有人把这个组切到 `🌍全球加速`，
国内 DNS 会跟着走代理，这个问题就回来了。写 `#DIRECT` 可以免疫，但会失去
"跟着直连组走"的一致性。**按仓库作者的选择用 `🎯直连`。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqKxHpC9nKXiUUkhwfLHt2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqKxHpC9nKXiUUkhwfLHt2)_