### PR TITLE
8.8.8.8 改钉 #🌐Google服务：上一版把它从 Google服务 降级成全球加速了

### DIFF
--- a/sub-template.yaml
+++ b/sub-template.yaml
@@ -62,12 +62,16 @@ tun:
 
 dns-anchor:
   cn-dns: &cn-dns ["https://223.5.5.5/dns-query#🎯直连", "https://doh.pub/dns-query#🎯直连"]
-  # 境外 DNS 钉 #🌍全球加速：它们【必须走代理】，直连在国内会被污染/拦掉。
+  # 境外 DNS 钉出站组：它们【必须走代理】，直连在国内会被污染/拦掉。
+  # 8.8.8.8 钉 #🌐Google服务 而不是 #🌍全球加速——钉之前它命中 google-ip (8.8.8.0/24)
+  # 走的就是 Google服务 组，一刀切成全球加速等于把它降级了。1.1.1.1 / 9.9.9.9 用
+  # 🌍全球加速 才是维持原状：前者命中 cloudflare-ip→🌍全球加速，后者一条规则都没命中、
+  # 掉到 MATCH→🤡漏网之鱼→🌍全球加速。
   # 现在的结果本来就是走代理，但那是「1.1.1.1 命中 cloudflare-ip、8.8.8.8 命中
   # google-ip、9.9.9.9 一条没命中掉到 MATCH → 🤡漏网之鱼」凑出来的——既依赖规则集
   # 已下载完，又依赖 🤡漏网之鱼 当前选的是 🌍全球加速。谁把漏网之鱼切成 🎯直连，
   # 冷启动时境外 DNS 就全部直连，境外域名解析直接废掉。钉住之后跟这两件事都无关。
-  global-dns: &global-dns ["https://1.1.1.1/dns-query#🌍全球加速", "https://8.8.8.8/dns-query#🌍全球加速", "https://9.9.9.9/dns-query#🌍全球加速", "tls://1.1.1.1:853#🌍全球加速", "tls://8.8.8.8:853#🌍全球加速"]
+  global-dns: &global-dns ["https://1.1.1.1/dns-query#🌍全球加速", "https://8.8.8.8/dns-query#🌐Google服务", "https://9.9.9.9/dns-query#🌍全球加速", "tls://1.1.1.1:853#🌍全球加速", "tls://8.8.8.8:853#🌐Google服务"]
 
 dns:
   enable: true
@@ -86,7 +90,7 @@ dns:
   fake-ip-filter: ["localhost","+.lan","+.local","+.arpa","+.ntp.org","captive.apple.com","connectivitycheck.gstatic.com","msftconnecttest.com","msftncsi.com","openai.*","+.openai.*","report-v2.samsung.japps.cn","rule-set:private"]
   direct-nameserver: ["system"]
   default-nameserver: ["223.5.5.5", "119.29.29.29"]
-  nameserver: ["https://223.5.5.5/dns-query#🎯直连", "https://doh.pub/dns-query#🎯直连", "https://1.1.1.1/dns-query#🌍全球加速", "https://8.8.8.8/dns-query#🌍全球加速", "https://9.9.9.9/dns-query#🌍全球加速", "tls://1.1.1.1:853#🌍全球加速", "tls://8.8.8.8:853#🌍全球加速"]
+  nameserver: ["https://223.5.5.5/dns-query#🎯直连", "https://doh.pub/dns-query#🎯直连", "https://1.1.1.1/dns-query#🌍全球加速", "https://8.8.8.8/dns-query#🌐Google服务", "https://9.9.9.9/dns-query#🌍全球加速", "tls://1.1.1.1:853#🌍全球加速", "tls://8.8.8.8:853#🌐Google服务"]
   proxy-server-nameserver: ["https://1.1.1.1/dns-query", "https://8.8.8.8/dns-query", "https://9.9.9.9/dns-query"]
   direct-nameserver-follow-policy: true
   nameserver-policy:


### PR DESCRIPTION
## 我在 #543 里改出来的回退

#543 给境外 DNS **一刀切**钉了 `#🌍全球加速`。但 8.8.8.8 钉之前命中的是
`google-ip` (8.8.8.0/24) → **`🌐Google服务`** —— 用户连接详情里也是这条链：

```
tcp://8.8.8.8:853  →  🇺🇸CN2·hy2 ← 🇺🇸美国随机 ← 🌐Google服务
```

一刀切等于把它降级了。

## 改成按各自原本的走向钉

| | 钉的组 | 依据 |
|---|---|---|
| `8.8.8.8` DoH/DoT | **`#🌐Google服务`** | 命中 `google-ip` 的原走向 |
| `1.1.1.1` DoH/DoT | `#🌍全球加速` | 命中 `cloudflare-ip` 的原走向 |
| `9.9.9.9` DoH | `#🌍全球加速` | 无规则命中，原本 MATCH → 🤡漏网之鱼 → 🌍全球加速 |

这样「钉死」只是把**原有走向固定下来**、不再依赖规则集加载和漏网之鱼的选择，
**不改变任何一条的实际目的地**。

## 验证

渲染后 `yaml.safe_load` 通过：

```
nameserver:
  https://223.5.5.5/dns-query#🎯直连
  https://doh.pub/dns-query#🎯直连
  https://1.1.1.1/dns-query#🌍全球加速
  https://8.8.8.8/dns-query#🌐Google服务      ← 本次
  https://9.9.9.9/dns-query#🌍全球加速
  tls://1.1.1.1:853#🌍全球加速
  tls://8.8.8.8:853#🌐Google服务              ← 本次

global-dns 锚点（nameserver-policy 里所有境外域名用）：同上五条
引用的 🎯直连 / 🌍全球加速 / 🌐Google服务 三个组都在 proxy-groups 里存在 ✓
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqKxHpC9nKXiUUkhwfLHt2

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqKxHpC9nKXiUUkhwfLHt2)_