### PR TITLE
DNS 出站全部钉死：sing-box bootstrap 补 detour，mihomo 境外 DNS 钉 #🌍全球加速

### DIFF
--- a/sub-template.yaml
+++ b/sub-template.yaml
@@ -62,7 +62,12 @@ tun:
 
 dns-anchor:
   cn-dns: &cn-dns ["https://223.5.5.5/dns-query#🎯直连", "https://doh.pub/dns-query#🎯直连"]
-  global-dns: &global-dns ["https://1.1.1.1/dns-query", "https://8.8.8.8/dns-query", "https://9.9.9.9/dns-query", "tls://1.1.1.1:853", "tls://8.8.8.8:853"]
+  # 境外 DNS 钉 #🌍全球加速：它们【必须走代理】，直连在国内会被污染/拦掉。
+  # 现在的结果本来就是走代理，但那是「1.1.1.1 命中 cloudflare-ip、8.8.8.8 命中
+  # google-ip、9.9.9.9 一条没命中掉到 MATCH → 🤡漏网之鱼」凑出来的——既依赖规则集
+  # 已下载完，又依赖 🤡漏网之鱼 当前选的是 🌍全球加速。谁把漏网之鱼切成 🎯直连，
+  # 冷启动时境外 DNS 就全部直连，境外域名解析直接废掉。钉住之后跟这两件事都无关。
+  global-dns: &global-dns ["https://1.1.1.1/dns-query#🌍全球加速", "https://8.8.8.8/dns-query#🌍全球加速", "https://9.9.9.9/dns-query#🌍全球加速", "tls://1.1.1.1:853#🌍全球加速", "tls://8.8.8.8:853#🌍全球加速"]
 
 dns:
   enable: true
@@ -81,7 +86,7 @@ dns:
   fake-ip-filter: ["localhost","+.lan","+.local","+.arpa","+.ntp.org","captive.apple.com","connectivitycheck.gstatic.com","msftconnecttest.com","msftncsi.com","openai.*","+.openai.*","report-v2.samsung.japps.cn","rule-set:private"]
   direct-nameserver: ["system"]
   default-nameserver: ["223.5.5.5", "119.29.29.29"]
-  nameserver: ["https://223.5.5.5/dns-query#🎯直连", "https://doh.pub/dns-query#🎯直连", "https://1.1.1.1/dns-query", "https://8.8.8.8/dns-query", "https://9.9.9.9/dns-query", "tls://1.1.1.1:853", "tls://8.8.8.8:853"]
+  nameserver: ["https://223.5.5.5/dns-query#🎯直连", "https://doh.pub/dns-query#🎯直连", "https://1.1.1.1/dns-query#🌍全球加速", "https://8.8.8.8/dns-query#🌍全球加速", "https://9.9.9.9/dns-query#🌍全球加速", "tls://1.1.1.1:853#🌍全球加速", "tls://8.8.8.8:853#🌍全球加速"]
   proxy-server-nameserver: ["https://1.1.1.1/dns-query", "https://8.8.8.8/dns-query", "https://9.9.9.9/dns-query"]
   direct-nameserver-follow-policy: true
   nameserver-policy:

--- a/subbox-template.json
+++ b/subbox-template.json
@@ -2,7 +2,7 @@
   "log": {"disabled": false, "level": "warning", "output": "./singbox.log", "timestamp": true},
   "dns": {
     "servers": [
-      {"tag": "bootstrap", "type": "udp", "server": "223.5.5.5"},
+      {"tag": "bootstrap", "type": "udp", "server": "223.5.5.5", "detour": "🎯直连"},
       {"tag": "local", "type": "https", "server": "223.5.5.5", "path": "/dns-query", "tls": {"server_name": "dns.alidns.com"}, "domain_resolver": "bootstrap", "detour": "🎯直连"},
       {"tag": "remote", "type": "https", "server": "1.1.1.1", "path": "/dns-query", "tls": {"server_name": "cloudflare-dns.com"}, "domain_resolver": "bootstrap", "detour": "🌍代理"},
       {"tag": "final", "type": "https", "server": "8.8.8.8", "path": "/dns-query", "tls": {"server_name": "dns.google"}, "domain_resolver": "bootstrap", "detour": "🌍代理"},


### PR DESCRIPTION
接 #542（国内 DNS 钉 `#🎯直连`，**真机已验证生效**：连接详情「规则」为空、
「特殊代理」显示 🎯直连、代理链 `DIRECT`）。把剩下两个还依赖规则引擎的口子补上。

## 一、sing-box：`bootstrap` 补 `detour: 🎯直连`

```diff
- {"tag": "bootstrap", "type": "udp", "server": "223.5.5.5"}
+ {"tag": "bootstrap", "type": "udp", "server": "223.5.5.5", "detour": "🎯直连"}
```

`local` / `remote` / `final` 三台都写了 `detour`，**唯独 `bootstrap` 没写**，会掉进
`route.rules`；而 `route.final` 是 `🤡漏网之鱼` → 代理。偏偏 `bootstrap` 是启动时
**最早用的那台**（负责解析 `dns.alidns.com` / `cloudflare-dns.com` 这些 DoH 域名），
规则集这时候还没下载完，一定掉到 final。

`system` / `fakeip` 不用补：前者用系统解析器、后者不发网络请求。

## 二、mihomo：境外 DNS 钉 `#🌍全球加速`

境外 DNS 现在的结果**是对的**（走代理），但那是凑出来的：

| | 靠什么走到代理 |
|---|---|
| `1.1.1.1` | 命中 `cloudflare-ip` (1.1.1.0/24) → 🌍全球加速 |
| `8.8.8.8` | 命中 `google-ip` (8.8.8.0/24) → 🌐Google服务 |
| `9.9.9.9` | **一条规则都没命中** → MATCH → 🤡漏网之鱼 → 🌍全球加速 |

既依赖规则集已下载完，又依赖 `🤡漏网之鱼` 当前选的是 `🌍全球加速`。
**谁把漏网之鱼切成 `🎯直连`，冷启动时境外 DNS 就全部直连** —— 在国内被污染/拦掉，
境外域名解析直接废掉。钉住之后跟这两件事都无关。

`global-dns` 锚点和 `nameserver` 里那份都加了；`proxy-server-nameserver` 不加
（mihomo 本就强制直连这一栏，加了反而会绕）；`default-nameserver` 不加
（bootstrap 只收裸 IP）。

## 验证

sing-box 逐台确认 `detour`：

```
bootstrap  detour=🎯直连      ← 本次补的
local      detour=🎯直连
remote     detour=🌍代理
final      detour=🌍代理
system     (无) ← 系统解析器，不需要
fakeip     (无) ← 不发网络请求，不需要
```

mihomo 走 `_fill_block` 渲染后 `yaml.safe_load` 通过：

```
nameserver:
  https://223.5.5.5/dns-query#🎯直连
  https://doh.pub/dns-query#🎯直连
  https://1.1.1.1/dns-query#🌍全球加速
  https://8.8.8.8/dns-query#🌍全球加速
  https://9.9.9.9/dns-query#🌍全球加速
  tls://1.1.1.1:853#🌍全球加速
  tls://8.8.8.8:853#🌍全球加速
proxy-server-nameserver / default-nameserver / direct-nameserver: 原样
引用的 🎯直连 / 🌍全球加速 两个组都在 proxy-groups 里存在 ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqKxHpC9nKXiUUkhwfLHt2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqKxHpC9nKXiUUkhwfLHt2)_